### PR TITLE
docs: add test engineer guidelines link to CLAUDE.md

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -39,6 +39,7 @@ Always format new and edited files according to `.editorconfig` before committin
 - **Architect role guidelines:** [docs/coding-guidelines/role-architect.md](../docs/coding-guidelines/role-architect.md)
 - **Backend developer role guidelines:** [docs/coding-guidelines/role-backend-developer.md](../docs/coding-guidelines/role-backend-developer.md)
 - **Frontend developer role guidelines:** [docs/coding-guidelines/role-frontend-developer.md](../docs/coding-guidelines/role-frontend-developer.md)
+- **Test engineer role guidelines:** [docs/coding-guidelines/role-test-engineer.md](../docs/coding-guidelines/role-test-engineer.md)
 
 ## Logging
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,7 @@ Always format new and edited files according to `.editorconfig` before committin
 - **Architect role guidelines:** [docs/coding-guidelines/role-architect.md](docs/coding-guidelines/role-architect.md)
 - **Backend developer role guidelines:** [docs/coding-guidelines/role-backend-developer.md](docs/coding-guidelines/role-backend-developer.md)
 - **Frontend developer role guidelines:** [docs/coding-guidelines/role-frontend-developer.md](docs/coding-guidelines/role-frontend-developer.md)
+- **Test engineer role guidelines:** [docs/coding-guidelines/role-test-engineer.md](docs/coding-guidelines/role-test-engineer.md)
 
 ## Logging
 


### PR DESCRIPTION
Adds a missing link to `docs/coding-guidelines/role-test-engineer.md` in `CLAUDE.md` and `.github/copilot-instructions.md`, which already linked the architect, backend-developer, and frontend-developer role guidelines but were missing the test engineer one.

Refs #667.

Generated with [Claude Code](https://claude.ai/code)