### PR TITLE
Limit catalog sync fan-out on new artist discovery

### DIFF
--- a/docs/releasenotes/snippets/20260630-0856-bugfix.md
+++ b/docs/releasenotes/snippets/20260630-0856-bugfix.md
@@ -1,0 +1,1 @@
+* Catalog sync no longer crawls a newly discovered artist's entire back catalog on every single playback or playlist event. Only the album of the actually played/listed track is synced now, keeping the sync queue proportional to listening activity instead of to each new artist's full discography.

--- a/domain-api/src/main/kotlin/de/chrgroth/spotify/control/domain/outbox/DomainOutboxEvent.kt
+++ b/domain-api/src/main/kotlin/de/chrgroth/spotify/control/domain/outbox/DomainOutboxEvent.kt
@@ -118,6 +118,10 @@ sealed interface DomainOutboxEvent : ApplicationOutboxEvent {
 
   /**
    * Syncs genres and images for a single artist from the Spotify API and updates app_artist.
+   * Does not enqueue SyncArtistAlbums - the artist's discography is synced separately, either via
+   * SyncAlbumDetails for the specific album tied to a playback/playlist event, or via the
+   * periodic partitioned backfill job, to avoid crawling a new artist's entire back catalog
+   * on every single track event.
    * Deduplication is by artistId only (artist data is shared across users).
    * payload = "$artistId:${userId.value}"
    */
@@ -162,6 +166,9 @@ sealed interface DomainOutboxEvent : ApplicationOutboxEvent {
   /**
    * Syncs all album IDs for a single artist from the Spotify API and enqueues
    * SyncAlbumDetails for any albums not yet in the catalog.
+   * Only enqueued explicitly (manual artist resync, full catalog resync, or the periodic
+   * partitioned backfill job) - never automatically when a new artist is first discovered,
+   * to keep per-event sync volume bounded.
    * Each page is fetched in a separate outbox task to avoid rate limit bursts.
    * Deduplication is by artistId and nextUrl so that each page can be queued independently.
    * payload: "$artistId:${userId.value}" for the first page;

--- a/domain-impl/src/main/kotlin/de/chrgroth/spotify/control/domain/catalog/CatalogService.kt
+++ b/domain-impl/src/main/kotlin/de/chrgroth/spotify/control/domain/catalog/CatalogService.kt
@@ -82,7 +82,6 @@ class CatalogService(
       .flatMap { detail ->
         if (detail != null) {
           appArtistRepository.upsertAll(listOf(detail))
-          outboxPort.enqueue(DomainOutboxEvent.SyncArtistAlbums(artistId, userId))
           dashboardRefresh.notifyCatalogData()
         } else {
           logger.warn { "No data returned from Spotify for artist $artistId" }
@@ -193,14 +192,15 @@ class CatalogService(
     val recentlyPlayed = recentlyPlayedRepository.findSince(userId, null)
     val partialPlayed = recentlyPartialPlayedRepository.findSince(userId, null)
     return (
-      recentlyPlayed.map { buildCatalogSyncRequest(it.trackId.value, it.artistIds) } +
-        partialPlayed.map { buildCatalogSyncRequest(it.trackId.value, it.artistIds) }
+      recentlyPlayed.map { buildCatalogSyncRequest(it.trackId.value, it.artistIds, it.albumId) } +
+        partialPlayed.map { buildCatalogSyncRequest(it.trackId.value, it.artistIds, it.albumId) }
     ).distinctBy { it.trackId }
   }
 
-  private fun buildCatalogSyncRequest(trackId: String, artistIds: List<ArtistId>) = CatalogSyncRequest(
+  private fun buildCatalogSyncRequest(trackId: String, artistIds: List<ArtistId>, albumId: AlbumId?) = CatalogSyncRequest(
     trackId = trackId,
     artistIds = artistIds.map { it.value }.filter { it.isNotBlank() }.distinct(),
+    albumId = albumId?.value,
   )
 
   private fun syncArtistAlbums(artistId: String, userId: UserId, nextUrl: String?): Either<DomainError, Unit> {

--- a/domain-impl/src/main/kotlin/de/chrgroth/spotify/control/domain/catalog/CatalogSyncRequest.kt
+++ b/domain-impl/src/main/kotlin/de/chrgroth/spotify/control/domain/catalog/CatalogSyncRequest.kt
@@ -3,4 +3,5 @@ package de.chrgroth.spotify.control.domain.catalog
 data class CatalogSyncRequest(
   val trackId: String,
   val artistIds: List<String>,
+  val albumId: String? = null,
 )

--- a/domain-impl/src/main/kotlin/de/chrgroth/spotify/control/domain/catalog/SyncController.kt
+++ b/domain-impl/src/main/kotlin/de/chrgroth/spotify/control/domain/catalog/SyncController.kt
@@ -1,9 +1,11 @@
 package de.chrgroth.spotify.control.domain.catalog
 
+import de.chrgroth.spotify.control.domain.model.catalog.AlbumId
 import de.chrgroth.spotify.control.domain.model.catalog.ArtistId
 import de.chrgroth.spotify.control.domain.model.catalog.TrackId
 import de.chrgroth.spotify.control.domain.model.user.UserId
 import de.chrgroth.spotify.control.domain.outbox.DomainOutboxEvent
+import de.chrgroth.spotify.control.domain.port.out.catalog.AppAlbumRepositoryPort
 import de.chrgroth.spotify.control.domain.port.out.catalog.AppArtistRepositoryPort
 import de.chrgroth.spotify.control.domain.port.out.catalog.AppTrackRepositoryPort
 import de.chrgroth.spotify.control.domain.port.out.infra.OutboxPort
@@ -13,12 +15,17 @@ import jakarta.enterprise.context.ApplicationScoped
 class SyncController(
   private val appTrackRepository: AppTrackRepositoryPort,
   private val appArtistRepository: AppArtistRepositoryPort,
+  private val appAlbumRepository: AppAlbumRepositoryPort,
   private val outboxPort: OutboxPort,
 ) {
   /**
    * For each track in the list:
    * - Checks which tracks are missing from app_track.
-   * - For missing tracks: enqueues SyncArtistDetails for any artists not yet in the catalog.
+   * - For missing tracks: enqueues SyncArtistDetails for any artists not yet in the catalog,
+   *   and SyncAlbumDetails for the specific album the track belongs to, if not yet in the catalog.
+   * This intentionally does not crawl an artist's full discography (SyncArtistAlbums) - only the
+   * album tied to the actual event is fetched, to keep the sync volume proportional to playback/
+   * playlist activity instead of to each new artist's entire back catalog.
    */
   fun syncForTracks(tracks: List<CatalogSyncRequest>, userId: UserId) {
     if (tracks.isEmpty()) return
@@ -28,6 +35,8 @@ class SyncController(
     if (missingTracks.isEmpty()) return
     val artistIds = missingTracks.flatMap { it.artistIds }.distinct()
     syncArtists(artistIds, userId)
+    val albumIds = missingTracks.mapNotNull { it.albumId }.distinct()
+    syncAlbums(albumIds)
   }
 
   /**
@@ -39,6 +48,18 @@ class SyncController(
     val newArtistIds = artistIds.filter { it !in existingArtistIds }.distinct()
     if (newArtistIds.isNotEmpty()) {
       newArtistIds.forEach { outboxPort.enqueue(DomainOutboxEvent.SyncArtistDetails(it, userId)) }
+    }
+  }
+
+  /**
+   * Checks which albums are missing from app_album and enqueues SyncAlbumDetails.
+   */
+  fun syncAlbums(albumIds: List<String>) {
+    if (albumIds.isEmpty()) return
+    val existingAlbumIds = appAlbumRepository.findByAlbumIds(albumIds.map { AlbumId(it) }.toSet()).map { it.id.value }.toSet()
+    val newAlbumIds = albumIds.filter { it !in existingAlbumIds }.distinct()
+    if (newAlbumIds.isNotEmpty()) {
+      newAlbumIds.forEach { outboxPort.enqueue(DomainOutboxEvent.SyncAlbumDetails(it)) }
     }
   }
 }

--- a/domain-impl/src/main/kotlin/de/chrgroth/spotify/control/domain/playback/PlaybackService.kt
+++ b/domain-impl/src/main/kotlin/de/chrgroth/spotify/control/domain/playback/PlaybackService.kt
@@ -266,8 +266,8 @@ class PlaybackService(
       }
 
     val catalogRequests = (
-      recentlyPlayed.map { CatalogSyncRequest(it.trackId.value, listOfNotNull(it.artistIds.firstOrNull()?.value)) } +
-        partialPlayed.map { CatalogSyncRequest(it.trackId.value, listOfNotNull(it.artistIds.firstOrNull()?.value)) }
+      recentlyPlayed.map { CatalogSyncRequest(it.trackId.value, listOfNotNull(it.artistIds.firstOrNull()?.value), it.albumId?.value) } +
+        partialPlayed.map { CatalogSyncRequest(it.trackId.value, listOfNotNull(it.artistIds.firstOrNull()?.value), it.albumId?.value) }
     ).distinctBy { it.trackId }
     syncController.syncForTracks(catalogRequests, userId)
   }

--- a/domain-impl/src/main/kotlin/de/chrgroth/spotify/control/domain/playlist/PlaylistService.kt
+++ b/domain-impl/src/main/kotlin/de/chrgroth/spotify/control/domain/playlist/PlaylistService.kt
@@ -102,7 +102,7 @@ class PlaylistService(
         playlistRepository.appendTracks(userId, playlistId, page.tracks)
       }
 
-      val catalogRequests = page.tracks.map { CatalogSyncRequest(it.trackId.value, listOfNotNull(it.artistIds.firstOrNull()?.value)) }
+      val catalogRequests = page.tracks.map { CatalogSyncRequest(it.trackId.value, listOfNotNull(it.artistIds.firstOrNull()?.value), it.albumId?.value) }
       syncController.syncForTracks(catalogRequests, userId)
 
       if (page.nextUrl != null) {

--- a/domain-impl/src/test/kotlin/de/chrgroth/spotify/control/domain/catalog/PlaybackEnrichmentServiceTests.kt
+++ b/domain-impl/src/test/kotlin/de/chrgroth/spotify/control/domain/catalog/PlaybackEnrichmentServiceTests.kt
@@ -80,7 +80,7 @@ class PlaybackEnrichmentServiceTests {
     adapter.syncArtistDetails(artistId, userId)
 
     verify { appArtistRepository.upsertAll(listOf(spotifyArtist)) }
-    verify { outboxPort.enqueue(de.chrgroth.spotify.control.domain.outbox.DomainOutboxEvent.SyncArtistAlbums(artistId, userId)) }
+    verify(exactly = 0) { outboxPort.enqueue(any()) }
   }
 
   @Test

--- a/domain-impl/src/test/kotlin/de/chrgroth/spotify/control/domain/catalog/SyncControllerTests.kt
+++ b/domain-impl/src/test/kotlin/de/chrgroth/spotify/control/domain/catalog/SyncControllerTests.kt
@@ -1,11 +1,14 @@
 package de.chrgroth.spotify.control.domain.catalog
 
+import de.chrgroth.spotify.control.domain.model.catalog.AlbumId
+import de.chrgroth.spotify.control.domain.model.catalog.AppAlbum
 import de.chrgroth.spotify.control.domain.model.catalog.AppArtist
 import de.chrgroth.spotify.control.domain.model.catalog.AppTrack
 import de.chrgroth.spotify.control.domain.model.catalog.ArtistId
 import de.chrgroth.spotify.control.domain.model.catalog.TrackId
 import de.chrgroth.spotify.control.domain.model.user.UserId
 import de.chrgroth.spotify.control.domain.outbox.DomainOutboxEvent
+import de.chrgroth.spotify.control.domain.port.out.catalog.AppAlbumRepositoryPort
 import de.chrgroth.spotify.control.domain.port.out.catalog.AppArtistRepositoryPort
 import de.chrgroth.spotify.control.domain.port.out.catalog.AppTrackRepositoryPort
 import de.chrgroth.spotify.control.domain.port.out.infra.OutboxPort
@@ -19,11 +22,13 @@ class SyncControllerTests {
 
   private val appTrackRepository: AppTrackRepositoryPort = mockk(relaxed = true)
   private val appArtistRepository: AppArtistRepositoryPort = mockk(relaxed = true)
+  private val appAlbumRepository: AppAlbumRepositoryPort = mockk(relaxed = true)
   private val outboxPort: OutboxPort = mockk(relaxed = true)
 
   private val controller = SyncController(
     appTrackRepository,
     appArtistRepository,
+    appAlbumRepository,
     outboxPort,
   )
 
@@ -39,6 +44,14 @@ class SyncControllerTests {
 
   private fun artist(id: String) = AppArtist(
     id = ArtistId(id),
+    artistName = "Artist $id",
+    lastSync = syncTime,
+  )
+
+  private fun album(id: String) = AppAlbum(
+    id = AlbumId(id),
+    title = "Album $id",
+    artistId = ArtistId("artist-$id"),
     artistName = "Artist $id",
     lastSync = syncTime,
   )
@@ -122,6 +135,49 @@ class SyncControllerTests {
     verify(exactly = 1) { outboxPort.enqueue(DomainOutboxEvent.SyncArtistDetails("artist-shared", userId)) }
   }
 
+  @Test
+  fun `syncForTracks enqueues SyncAlbumDetails for missing album of a missing track`() {
+    every { appTrackRepository.findByTrackIds(any()) } returns emptyList()
+    every { appArtistRepository.findByArtistIds(any()) } returns listOf(artist("artist-1"))
+    every { appAlbumRepository.findByAlbumIds(any()) } returns emptyList()
+
+    controller.syncForTracks(
+      listOf(CatalogSyncRequest("t1", listOf("artist-1"), "album-1")),
+      userId,
+    )
+
+    verify { outboxPort.enqueue(DomainOutboxEvent.SyncAlbumDetails("album-1")) }
+    verify(exactly = 0) { outboxPort.enqueue(match { it is DomainOutboxEvent.SyncArtistAlbums }) }
+  }
+
+  @Test
+  fun `syncForTracks does not enqueue SyncAlbumDetails when album already in catalog`() {
+    every { appTrackRepository.findByTrackIds(any()) } returns emptyList()
+    every { appArtistRepository.findByArtistIds(any()) } returns listOf(artist("artist-1"))
+    every { appAlbumRepository.findByAlbumIds(any()) } returns listOf(album("album-1"))
+
+    controller.syncForTracks(
+      listOf(CatalogSyncRequest("t1", listOf("artist-1"), "album-1")),
+      userId,
+    )
+
+    verify(exactly = 0) { outboxPort.enqueue(match { it is DomainOutboxEvent.SyncAlbumDetails }) }
+  }
+
+  @Test
+  fun `syncForTracks does not enqueue SyncAlbumDetails when track has no albumId`() {
+    every { appTrackRepository.findByTrackIds(any()) } returns emptyList()
+    every { appArtistRepository.findByArtistIds(any()) } returns listOf(artist("artist-1"))
+
+    controller.syncForTracks(
+      listOf(CatalogSyncRequest("t1", listOf("artist-1"))),
+      userId,
+    )
+
+    verify(exactly = 0) { outboxPort.enqueue(match { it is DomainOutboxEvent.SyncAlbumDetails }) }
+    verify(exactly = 0) { appAlbumRepository.findByAlbumIds(any()) }
+  }
+
   // --- syncArtists ---
 
   @Test
@@ -148,6 +204,35 @@ class SyncControllerTests {
     controller.syncArtists(emptyList(), userId)
 
     verify(exactly = 0) { appArtistRepository.findByArtistIds(any()) }
+    verify(exactly = 0) { outboxPort.enqueue(any()) }
+  }
+
+  // --- syncAlbums ---
+
+  @Test
+  fun `syncAlbums enqueues SyncAlbumDetails for missing albums`() {
+    every { appAlbumRepository.findByAlbumIds(any()) } returns emptyList()
+
+    controller.syncAlbums(listOf("album-1", "album-2"))
+
+    verify { outboxPort.enqueue(DomainOutboxEvent.SyncAlbumDetails("album-1")) }
+    verify { outboxPort.enqueue(DomainOutboxEvent.SyncAlbumDetails("album-2")) }
+  }
+
+  @Test
+  fun `syncAlbums skips albums already in catalog`() {
+    every { appAlbumRepository.findByAlbumIds(any()) } returns listOf(album("album-1"))
+
+    controller.syncAlbums(listOf("album-1"))
+
+    verify(exactly = 0) { outboxPort.enqueue(any()) }
+  }
+
+  @Test
+  fun `syncAlbums with empty list does nothing`() {
+    controller.syncAlbums(emptyList())
+
+    verify(exactly = 0) { appAlbumRepository.findByAlbumIds(any()) }
     verify(exactly = 0) { outboxPort.enqueue(any()) }
   }
 }

--- a/domain-impl/src/test/kotlin/de/chrgroth/spotify/control/domain/playback/RecentlyPlayedServiceTests.kt
+++ b/domain-impl/src/test/kotlin/de/chrgroth/spotify/control/domain/playback/RecentlyPlayedServiceTests.kt
@@ -701,7 +701,7 @@ class RecentlyPlayedServiceTests {
 
     verify {
       syncController.syncForTracks(
-        listOf(CatalogSyncRequest("track-1", listOf("artist-id-1"))),
+        listOf(CatalogSyncRequest("track-1", listOf("artist-id-1"), "album-1")),
         userId,
       )
     }

--- a/domain-impl/src/test/kotlin/de/chrgroth/spotify/control/domain/playlist/PlaylistServiceTests.kt
+++ b/domain-impl/src/test/kotlin/de/chrgroth/spotify/control/domain/playlist/PlaylistServiceTests.kt
@@ -481,7 +481,7 @@ class PlaylistServiceTests {
 
     verify {
       syncController.syncForTracks(
-        listOf(CatalogSyncRequest("track-1", listOf("artist-1"))),
+        listOf(CatalogSyncRequest("track-1", listOf("artist-1"), "album-1")),
         userId,
       )
     }


### PR DESCRIPTION
Newly discovered artists no longer trigger a full back-catalog crawl on every playback or playlist event. Only the album of the actually played or listed track is synced now via a direct SyncAlbumDetails event. Manual resync, full catalog resync, and the nightly partitioned backfill job are unchanged. Closes #669