### PR TITLE
fix: limit catalog resync/wipe-recovery to primary artist per track

### DIFF
--- a/docs/releasenotes/snippets/1044-bugfix.md
+++ b/docs/releasenotes/snippets/1044-bugfix.md
@@ -1,0 +1,1 @@
+* Catalog resync and outbox/catalog wipe recovery now discover artists the same way as live playback and playlist sync, fixing an inconsistency that previously caused far more sync events than expected after a catalog wipe.

--- a/domain-impl/src/main/kotlin/de/chrgroth/spotify/control/domain/catalog/CatalogService.kt
+++ b/domain-impl/src/main/kotlin/de/chrgroth/spotify/control/domain/catalog/CatalogService.kt
@@ -206,7 +206,7 @@ class CatalogService(
 
   private fun buildCatalogSyncRequest(trackId: String, artistIds: List<ArtistId>) = CatalogSyncRequest(
     trackId = trackId,
-    artistIds = artistIds.map { it.value }.filter { it.isNotBlank() }.distinct(),
+    artistIds = listOfNotNull(artistIds.firstOrNull()?.value?.takeIf { it.isNotBlank() }),
     cause = SyncCause.ManualResync,
   )
 

--- a/domain-impl/src/test/kotlin/de/chrgroth/spotify/control/domain/catalog/CatalogServiceTests.kt
+++ b/domain-impl/src/test/kotlin/de/chrgroth/spotify/control/domain/catalog/CatalogServiceTests.kt
@@ -181,7 +181,7 @@ class CatalogServiceTests {
       syncController.syncForTracks(
         match { requests ->
           requests.size == 2 &&
-            requests.any { it == CatalogSyncRequest("track-1", listOf("artist-1", "artist-1b"), SyncCause.ManualResync) } &&
+            requests.any { it == CatalogSyncRequest("track-1", listOf("artist-1"), SyncCause.ManualResync) } &&
             requests.any { it == CatalogSyncRequest("track-2", listOf("artist-2"), SyncCause.ManualResync) }
         },
         userId,
@@ -435,7 +435,7 @@ class CatalogServiceTests {
   }
 
   @Test
-  fun `enqueuePlaybackArtistsForSync delegates playback tracks to syncController`() {
+  fun `enqueuePlaybackArtistsForSync delegates playback tracks to syncController using only primary artist per track`() {
     every { userRepository.findAll() } returns listOf(buildUser())
     every { recentlyPlayedRepository.findSince(userId, null) } returns listOf(recentlyPlayedItem("track-1", "artist-1", "artist-1b"))
     every { recentlyPartialPlayedRepository.findSince(userId, null) } returns listOf(recentlyPartialPlayedItem("track-2", "artist-2"))
@@ -446,7 +446,7 @@ class CatalogServiceTests {
       syncController.syncForTracks(
         match { requests ->
           requests.size == 2 &&
-            requests.any { it == CatalogSyncRequest("track-1", listOf("artist-1", "artist-1b"), SyncCause.ManualResync) } &&
+            requests.any { it == CatalogSyncRequest("track-1", listOf("artist-1"), SyncCause.ManualResync) } &&
             requests.any { it == CatalogSyncRequest("track-2", listOf("artist-2"), SyncCause.ManualResync) }
         },
         userId,


### PR DESCRIPTION
Fixes #669.

`resyncCatalog()` and the wipe-recovery starter (`enqueuePlaybackArtistsForSync()`) previously enqueued sync for *all* artists found on a playback track, while live playback/playlist sync only ever sync the primary artist. This inconsistency meant a catalog wipe + resync pulled in every featuring/collaborating artist from the entire playback history at once, each fanning out into a full discography sync and flooding the outbox.

`buildCatalogSyncRequest()` now matches the primary-artist-only pattern used by `PlaybackService` and `PlaylistService`, so all sync entry points are structurally consistent.

Generated with [Claude Code](https://claude.ai/code)