### PR TITLE
fix: deliver outbox events via @ObservesAsync so SSE outbox refresh fires

### DIFF
--- a/adapter-in-outbox/src/main/kotlin/de/chrgroth/spotify/control/adapter/in/outbox/OutboxPartitionEventAdapter.kt
+++ b/adapter-in-outbox/src/main/kotlin/de/chrgroth/spotify/control/adapter/in/outbox/OutboxPartitionEventAdapter.kt
@@ -10,7 +10,7 @@ import de.chrgroth.quarkus.outbox.domain.event.OutboxTaskRetryScheduledEvent
 import de.chrgroth.spotify.control.domain.port.out.infra.OutboxPartitionObserver
 import de.chrgroth.spotify.control.domain.port.out.infra.OutboxTaskCountObserver
 import jakarta.enterprise.context.ApplicationScoped
-import jakarta.enterprise.event.Observes
+import jakarta.enterprise.event.ObservesAsync
 import jakarta.enterprise.inject.Any
 import jakarta.enterprise.inject.Instance
 
@@ -21,37 +21,38 @@ class OutboxPartitionEventAdapter(
   @param:Any private val taskCountObservers: Instance<OutboxTaskCountObserver>,
 ) {
 
-  fun onPartitionPaused(@Observes event: OutboxPartitionPausedEvent) {
+  // the outbox library fires all of these events via Event.fireAsync(), which the CDI spec only delivers to @ObservesAsync observers
+  fun onPartitionPaused(@ObservesAsync event: OutboxPartitionPausedEvent) {
     val reason = event.reason?.takeIf { it.isNotBlank() } ?: "unknown"
     partitionObservers.forEach { it.onPartitionPaused(event.partition.key, reason) }
   }
 
-  fun onPartitionActivated(@Observes event: OutboxPartitionActivatedEvent) {
+  fun onPartitionActivated(@ObservesAsync event: OutboxPartitionActivatedEvent) {
     partitionObservers.forEach { it.onPartitionActivated(event.partition.key) }
   }
 
   @Suppress("UnusedParameter")
-  fun onTaskEnqueued(@Observes event: OutboxTaskEnqueuedEvent) {
+  fun onTaskEnqueued(@ObservesAsync event: OutboxTaskEnqueuedEvent) {
     taskCountObservers.forEach { it.onOutboxTaskCountChanged() }
   }
 
   @Suppress("UnusedParameter")
-  fun onTaskDispatched(@Observes event: OutboxTaskDispatchedEvent) {
+  fun onTaskDispatched(@ObservesAsync event: OutboxTaskDispatchedEvent) {
     taskCountObservers.forEach { it.onOutboxTaskCountChanged() }
   }
 
   @Suppress("UnusedParameter")
-  fun onTaskFailed(@Observes event: OutboxTaskFailedEvent) {
+  fun onTaskFailed(@ObservesAsync event: OutboxTaskFailedEvent) {
     taskCountObservers.forEach { it.onOutboxTaskCountChanged() }
   }
 
   @Suppress("UnusedParameter")
-  fun onTaskRescheduled(@Observes event: OutboxTaskRescheduledEvent) {
+  fun onTaskRescheduled(@ObservesAsync event: OutboxTaskRescheduledEvent) {
     taskCountObservers.forEach { it.onOutboxTaskCountChanged() }
   }
 
   @Suppress("UnusedParameter")
-  fun onTaskRetryScheduled(@Observes event: OutboxTaskRetryScheduledEvent) {
+  fun onTaskRetryScheduled(@ObservesAsync event: OutboxTaskRetryScheduledEvent) {
     taskCountObservers.forEach { it.onOutboxTaskCountChanged() }
   }
 }

--- a/docs/releasenotes/snippets/0418-bugfix.md
+++ b/docs/releasenotes/snippets/0418-bugfix.md
@@ -1,0 +1,1 @@
+* Fixed the "Outbox Partitions" section on the Config UI (`/health`) not refreshing live via SSE.


### PR DESCRIPTION
## Summary
- The quarkus-outbox library fires all partition/task lifecycle events via `Event.fireAsync()`, which CDI only delivers to `@ObservesAsync` observers.
- `OutboxPartitionEventAdapter` used plain `@Observes`, so it was never invoked in production, and the "Outbox Partitions" section on /health never refreshed via SSE.
- Switched the observer methods to `@ObservesAsync` so they actually receive the events.

Closes #677

## Test plan
- [x] `./gradlew build` passes (build, tests, static analysis)
- [ ] Manually verify on /health that the Outbox Partitions card updates live when tasks are enqueued/processed/partitions paused/activated

Generated with [Claude Code](https://claude.ai/code)