### PR TITLE
fix: only refresh dashboard playback stats when data actually changed

### DIFF
--- a/docs/releasenotes/snippets/0511-bugfix.md
+++ b/docs/releasenotes/snippets/0511-bugfix.md
@@ -1,0 +1,1 @@
+* Dashboard no longer fades its playback stats sections on every playback poll while a track is playing; it now only refreshes them when the recently played or listening stats actually change.

--- a/domain-impl/src/main/kotlin/de/chrgroth/spotify/control/domain/playback/PlaybackService.kt
+++ b/domain-impl/src/main/kotlin/de/chrgroth/spotify/control/domain/playback/PlaybackService.kt
@@ -79,7 +79,7 @@ class PlaybackService(
       if (item != null && item.isPlaying) {
         playbackState.onPlaybackDetected()
       }
-      if (item != null) {
+      val orphanedItemsConverted = if (item != null) {
         val existing = currentlyPlayingRepository.findMostRecentByUserAndTrack(userId, item.trackId)
         if (existing != null && !isTrackRestart(item, existing)) {
           currentlyPlayingRepository.updateProgress(item.copy(startTime = existing.startTime))
@@ -90,9 +90,11 @@ class PlaybackService(
           currentlyPlayingRepository.save(item)
         }
         convertAndDeleteOrphanedItems(userId, item.trackId)
-        dashboardRefresh.notifyUserPlaybackData(userId)
       } else {
         convertAndDeleteOrphanedItems(userId, null)
+      }
+      if (orphanedItemsConverted) {
+        dashboardRefresh.notifyUserPlaybackData(userId)
       }
       Unit.right()
     }
@@ -101,13 +103,13 @@ class PlaybackService(
   private fun isTrackRestart(newItem: CurrentlyPlayingItem, existingItem: CurrentlyPlayingItem): Boolean =
     newItem.progressMs < RESTART_THRESHOLD_MS && existingItem.progressMs > minimumProgressMs
 
-  private fun convertAndDeleteOrphanedItems(userId: UserId, currentTrackId: TrackId?) {
+  private fun convertAndDeleteOrphanedItems(userId: UserId, currentTrackId: TrackId?): Boolean {
     val orphanedItems = currentlyPlayingRepository.findByUserId(userId)
       .let { items -> if (currentTrackId != null) items.filter { it.trackId != currentTrackId } else items }
-    if (orphanedItems.isEmpty()) return
+    if (orphanedItems.isEmpty()) return false
 
     val convertibleItems = orphanedItems.filter { it.progressMs > minimumProgressMs }
-    if (convertibleItems.isNotEmpty()) {
+    val newPartialSaved = if (convertibleItems.isNotEmpty()) {
       val partialItems = convertibleItems.map { item ->
         val playedMs = minOf(item.progressMs, item.durationMs)
         RecentlyPartialPlayedItem(
@@ -127,10 +129,14 @@ class PlaybackService(
       if (newPartial.isNotEmpty()) {
         recentlyPartialPlayedRepository.saveAll(newPartial)
       }
+      newPartial.isNotEmpty()
+    } else {
+      false
     }
 
     val orphanedTrackIds = orphanedItems.map { it.trackId.value }.toSet()
     currentlyPlayingRepository.deleteByUserIdAndTrackIds(userId, orphanedTrackIds)
+    return newPartialSaved
   }
 
   // --- Recently Played ---

--- a/domain-impl/src/test/kotlin/de/chrgroth/spotify/control/domain/playback/FetchCurrentlyPlayingServiceTests.kt
+++ b/domain-impl/src/test/kotlin/de/chrgroth/spotify/control/domain/playback/FetchCurrentlyPlayingServiceTests.kt
@@ -230,6 +230,7 @@ class FetchCurrentlyPlayingServiceTests {
     assertThat(savedSlot.captured[0].trackId).isEqualTo(TrackId("track-a"))
     assertThat(savedSlot.captured[0].playedSeconds).isEqualTo(50L)
     verify { currentlyPlayingRepository.deleteByUserIdAndTrackIds(userId, setOf("track-a")) }
+    verify { dashboardRefresh.notifyUserPlaybackData(userId) }
   }
 
   @Test
@@ -245,6 +246,7 @@ class FetchCurrentlyPlayingServiceTests {
 
     verify(exactly = 0) { recentlyPartialPlayedRepository.saveAll(any()) }
     verify { currentlyPlayingRepository.deleteByUserIdAndTrackIds(userId, setOf("track-a")) }
+    verify(exactly = 0) { dashboardRefresh.notifyUserPlaybackData(any()) }
   }
 
   @Test
@@ -301,6 +303,7 @@ class FetchCurrentlyPlayingServiceTests {
     assertThat(savedSlot.captured[0].trackId).isEqualTo(TrackId("track-a"))
     assertThat(savedSlot.captured[0].playedSeconds).isEqualTo(50L)
     verify { currentlyPlayingRepository.deleteByUserIdAndTrackIds(userId, setOf("track-a")) }
+    verify { dashboardRefresh.notifyUserPlaybackData(userId) }
   }
 
   @Test
@@ -314,6 +317,7 @@ class FetchCurrentlyPlayingServiceTests {
 
     verify(exactly = 0) { recentlyPartialPlayedRepository.saveAll(any()) }
     verify { currentlyPlayingRepository.deleteByUserIdAndTrackIds(userId, setOf("track-a")) }
+    verify(exactly = 0) { dashboardRefresh.notifyUserPlaybackData(any()) }
   }
 
   // --- playback state and dashboard notifications ---
@@ -343,7 +347,7 @@ class FetchCurrentlyPlayingServiceTests {
   }
 
   @Test
-  fun `fetchCurrentlyPlaying notifies dashboard when track is detected`() {
+  fun `fetchCurrentlyPlaying does not notify dashboard when track is merely still playing`() {
     val item = currentlyPlayingItem("track-1", progressMs = 30_000L)
     every { spotifyAccessToken.getValidAccessToken(userId) } returns accessToken
     every { spotifyPlayback.getCurrentlyPlaying(userId, accessToken) } returns item.right()
@@ -351,7 +355,7 @@ class FetchCurrentlyPlayingServiceTests {
 
     service.fetchCurrentlyPlaying(userId)
 
-    verify { dashboardRefresh.notifyUserPlaybackData(userId) }
+    verify(exactly = 0) { dashboardRefresh.notifyUserPlaybackData(any()) }
   }
 
   @Test


### PR DESCRIPTION
## Summary
- `PlaybackService.fetchCurrentlyPlaying()` unconditionally triggered a Dashboard SSE refresh (and thus a whole-block fade of the playback histogram, recently played, and listening stats snippets) on every 20s poll while something was playing, even though those snippets almost never actually change from that code path.
- The dashboard notification is now only sent when cleaning up orphaned "currently playing" entries actually produces a new partial play, matching how `fetchRecentlyPlayed` already gates its own notification on real new data.
- Updated/added unit tests in `FetchCurrentlyPlayingServiceTests.kt` to cover the gated behavior.

Addresses the follow-up on #679 asking to investigate what triggers SSE updates and why some fades fire without a real data change.

## Test plan
- [x] `./gradlew build` passes (tests + static analysis)
- [ ] Manually verify the Dashboard no longer fades the histogram/recently-played/listening-stats blocks on every poll while a track keeps playing

Generated with [Claude Code](https://claude.ai/code)