### PR TITLE
fix: replace whole-block SSE fade with granular DOM patch

### DIFF
--- a/adapter-in-web/src/main/resources/META-INF/resources/sse-utils.js
+++ b/adapter-in-web/src/main/resources/META-INF/resources/sse-utils.js
@@ -1,18 +1,70 @@
-function fadeUpdate(elementId, url, callback) {
+function sseFlash(el) {
+    if (!el || el.nodeType !== Node.ELEMENT_NODE) return;
+    el.classList.remove('sse-flash');
+    void el.offsetWidth;
+    el.classList.add('sse-flash');
+}
+
+function sseMorphAttributes(oldEl, newEl) {
+    Array.prototype.slice.call(oldEl.attributes).forEach(function (attr) {
+        if (!newEl.hasAttribute(attr.name)) oldEl.removeAttribute(attr.name);
+    });
+    Array.prototype.slice.call(newEl.attributes).forEach(function (attr) {
+        if (oldEl.getAttribute(attr.name) !== attr.value) oldEl.setAttribute(attr.name, attr.value);
+    });
+}
+
+function sseMorphNode(parent, oldNode, newNode) {
+    if (!newNode) {
+        if (oldNode) parent.removeChild(oldNode);
+        return;
+    }
+    if (!oldNode) {
+        var added = newNode.cloneNode(true);
+        parent.appendChild(added);
+        sseFlash(added);
+        return;
+    }
+    if (oldNode.nodeType !== newNode.nodeType || oldNode.nodeName !== newNode.nodeName) {
+        var replacement = newNode.cloneNode(true);
+        parent.replaceChild(replacement, oldNode);
+        sseFlash(replacement);
+        return;
+    }
+    if (oldNode.nodeType === Node.TEXT_NODE) {
+        if (oldNode.nodeValue !== newNode.nodeValue) {
+            oldNode.nodeValue = newNode.nodeValue;
+            sseFlash(parent);
+        }
+        return;
+    }
+    if (oldNode.nodeType === Node.ELEMENT_NODE) {
+        sseMorphAttributes(oldNode, newNode);
+        sseMorphChildren(oldNode, newNode);
+    }
+}
+
+function sseMorphChildren(oldParent, newParent) {
+    var oldNodes = Array.prototype.slice.call(oldParent.childNodes);
+    var newNodes = Array.prototype.slice.call(newParent.childNodes);
+    var max = Math.max(oldNodes.length, newNodes.length);
+    for (var i = 0; i < max; i++) {
+        sseMorphNode(oldParent, oldNodes[i], newNodes[i]);
+    }
+}
+
+function patchUpdate(elementId, url, callback) {
     var el = document.getElementById(elementId);
     if (!el) return;
-    el.style.transition = 'opacity 0.5s ease';
-    el.style.opacity = '0';
     fetch(url)
         .then(function (r) { return r.text(); })
         .then(function (html) {
-            el.innerHTML = html;
-            el.style.opacity = '1';
+            var parsed = document.createElement('div');
+            parsed.innerHTML = html;
+            sseMorphChildren(el, parsed);
             if (callback) callback();
         })
-        .catch(function () {
-            el.style.opacity = '1';
-        });
+        .catch(function () {});
 }
 
 function connectSse(url, onMessage, onOpen) {

--- a/adapter-in-web/src/main/resources/templates/dashboard.html
+++ b/adapter-in-web/src/main/resources/templates/dashboard.html
@@ -167,9 +167,9 @@
     <script>
         connectSse('/dashboard/events', function (event) {
             if (event.data === 'refresh-playback-data') {
-                fadeUpdate('snippet-playback-histogram', '/dashboard/snippets/playback-histogram');
-                fadeUpdate('snippet-recently-played', '/dashboard/snippets/recently-played');
-                fadeUpdate('snippet-listening-stats', '/dashboard/snippets/listening-stats');
+                patchUpdate('snippet-playback-histogram', '/dashboard/snippets/playback-histogram');
+                patchUpdate('snippet-recently-played', '/dashboard/snippets/recently-played');
+                patchUpdate('snippet-listening-stats', '/dashboard/snippets/listening-stats');
             }
         });
     </script>

--- a/adapter-in-web/src/main/resources/templates/health.html
+++ b/adapter-in-web/src/main/resources/templates/health.html
@@ -291,7 +291,7 @@
                         row.dataset.pulsing = 'true';
                         row.classList.add('cronjob-pulse');
                         setTimeout(function () {
-                            fadeUpdate('snippet-cronjobs', '/health/snippets/cronjobs', function () {
+                            patchUpdate('snippet-cronjobs', '/health/snippets/cronjobs', function () {
                                 updateCronjobCountdowns();
                             });
                         }, 5000);
@@ -342,15 +342,15 @@
 
             connectSse('/health/events', function (event) {
                 if (event.data === 'refresh-outgoing-http-calls') {
-                    fadeUpdate('snippet-outgoing-http-calls', '/health/snippets/outgoing-http-calls');
+                    patchUpdate('snippet-outgoing-http-calls', '/health/snippets/outgoing-http-calls');
                 } else if (event.data === 'refresh-outbox-partitions') {
                     if (outboxBlockedUntilInterval) {
                         clearInterval(outboxBlockedUntilInterval);
                         outboxBlockedUntilInterval = null;
                     }
-                    fadeUpdate('snippet-outbox-partitions', '/health/snippets/outbox-partitions', startOutboxBlockedUntilInterval);
+                    patchUpdate('snippet-outbox-partitions', '/health/snippets/outbox-partitions', startOutboxBlockedUntilInterval);
                 } else if (event.data === 'refresh-playback-state') {
-                    fadeUpdate('snippet-predicates', '/health/snippets/predicates', updatePredicateLastChecks);
+                    patchUpdate('snippet-predicates', '/health/snippets/predicates', updatePredicateLastChecks);
                 }
             });
         })();

--- a/adapter-in-web/src/main/resources/templates/layout.html
+++ b/adapter-in-web/src/main/resources/templates/layout.html
@@ -140,6 +140,14 @@
             color: var(--color-text-primary);
             background: transparent;
         }
+        /* Localized highlight for SSE-patched content, applied only to the elements that actually changed */
+        @keyframes sse-flash-pulse {
+            0%   { background-color: rgba(30, 185, 84, 0.35); }
+            100% { background-color: transparent; }
+        }
+        .sse-flash {
+            animation: sse-flash-pulse 1s ease-out;
+        }
     </style>
 </head>
 <body>

--- a/adapter-in-web/src/main/resources/templates/outbox-viewer.html
+++ b/adapter-in-web/src/main/resources/templates/outbox-viewer.html
@@ -100,10 +100,10 @@
     <script>
         connectSse('/health/events', function (event) {
             if (event.data === 'refresh-outbox-partitions') {
-                fadeUpdate('snippet-outbox-tasks', '/outbox-viewer/snippets/tasks');
+                patchUpdate('snippet-outbox-tasks', '/outbox-viewer/snippets/tasks');
             }
         }, function () {
-            fadeUpdate('snippet-outbox-tasks', '/outbox-viewer/snippets/tasks');
+            patchUpdate('snippet-outbox-tasks', '/outbox-viewer/snippets/tasks');
         });
 
         (function() {
@@ -132,7 +132,7 @@
                 }
                 wipeModal.hide();
                 postWithButton(document.getElementById('wipe-outbox-btn'), '/outbox-viewer/wipe', 'Outbox wiped successfully.', 'Wipe failed', function() {
-                    fadeUpdate('snippet-outbox-tasks', '/outbox-viewer/snippets/tasks');
+                    patchUpdate('snippet-outbox-tasks', '/outbox-viewer/snippets/tasks');
                 });
             });
         })();

--- a/application-quarkus/src/test/kotlin/de/chrgroth/spotify/control/adapter/in/web/DashboardPageTests.kt
+++ b/application-quarkus/src/test/kotlin/de/chrgroth/spotify/control/adapter/in/web/DashboardPageTests.kt
@@ -92,14 +92,14 @@ class DashboardPageTests {
   }
 
   @Test
-  fun `dashboard page uses specific sse events with fade updates instead of full reload`() {
+  fun `dashboard page uses specific sse events with patch updates instead of full reload`() {
     given()
       .`when`()
       .get("/dashboard")
       .then()
       .statusCode(200)
       .body(containsString("refresh-playback-data"))
-      .body(containsString("fadeUpdate"))
+      .body(containsString("patchUpdate"))
   }
 
   @Test

--- a/application-quarkus/src/test/kotlin/de/chrgroth/spotify/control/adapter/in/web/HealthPageTests.kt
+++ b/application-quarkus/src/test/kotlin/de/chrgroth/spotify/control/adapter/in/web/HealthPageTests.kt
@@ -63,7 +63,7 @@ class HealthPageTests {
   }
 
   @Test
-  fun `health page uses specific sse events with fade updates instead of full reload`() {
+  fun `health page uses specific sse events with patch updates instead of full reload`() {
     given()
       .`when`()
       .get("/health")
@@ -71,7 +71,7 @@ class HealthPageTests {
       .statusCode(200)
       .body(containsString("refresh-outgoing-http-calls"))
       .body(containsString("refresh-outbox-partitions"))
-      .body(containsString("fadeUpdate"))
+      .body(containsString("patchUpdate"))
   }
 
   @Test
@@ -300,7 +300,7 @@ class HealthPageTests {
       .get("/health")
       .then()
       .statusCode(200)
-      .body(containsString("fadeUpdate('snippet-cronjobs', '/health/snippets/cronjobs'"))
+      .body(containsString("patchUpdate('snippet-cronjobs', '/health/snippets/cronjobs'"))
   }
 
   @Test

--- a/application-quarkus/src/test/kotlin/de/chrgroth/spotify/control/adapter/in/web/OutboxViewerPageTests.kt
+++ b/application-quarkus/src/test/kotlin/de/chrgroth/spotify/control/adapter/in/web/OutboxViewerPageTests.kt
@@ -35,14 +35,14 @@ class OutboxViewerPageTests {
   }
 
   @Test
-  fun `outbox-viewer page uses specific sse events with fade updates instead of full reload`() {
+  fun `outbox-viewer page uses specific sse events with patch updates instead of full reload`() {
     given()
       .`when`()
       .get("/outbox-viewer")
       .then()
       .statusCode(200)
       .body(containsString("refresh-outbox-partitions"))
-      .body(containsString("fadeUpdate"))
+      .body(containsString("patchUpdate"))
       .body(containsString("snippet-outbox-tasks"))
   }
 

--- a/docs/coding-guidelines/role-frontend-developer.md
+++ b/docs/coding-guidelines/role-frontend-developer.md
@@ -33,7 +33,7 @@ View-specific calculations and DTO/model classes may live in `adapter-in-web` to
 
 ## Live Updates via SSE
 
-SSE streams deliver named string events (e.g. `refresh-playback-data`) from the backend to the browser. Each page that needs live updates connects to its SSE endpoint using the `connectSse(url, onMessage)` helper from `sse-utils.js`. On receiving an event, the handler calls `fadeUpdate(elementId, snippetUrl)` to fetch and replace the targeted fragment.
+SSE streams deliver named string events (e.g. `refresh-playback-data`) from the backend to the browser. Each page that needs live updates connects to its SSE endpoint using the `connectSse(url, onMessage)` helper from `sse-utils.js`. On receiving an event, the handler calls `patchUpdate(elementId, snippetUrl)` to fetch the targeted fragment and merge it into the existing DOM node-by-node, only touching the text/attributes/elements that actually changed (instead of replacing the whole fragment). Elements that changed get a brief `sse-flash` highlight so updates stay noticeable without the surrounding block fading in and out.
 
 **Available SSE endpoints:**
 
@@ -47,7 +47,7 @@ SSE streams deliver named string events (e.g. `refresh-playback-data`) from the 
 1. Add a named event constant to the SSE adapter (e.g. `DashboardSseAdapter` or `HealthSseAdapter`)
 2. Implement the port method that triggers the event (outbound port `DashboardRefreshPort` or equivalent)
 3. Add a new snippet endpoint in the resource class that returns the HTML fragment
-4. Add a `case` in the page's `connectSse` handler to call `fadeUpdate(elementId, snippetUrl)` on the new event
+4. Add a `case` in the page's `connectSse` handler to call `patchUpdate(elementId, snippetUrl)` on the new event
 5. The fragment template must be independently renderable (no dependency on page-level context)
 
 ## Design Principles

--- a/docs/releasenotes/snippets/0458-bugfix.md
+++ b/docs/releasenotes/snippets/0458-bugfix.md
@@ -1,0 +1,2 @@
+* Live-updating sections (e.g. Health UI) no longer fade the whole block in and out on every update.
+* Only the parts of the page that actually changed are highlighted briefly, so content stays readable while updates happen in the background.


### PR DESCRIPTION
## Summary
- Replaces the full-block opacity fade (`fadeUpdate`) used on every SSE update with a granular DOM-patching mechanism (`patchUpdate`) that diffs old vs. new fragment HTML and only touches nodes that actually changed.
- Changed elements get a brief, localized `.sse-flash` highlight instead of the whole card fading, so updates stay visible without flickering the entire UI, especially on the Health page where several SSE streams fire frequently.
- Updates all pages using SSE live updates (Health, Dashboard, Outbox Viewer), related tests, and frontend guidelines.

Closes #679.

## Test plan
- [x] `./gradlew build` passes (tests + static analysis)
- [ ] Manually verify in browser that Health UI updates no longer fade/flicker the whole block

Generated with [Claude Code](https://claude.ai/code)