### PR TITLE
fix: reuse album metadata from artist discography response

### DIFF
--- a/adapter-out-spotify/src/main/kotlin/de/chrgroth/spotify/control/adapter/out/spotify/SpotifyCatalogAdapter.kt
+++ b/adapter-out-spotify/src/main/kotlin/de/chrgroth/spotify/control/adapter/out/spotify/SpotifyCatalogAdapter.kt
@@ -4,9 +4,12 @@ import arrow.core.Either
 import arrow.core.left
 import arrow.core.right
 import de.chrgroth.spotify.control.adapter.out.spotify.model.AlbumObject
+import de.chrgroth.spotify.control.adapter.out.spotify.model.ArtistDiscographyAlbumObject
 import de.chrgroth.spotify.control.adapter.out.spotify.model.ArtistObject
+import de.chrgroth.spotify.control.adapter.out.spotify.model.ImageObject
 import de.chrgroth.spotify.control.adapter.out.spotify.model.PagingArtistDiscographyAlbumObject
 import de.chrgroth.spotify.control.adapter.out.spotify.model.PagingSimplifiedTrackObject
+import de.chrgroth.spotify.control.adapter.out.spotify.model.SimplifiedArtistObject
 import de.chrgroth.spotify.control.adapter.out.spotify.model.SimplifiedTrackObject
 import de.chrgroth.spotify.control.domain.error.DomainError
 import de.chrgroth.spotify.control.domain.error.SpotifyRateLimitError
@@ -28,6 +31,7 @@ import mu.KLogging
 import org.eclipse.microprofile.rest.client.inject.RestClient
 import kotlin.time.Clock
 import kotlin.time.Duration.Companion.seconds
+import kotlin.time.Instant
 
 @ApplicationScoped
 @Suppress("Unused", "TooGenericExceptionCaught")
@@ -80,7 +84,7 @@ class SpotifyCatalogAdapter(
         allTracks.addAll(nextPage.items)
         nextOffset = nextPage.next?.queryParamInt("offset")
       }
-      val parsedTracks = allTracks.mapNotNull { parseAlbumTrack(it, appAlbum) }
+      val parsedTracks = allTracks.mapNotNull { parseAlbumTrack(it, appAlbum, appAlbum.lastSync) }
       val droppedCount = allTracks.size - parsedTracks.size
       if (droppedCount > 0) {
         logger.warn {
@@ -107,6 +111,49 @@ class SpotifyCatalogAdapter(
     }
   }
 
+  override fun getAlbumTracks(
+    userId: UserId,
+    accessToken: AccessToken,
+    album: AppAlbum,
+  ): Either<DomainError, List<AppTrack>> {
+    val albumId = album.id.value
+    return try {
+      SpotifyApiAuthContext.set(accessToken)
+      val lastSync = Clock.System.now()
+      val allTracks = mutableListOf<SimplifiedTrackObject>()
+      var offset: Int? = 0
+      while (offset != null) {
+        throttler.throttle(DomainOutboxPartition.ToSpotifyCatalog.key)
+        val page = httpMetrics.timed("/v1/albums/{id}/tracks") {
+          apiClient.getAlbumTracks(albumId, ALBUM_TRACKS_PAGE_SIZE, offset)
+        }
+        allTracks.addAll(page.items)
+        offset = page.next?.queryParamInt("offset")
+      }
+      val parsedTracks = allTracks.mapNotNull { parseAlbumTrack(it, album, lastSync) }
+      val droppedCount = allTracks.size - parsedTracks.size
+      if (droppedCount > 0) {
+        logger.warn {
+          "Album $albumId: dropped $droppedCount track(s) without id or primary artist" +
+            " (fetched ${allTracks.size}, album reports ${album.totalTracks} total)"
+        }
+      }
+      parsedTracks.right()
+    } catch (e: SpotifyRateLimitException) {
+      SpotifyRateLimitError(e.retryAfterSeconds.seconds).left()
+    } catch (e: SpotifyApiException) {
+      logger.error { "Spotify album tracks fetch failed for $albumId (user ${userId.value}): status=${e.statusCode}, body=${e.body.take(500)}" }
+      SyncError.TRACK_DETAILS_FETCH_FAILED.left()
+    } catch (e: Exception) {
+      logger.error(e) {
+        "Unexpected error fetching album tracks for album $albumId (user ${userId.value}): ${e::class.simpleName}: ${e.message}"
+      }
+      SyncError.TRACK_DETAILS_FETCH_FAILED.left()
+    } finally {
+      SpotifyApiAuthContext.clear()
+    }
+  }
+
   override fun getArtistAlbumsPage(
     userId: UserId,
     accessToken: AccessToken,
@@ -120,7 +167,7 @@ class SpotifyCatalogAdapter(
       val page = httpMetrics.timed("/v1/artists/{id}/albums") {
         apiClient.getArtistAlbums(artistId, ARTIST_ALBUMS_PAGE_SIZE, offset, ARTIST_ALBUMS_INCLUDE_GROUPS)
       }
-      ArtistAlbumsPage(albumIds = page.items.mapNotNull { it.id }, nextUrl = page.next).right()
+      ArtistAlbumsPage(albums = page.items.mapNotNull { parseDiscographyAlbum(it) }, nextUrl = page.next).right()
     } catch (e: SpotifyRateLimitException) {
       SpotifyRateLimitError(e.retryAfterSeconds.seconds).left()
     } catch (e: SpotifyApiException) {
@@ -144,22 +191,57 @@ class SpotifyCatalogAdapter(
     )
 
   private fun parseAlbum(album: AlbumObject, fallbackAlbumId: String): AppAlbum =
-    AppAlbum(
-      id = AlbumId(album.id ?: fallbackAlbumId),
-      totalTracks = album.totalTracks,
-      title = album.name,
-      imageLink = album.images.firstOrNull()?.url,
+    buildAppAlbum(
+      albumId = album.id ?: fallbackAlbumId,
+      name = album.name,
+      images = album.images,
       releaseDate = album.releaseDate,
-      releaseDatePrecision = album.releaseDatePrecision ?: "",
-      type = album.albumType ?: "",
-      artistId = album.artists.firstOrNull()?.id?.let { ArtistId(it) },
-      artistName = album.artists.firstOrNull()?.name,
-      additionalArtistIds = album.artists.additionalItems { id?.let { ArtistId(it) } }?.filterNotNull(),
-      additionalArtistNames = album.artists.additionalItems { name }?.filterNotNull(),
+      releaseDatePrecision = album.releaseDatePrecision,
+      albumType = album.albumType,
+      totalTracks = album.totalTracks,
+      artists = album.artists,
+    )
+
+  private fun parseDiscographyAlbum(album: ArtistDiscographyAlbumObject): AppAlbum? {
+    val albumId = album.id ?: return null
+    return buildAppAlbum(
+      albumId = albumId,
+      name = album.name,
+      images = album.images,
+      releaseDate = album.releaseDate,
+      releaseDatePrecision = album.releaseDatePrecision,
+      albumType = album.albumType,
+      totalTracks = album.totalTracks,
+      artists = album.artists,
+    )
+  }
+
+  private fun buildAppAlbum(
+    albumId: String,
+    name: String?,
+    images: List<ImageObject>,
+    releaseDate: String?,
+    releaseDatePrecision: String?,
+    albumType: String?,
+    totalTracks: Int?,
+    artists: List<SimplifiedArtistObject>,
+  ): AppAlbum =
+    AppAlbum(
+      id = AlbumId(albumId),
+      totalTracks = totalTracks,
+      title = name,
+      imageLink = images.firstOrNull()?.url,
+      releaseDate = releaseDate,
+      releaseDatePrecision = releaseDatePrecision ?: "",
+      type = albumType ?: "",
+      artistId = artists.firstOrNull()?.id?.let { ArtistId(it) },
+      artistName = artists.firstOrNull()?.name,
+      additionalArtistIds = artists.additionalItems { id?.let { ArtistId(it) } }?.filterNotNull(),
+      additionalArtistNames = artists.additionalItems { name }?.filterNotNull(),
       lastSync = Clock.System.now(),
     )
 
-  private fun parseAlbumTrack(track: SimplifiedTrackObject, album: AppAlbum): AppTrack? {
+  private fun parseAlbumTrack(track: SimplifiedTrackObject, album: AppAlbum, lastSync: Instant): AppTrack? {
     val trackId = track.id ?: return null
     val (primaryArtistId, primaryArtistName) = (track.artists ?: emptyList()).firstOrNull()
       ?.let { artist -> artist.id?.let { id -> id to artist.name } }
@@ -177,7 +259,7 @@ class SpotifyCatalogAdapter(
       durationMs = track.durationMs?.toLong(),
       trackNumber = track.trackNumber,
       type = track.type,
-      lastSync = album.lastSync,
+      lastSync = lastSync,
     )
   }
 

--- a/docs/releasenotes/snippets/1049-bugfix.md
+++ b/docs/releasenotes/snippets/1049-bugfix.md
@@ -1,0 +1,1 @@
+* Reduced the number of Spotify requests needed during catalog sync, helping avoid rate limiting.

--- a/domain-api/src/main/kotlin/de/chrgroth/spotify/control/domain/model/catalog/ArtistAlbumsPage.kt
+++ b/domain-api/src/main/kotlin/de/chrgroth/spotify/control/domain/model/catalog/ArtistAlbumsPage.kt
@@ -2,8 +2,10 @@ package de.chrgroth.spotify.control.domain.model.catalog
 
 /**
  * Result of a single page from the Spotify artist albums API.
+ * Albums carry their full metadata as returned by the discography endpoint, so callers
+ * do not need a separate request to fetch metadata for newly discovered albums.
  */
 data class ArtistAlbumsPage(
-  val albumIds: List<String>,
+  val albums: List<AppAlbum>,
   val nextUrl: String?,
 )

--- a/domain-api/src/main/kotlin/de/chrgroth/spotify/control/domain/port/out/catalog/SpotifyCatalogPort.kt
+++ b/domain-api/src/main/kotlin/de/chrgroth/spotify/control/domain/port/out/catalog/SpotifyCatalogPort.kt
@@ -4,12 +4,25 @@ import arrow.core.Either
 import de.chrgroth.spotify.control.domain.error.DomainError
 import de.chrgroth.spotify.control.domain.model.user.AccessToken
 import de.chrgroth.spotify.control.domain.model.catalog.AlbumSyncResult
+import de.chrgroth.spotify.control.domain.model.catalog.AppAlbum
 import de.chrgroth.spotify.control.domain.model.catalog.AppArtist
+import de.chrgroth.spotify.control.domain.model.catalog.AppTrack
 import de.chrgroth.spotify.control.domain.model.catalog.ArtistAlbumsPage
 import de.chrgroth.spotify.control.domain.model.user.UserId
 
 interface SpotifyCatalogPort {
   fun getArtist(userId: UserId, accessToken: AccessToken, artistId: String): Either<DomainError, AppArtist?>
+
+  /**
+   * Fetches an album's full metadata and all tracks via GET /v1/albums/{id}.
+   * Used as a fallback for albums whose metadata is not yet known locally.
+   */
   fun getAlbum(userId: UserId, accessToken: AccessToken, albumId: String): Either<DomainError, AlbumSyncResult>
+
+  /**
+   * Fetches all tracks for an album whose metadata is already known, via GET /v1/albums/{id}/tracks.
+   * Avoids re-fetching album metadata that was already captured from the artist discography response.
+   */
+  fun getAlbumTracks(userId: UserId, accessToken: AccessToken, album: AppAlbum): Either<DomainError, List<AppTrack>>
   fun getArtistAlbumsPage(userId: UserId, accessToken: AccessToken, artistId: String, nextUrl: String?): Either<DomainError, ArtistAlbumsPage>
 }

--- a/domain-impl/src/main/kotlin/de/chrgroth/spotify/control/domain/catalog/CatalogService.kt
+++ b/domain-impl/src/main/kotlin/de/chrgroth/spotify/control/domain/catalog/CatalogService.kt
@@ -6,6 +6,7 @@ import arrow.core.left
 import arrow.core.right
 import de.chrgroth.spotify.control.domain.error.ArtistSettingsError
 import de.chrgroth.spotify.control.domain.error.DomainError
+import de.chrgroth.spotify.control.domain.model.catalog.AlbumSyncResult
 import de.chrgroth.spotify.control.domain.model.catalog.AppArtist
 import de.chrgroth.spotify.control.domain.model.catalog.AlbumId
 import de.chrgroth.spotify.control.domain.model.catalog.ArtistId
@@ -136,14 +137,23 @@ class CatalogService(
       return 0.right()
     }
     val accessToken = spotifyAccessToken.getValidAccessToken(userId)
-    val result = spotifyCatalog.getAlbum(userId, accessToken, albumId)
+    val knownAlbum = appAlbumRepository.findByAlbumIds(setOf(AlbumId(albumId))).firstOrNull()
+    val result = if (knownAlbum != null) {
+      // metadata already captured from the artist discography response, only tracks are missing
+      spotifyCatalog.getAlbumTracks(userId, accessToken, knownAlbum).map { tracks -> AlbumSyncResult(knownAlbum, tracks) }
+    } else {
+      // fallback for albums without known metadata, e.g. events enqueued before this album was upserted
+      spotifyCatalog.getAlbum(userId, accessToken, albumId)
+    }
     return when (result) {
       is Either.Left -> result.value.left()
       is Either.Right -> {
         val albumResult = result.value
         if (albumResult.tracks.isNotEmpty()) {
           appTrackRepository.upsertAll(albumResult.tracks)
-          appAlbumRepository.upsertAll(listOf(albumResult.album))
+          if (knownAlbum == null) {
+            appAlbumRepository.upsertAll(listOf(albumResult.album))
+          }
           val expectedTracks = albumResult.album.totalTracks
           if (expectedTracks != null && albumResult.tracks.size < expectedTracks) {
             logger.warn { "Album '${albumResult.album.title ?: albumId}' ($albumId): synced ${albumResult.tracks.size} track(s) but album reports $expectedTracks total" }
@@ -214,19 +224,20 @@ class CatalogService(
     val accessToken = spotifyAccessToken.getValidAccessToken(userId)
     return spotifyCatalog.getArtistAlbumsPage(userId, accessToken, artistId, nextUrl)
       .flatMap { page ->
-        val existingAlbumIds = appAlbumRepository.findByAlbumIds(page.albumIds.map { AlbumId(it) }.toSet()).map { it.id.value }.toSet()
-        val newAlbumIds = page.albumIds.filter { it !in existingAlbumIds }
-        if (newAlbumIds.isNotEmpty()) {
+        val existingAlbumIds = appAlbumRepository.findByAlbumIds(page.albums.map { it.id }.toSet()).map { it.id.value }.toSet()
+        val newAlbums = page.albums.filter { it.id.value !in existingAlbumIds }
+        if (newAlbums.isNotEmpty()) {
+          appAlbumRepository.upsertAll(newAlbums)
           val now = Clock.System.now()
-          newAlbumIds.forEach { albumId ->
-            syncTraceRepository.upsert(SyncTrace(SyncTraceEntityType.ALBUM, albumId, SyncCause.ArtistDiscography(artistId), now))
-            outboxPort.enqueue(DomainOutboxEvent.SyncAlbumDetails(albumId))
+          newAlbums.forEach { album ->
+            syncTraceRepository.upsert(SyncTrace(SyncTraceEntityType.ALBUM, album.id.value, SyncCause.ArtistDiscography(artistId), now))
+            outboxPort.enqueue(DomainOutboxEvent.SyncAlbumDetails(album.id.value))
           }
         } else {
-          logger.debug { "All ${page.albumIds.size} album(s) on this page for artist $artistId already in catalog" }
+          logger.debug { "All ${page.albums.size} album(s) on this page for artist $artistId already in catalog" }
         }
         if (page.nextUrl != null) {
-          if (newAlbumIds.isNotEmpty()) {
+          if (newAlbums.isNotEmpty()) {
             outboxPort.enqueue(DomainOutboxEvent.SyncArtistAlbums(artistId, userId, page.nextUrl))
           }
         }

--- a/domain-impl/src/test/kotlin/de/chrgroth/spotify/control/domain/catalog/CatalogServiceTests.kt
+++ b/domain-impl/src/test/kotlin/de/chrgroth/spotify/control/domain/catalog/CatalogServiceTests.kt
@@ -85,6 +85,7 @@ class CatalogServiceTests {
   private val userId = UserId("user-1")
   private val accessToken = AccessToken("token")
   private val album1 = AppAlbum(id = AlbumId("album-1"), title = "Album One", artistId = ArtistId("artist-1"), artistName = "Artist One", lastSync = syncTimestamp)
+  private val album2 = AppAlbum(id = AlbumId("album-2"), title = "Album Two", artistId = ArtistId("artist-2"), artistName = "Artist Two", lastSync = syncTimestamp)
   private val trackWithAlbum1 = AppTrack(
     id = TrackId("track-1"), title = "Track One",
     albumId = AlbumId("album-1"), artistId = ArtistId("artist-1"), lastSync = syncTimestamp,
@@ -253,9 +254,28 @@ class CatalogServiceTests {
   }
 
   @Test
-  fun `handle SyncAlbumDetails syncs album and upserts all tracks`() {
+  fun `handle SyncAlbumDetails fetches only tracks and skips album upsert when album metadata already known`() {
     every { userRepository.findAll() } returns listOf(buildUser())
     every { spotifyAccessToken.getValidAccessToken(userId) } returns accessToken
+    every { appAlbumRepository.findByAlbumIds(setOf(AlbumId("album-1"))) } returns listOf(album1)
+    every { spotifyCatalog.getAlbumTracks(userId, accessToken, album1) } returns listOf(trackWithAlbum1, trackWithAlbum2).right()
+    every { appTrackRepository.upsertAll(any()) } just runs
+    every { outboxPort.enqueue(any()) } just runs
+
+    val result = adapter.handle(DomainOutboxEvent.SyncAlbumDetails("album-1"))
+
+    assertThat(result.isRight()).isTrue()
+    verify { spotifyCatalog.getAlbumTracks(userId, accessToken, album1) }
+    verify(exactly = 0) { spotifyCatalog.getAlbum(any(), any(), any()) }
+    verify { appTrackRepository.upsertAll(listOf(trackWithAlbum1, trackWithAlbum2)) }
+    verify(exactly = 0) { appAlbumRepository.upsertAll(any()) }
+  }
+
+  @Test
+  fun `handle SyncAlbumDetails falls back to full album fetch and upserts album when metadata not yet known`() {
+    every { userRepository.findAll() } returns listOf(buildUser())
+    every { spotifyAccessToken.getValidAccessToken(userId) } returns accessToken
+    every { appAlbumRepository.findByAlbumIds(setOf(AlbumId("album-1"))) } returns emptyList()
     every { spotifyCatalog.getAlbum(userId, accessToken, "album-1") } returns albumSyncResult.right()
     every { appTrackRepository.upsertAll(any()) } just runs
     every { appAlbumRepository.upsertAll(any()) } just runs
@@ -265,6 +285,7 @@ class CatalogServiceTests {
 
     assertThat(result.isRight()).isTrue()
     verify { spotifyCatalog.getAlbum(userId, accessToken, "album-1") }
+    verify(exactly = 0) { spotifyCatalog.getAlbumTracks(any(), any(), any()) }
     verify { appTrackRepository.upsertAll(listOf(trackWithAlbum1, trackWithAlbum2)) }
     verify { appAlbumRepository.upsertAll(listOf(album1)) }
   }
@@ -273,6 +294,7 @@ class CatalogServiceTests {
   fun `handle SyncAlbumDetails does not sync artists found in album tracks`() {
     every { userRepository.findAll() } returns listOf(buildUser())
     every { spotifyAccessToken.getValidAccessToken(userId) } returns accessToken
+    every { appAlbumRepository.findByAlbumIds(setOf(AlbumId("album-1"))) } returns emptyList()
     every { spotifyCatalog.getAlbum(userId, accessToken, "album-1") } returns albumSyncResult.right()
     every { appTrackRepository.upsertAll(any()) } just runs
     every { appAlbumRepository.upsertAll(any()) } just runs
@@ -286,6 +308,7 @@ class CatalogServiceTests {
   fun `handle SyncAlbumDetails returns failed when album endpoint returns error`() {
     every { userRepository.findAll() } returns listOf(buildUser())
     every { spotifyAccessToken.getValidAccessToken(userId) } returns accessToken
+    every { appAlbumRepository.findByAlbumIds(setOf(AlbumId("album-1"))) } returns emptyList()
     every { spotifyCatalog.getAlbum(userId, accessToken, "album-1") } returns SyncError.TRACK_DETAILS_FETCH_FAILED.left()
 
     val result = adapter.handle(DomainOutboxEvent.SyncAlbumDetails("album-1"))
@@ -299,6 +322,7 @@ class CatalogServiceTests {
     val rateLimitError = SpotifyRateLimitError(30.seconds)
     every { userRepository.findAll() } returns listOf(buildUser())
     every { spotifyAccessToken.getValidAccessToken(userId) } returns accessToken
+    every { appAlbumRepository.findByAlbumIds(setOf(AlbumId("album-1"))) } returns emptyList()
     every { spotifyCatalog.getAlbum(userId, accessToken, "album-1") } returns rateLimitError.left()
 
     val result = adapter.handle(DomainOutboxEvent.SyncAlbumDetails("album-1"))
@@ -310,15 +334,17 @@ class CatalogServiceTests {
 
   @Test
   fun `handle SyncArtistAlbums enqueues SyncAlbumDetails for new albums and completes when no next page`() {
-    val page = ArtistAlbumsPage(albumIds = listOf("album-1", "album-2"), nextUrl = null)
+    val page = ArtistAlbumsPage(albums = listOf(album1, album2), nextUrl = null)
     every { spotifyAccessToken.getValidAccessToken(userId) } returns accessToken
     every { spotifyCatalog.getArtistAlbumsPage(userId, accessToken, "artist-1", null) } returns page.right()
     every { appAlbumRepository.findByAlbumIds(setOf(AlbumId("album-1"), AlbumId("album-2"))) } returns emptyList()
+    every { appAlbumRepository.upsertAll(any()) } just runs
     every { outboxPort.enqueue(any()) } just runs
 
     val result = adapter.handle(DomainOutboxEvent.SyncArtistAlbums("artist-1", userId))
 
     assertThat(result.isRight()).isTrue()
+    verify { appAlbumRepository.upsertAll(listOf(album1, album2)) }
     verify { outboxPort.enqueue(DomainOutboxEvent.SyncAlbumDetails("album-1")) }
     verify { outboxPort.enqueue(DomainOutboxEvent.SyncAlbumDetails("album-2")) }
     verify(exactly = 0) { outboxPort.enqueue(match { it is DomainOutboxEvent.SyncArtistAlbums }) }
@@ -327,10 +353,11 @@ class CatalogServiceTests {
   @Test
   fun `handle SyncArtistAlbums enqueues next page via outbox when nextUrl is present`() {
     val nextPageUrl = "https://api.spotify.com/v1/artists/artist-1/albums?offset=50&limit=50"
-    val page = ArtistAlbumsPage(albumIds = listOf("album-1"), nextUrl = nextPageUrl)
+    val page = ArtistAlbumsPage(albums = listOf(album1), nextUrl = nextPageUrl)
     every { spotifyAccessToken.getValidAccessToken(userId) } returns accessToken
     every { spotifyCatalog.getArtistAlbumsPage(userId, accessToken, "artist-1", null) } returns page.right()
     every { appAlbumRepository.findByAlbumIds(setOf(AlbumId("album-1"))) } returns emptyList()
+    every { appAlbumRepository.upsertAll(any()) } just runs
     every { outboxPort.enqueue(any()) } just runs
 
     val result = adapter.handle(DomainOutboxEvent.SyncArtistAlbums("artist-1", userId))
@@ -343,10 +370,11 @@ class CatalogServiceTests {
   @Test
   fun `handle SyncArtistAlbums processes subsequent page and fetches using nextUrl`() {
     val nextPageUrl = "https://api.spotify.com/v1/artists/artist-1/albums?offset=50&limit=50"
-    val page = ArtistAlbumsPage(albumIds = listOf("album-2"), nextUrl = null)
+    val page = ArtistAlbumsPage(albums = listOf(album2), nextUrl = null)
     every { spotifyAccessToken.getValidAccessToken(userId) } returns accessToken
     every { spotifyCatalog.getArtistAlbumsPage(userId, accessToken, "artist-1", nextPageUrl) } returns page.right()
     every { appAlbumRepository.findByAlbumIds(setOf(AlbumId("album-2"))) } returns emptyList()
+    every { appAlbumRepository.upsertAll(any()) } just runs
     every { outboxPort.enqueue(any()) } just runs
 
     val result = adapter.handle(DomainOutboxEvent.SyncArtistAlbums("artist-1", userId, nextPageUrl))
@@ -358,15 +386,17 @@ class CatalogServiceTests {
 
   @Test
   fun `handle SyncArtistAlbums enqueues only new albums and skips existing ones`() {
-    val page = ArtistAlbumsPage(albumIds = listOf("album-1", "album-2"), nextUrl = null)
+    val page = ArtistAlbumsPage(albums = listOf(album1, album2), nextUrl = null)
     every { spotifyAccessToken.getValidAccessToken(userId) } returns accessToken
     every { spotifyCatalog.getArtistAlbumsPage(userId, accessToken, "artist-1", null) } returns page.right()
     every { appAlbumRepository.findByAlbumIds(setOf(AlbumId("album-1"), AlbumId("album-2"))) } returns listOf(album1)
+    every { appAlbumRepository.upsertAll(any()) } just runs
     every { outboxPort.enqueue(any()) } just runs
 
     val result = adapter.handle(DomainOutboxEvent.SyncArtistAlbums("artist-1", userId))
 
     assertThat(result.isRight()).isTrue()
+    verify { appAlbumRepository.upsertAll(listOf(album2)) }
     verify { outboxPort.enqueue(DomainOutboxEvent.SyncAlbumDetails("album-2")) }
     verify(exactly = 0) { outboxPort.enqueue(DomainOutboxEvent.SyncAlbumDetails("album-1")) }
   }
@@ -374,8 +404,7 @@ class CatalogServiceTests {
   @Test
   fun `handle SyncArtistAlbums skips next page when all albums on current page are already in catalog`() {
     val nextPageUrl = "https://api.spotify.com/v1/artists/artist-1/albums?offset=50&limit=50"
-    val album2 = AppAlbum(id = AlbumId("album-2"), lastSync = syncTimestamp)
-    val page = ArtistAlbumsPage(albumIds = listOf("album-1", "album-2"), nextUrl = nextPageUrl)
+    val page = ArtistAlbumsPage(albums = listOf(album1, album2), nextUrl = nextPageUrl)
     every { spotifyAccessToken.getValidAccessToken(userId) } returns accessToken
     every { spotifyCatalog.getArtistAlbumsPage(userId, accessToken, "artist-1", null) } returns page.right()
     every { appAlbumRepository.findByAlbumIds(setOf(AlbumId("album-1"), AlbumId("album-2"))) } returns listOf(album1, album2)
@@ -385,20 +414,23 @@ class CatalogServiceTests {
 
     assertThat(result.isRight()).isTrue()
     verify(exactly = 0) { outboxPort.enqueue(any()) }
+    verify(exactly = 0) { appAlbumRepository.upsertAll(any()) }
   }
 
   @Test
   fun `handle SyncArtistAlbums enqueues next page when some albums on current page are new`() {
     val nextPageUrl = "https://api.spotify.com/v1/artists/artist-1/albums?offset=50&limit=50"
-    val page = ArtistAlbumsPage(albumIds = listOf("album-1", "album-2"), nextUrl = nextPageUrl)
+    val page = ArtistAlbumsPage(albums = listOf(album1, album2), nextUrl = nextPageUrl)
     every { spotifyAccessToken.getValidAccessToken(userId) } returns accessToken
     every { spotifyCatalog.getArtistAlbumsPage(userId, accessToken, "artist-1", null) } returns page.right()
     every { appAlbumRepository.findByAlbumIds(setOf(AlbumId("album-1"), AlbumId("album-2"))) } returns listOf(album1)
+    every { appAlbumRepository.upsertAll(any()) } just runs
     every { outboxPort.enqueue(any()) } just runs
 
     val result = adapter.handle(DomainOutboxEvent.SyncArtistAlbums("artist-1", userId))
 
     assertThat(result.isRight()).isTrue()
+    verify { appAlbumRepository.upsertAll(listOf(album2)) }
     verify { outboxPort.enqueue(DomainOutboxEvent.SyncAlbumDetails("album-2")) }
     verify { outboxPort.enqueue(DomainOutboxEvent.SyncArtistAlbums("artist-1", userId, nextPageUrl)) }
   }


### PR DESCRIPTION
## Summary
- Avoids re-fetching album metadata via `GET /v1/albums/{id}` once it has already been captured from `GET /v1/artists/{id}/albums` during artist discography sync.
- New albums now persist their metadata immediately when discovered; `SyncAlbumDetails` only fetches the remaining tracklist via `GET /v1/albums/{id}/tracks` (limit=50 from the first page).
- Falls back to the previous full `GET /v1/albums/{id}` fetch for albums whose metadata is not yet known locally, e.g. outbox events enqueued before this change.

Reduces duplicate Spotify API calls during catalog sync, helping avoid rate limiting.

Refs #682.

## Test plan
- [x] `./gradlew build` passes (tests + static analysis)
- [x] Updated `CatalogServiceTests` cover both the "metadata already known" and "fallback fetch" paths

🤖 Generated with [Claude Code](https://claude.ai/code)