### PR TITLE
Fix broken Technical Metrics dashboard panels and add missing metrics

### DIFF
--- a/adapter-in-scheduler/build.gradle.kts
+++ b/adapter-in-scheduler/build.gradle.kts
@@ -10,6 +10,7 @@ dependencies {
   implementation(enforcedPlatform(libs.quarkusBom))
   implementation("io.quarkus:quarkus-arc")
   implementation("io.quarkus:quarkus-scheduler")
+  implementation("io.quarkus:quarkus-micrometer")
 }
 
 allOpen {

--- a/adapter-in-scheduler/src/main/kotlin/de/chrgroth/spotify/control/adapter/in/scheduler/ArtistCatalogSyncJob.kt
+++ b/adapter-in-scheduler/src/main/kotlin/de/chrgroth/spotify/control/adapter/in/scheduler/ArtistCatalogSyncJob.kt
@@ -2,6 +2,7 @@ package de.chrgroth.spotify.control.adapter.`in`.scheduler
 
 import de.chrgroth.quarkus.starters.domain.ScheduledSkipPredicate
 import de.chrgroth.spotify.control.domain.port.`in`.catalog.CatalogPort
+import io.micrometer.core.annotation.Timed
 import io.quarkus.scheduler.Scheduled
 import jakarta.enterprise.context.ApplicationScoped
 import java.time.LocalDate
@@ -13,6 +14,7 @@ class ArtistCatalogSyncJob(
   private val catalog: CatalogPort,
 ) {
 
+  @Timed(value = "scheduler.job", extraTags = ["invoker", "ArtistCatalogSyncJob"], histogram = true)
   @Scheduled(cron = "0 0 2 * * ?", skipExecutionIf = ScheduledSkipPredicate::class)
   fun run() {
     val partition = LocalDate.now(ZoneOffset.UTC).dayOfYear % TOTAL_PARTITIONS

--- a/adapter-in-scheduler/src/main/kotlin/de/chrgroth/spotify/control/adapter/in/scheduler/PlaybackAggregationJob.kt
+++ b/adapter-in-scheduler/src/main/kotlin/de/chrgroth/spotify/control/adapter/in/scheduler/PlaybackAggregationJob.kt
@@ -2,6 +2,7 @@ package de.chrgroth.spotify.control.adapter.`in`.scheduler
 
 import de.chrgroth.quarkus.starters.domain.ScheduledSkipPredicate
 import de.chrgroth.spotify.control.domain.port.`in`.playback.PlaybackAggregationPort
+import io.micrometer.core.annotation.Timed
 import io.quarkus.scheduler.Scheduled
 import jakarta.enterprise.context.ApplicationScoped
 import java.time.LocalDate
@@ -14,26 +15,31 @@ class PlaybackAggregationJob(
   private val aggregation: PlaybackAggregationPort,
 ) {
 
+  @Timed(value = "scheduler.job", extraTags = ["invoker", "PlaybackAggregationJob.aggregateDaily"], histogram = true)
   @Scheduled(cron = "0 0 1 * * ?", skipExecutionIf = ScheduledSkipPredicate::class)
   fun aggregateDaily() {
     aggregation.enqueueAggregateDay(LocalDate.now(ZoneOffset.UTC).minusDays(1).toKotlin())
   }
 
+  @Timed(value = "scheduler.job", extraTags = ["invoker", "PlaybackAggregationJob.aggregateWeekly"], histogram = true)
   @Scheduled(cron = "0 30 1 ? * MON", skipExecutionIf = ScheduledSkipPredicate::class)
   fun aggregateWeekly() {
     aggregation.enqueueAggregateWeek(LocalDate.now(ZoneOffset.UTC).minusWeeks(1).toKotlin())
   }
 
+  @Timed(value = "scheduler.job", extraTags = ["invoker", "PlaybackAggregationJob.aggregateMonthly"], histogram = true)
   @Scheduled(cron = "0 0 2 1 * ?", skipExecutionIf = ScheduledSkipPredicate::class)
   fun aggregateMonthly() {
     aggregation.enqueueAggregateMonth(LocalDate.now(ZoneOffset.UTC).minusMonths(1).withDayOfMonth(1).toKotlin())
   }
 
+  @Timed(value = "scheduler.job", extraTags = ["invoker", "PlaybackAggregationJob.aggregateQuarterly"], histogram = true)
   @Scheduled(cron = "0 30 2 1 1,4,7,10 ?", skipExecutionIf = ScheduledSkipPredicate::class)
   fun aggregateQuarterly() {
     aggregation.enqueueAggregateQuarter(LocalDate.now(ZoneOffset.UTC).minusMonths(MONTHS_PER_QUARTER).withDayOfMonth(1).toKotlin())
   }
 
+  @Timed(value = "scheduler.job", extraTags = ["invoker", "PlaybackAggregationJob.aggregateYearly"], histogram = true)
   @Scheduled(cron = "0 0 3 1 1 ?", skipExecutionIf = ScheduledSkipPredicate::class)
   fun aggregateYearly() {
     aggregation.enqueueAggregateYear(LocalDate.now(ZoneOffset.UTC).minusYears(1).withDayOfMonth(1).toKotlin())

--- a/adapter-in-scheduler/src/main/kotlin/de/chrgroth/spotify/control/adapter/in/scheduler/PlaybackDetectionJob.kt
+++ b/adapter-in-scheduler/src/main/kotlin/de/chrgroth/spotify/control/adapter/in/scheduler/PlaybackDetectionJob.kt
@@ -1,6 +1,7 @@
 package de.chrgroth.spotify.control.adapter.`in`.scheduler
 
 import de.chrgroth.spotify.control.domain.port.`in`.playback.PlaybackPort
+import io.micrometer.core.annotation.Timed
 import io.quarkus.scheduler.Scheduled
 import jakarta.enterprise.context.ApplicationScoped
 
@@ -10,6 +11,7 @@ class PlaybackDetectionJob(
   private val playback: PlaybackPort,
 ) {
 
+  @Timed(value = "scheduler.job", extraTags = ["invoker", "PlaybackDetectionJob"], histogram = true)
   @Scheduled(every = "20s", skipExecutionIf = CurrentlyPlayingSkipPredicate::class)
   fun run() {
     playback.enqueueFetchPlaybackData()

--- a/adapter-in-scheduler/src/main/kotlin/de/chrgroth/spotify/control/adapter/in/scheduler/PlaylistSyncJob.kt
+++ b/adapter-in-scheduler/src/main/kotlin/de/chrgroth/spotify/control/adapter/in/scheduler/PlaylistSyncJob.kt
@@ -2,6 +2,7 @@ package de.chrgroth.spotify.control.adapter.`in`.scheduler
 
 import de.chrgroth.spotify.control.domain.port.`in`.playlist.PlaylistPort
 import de.chrgroth.quarkus.starters.domain.ScheduledSkipPredicate
+import io.micrometer.core.annotation.Timed
 import io.quarkus.scheduler.Scheduled
 import jakarta.enterprise.context.ApplicationScoped
 import mu.KLogging
@@ -12,6 +13,7 @@ class PlaylistSyncJob(
   private val playlist: PlaylistPort,
 ) {
 
+  @Timed(value = "scheduler.job", extraTags = ["invoker", "PlaylistSyncJob"], histogram = true)
   @Scheduled(cron = "0 30 * * * ?", skipExecutionIf = ScheduledSkipPredicate::class)
   fun run() {
     logger.info { "Running scheduled playlist sync" }

--- a/adapter-in-scheduler/src/main/kotlin/de/chrgroth/spotify/control/adapter/in/scheduler/UserProfileUpdateJob.kt
+++ b/adapter-in-scheduler/src/main/kotlin/de/chrgroth/spotify/control/adapter/in/scheduler/UserProfileUpdateJob.kt
@@ -2,6 +2,7 @@ package de.chrgroth.spotify.control.adapter.`in`.scheduler
 
 import de.chrgroth.spotify.control.domain.port.`in`.user.UserProfilePort
 import de.chrgroth.quarkus.starters.domain.ScheduledSkipPredicate
+import io.micrometer.core.annotation.Timed
 import io.quarkus.scheduler.Scheduled
 import jakarta.enterprise.context.ApplicationScoped
 import mu.KLogging
@@ -12,6 +13,7 @@ class UserProfileUpdateJob(
   private val userProfile: UserProfilePort,
 ) {
 
+  @Timed(value = "scheduler.job", extraTags = ["invoker", "UserProfileUpdateJob"], histogram = true)
   @Scheduled(cron = "0 0 4 * * ?", skipExecutionIf = ScheduledSkipPredicate::class)
   fun run() {
     logger.info { "Running scheduled user profile update" }

--- a/adapter-out-mongodb/src/main/kotlin/de/chrgroth/spotify/control/adapter/out/mongodb/MongoQueryMetrics.kt
+++ b/adapter-out-mongodb/src/main/kotlin/de/chrgroth/spotify/control/adapter/out/mongodb/MongoQueryMetrics.kt
@@ -54,6 +54,7 @@ class MongoQueryMetrics(
     timers.getOrPut(operation) {
       Timer.builder("mongodb.query")
         .tag("operation", operation)
+        .publishPercentileHistogram()
         .register(meterRegistry)
     }.record(durationMs, TimeUnit.MILLISECONDS)
 

--- a/adapter-out-spotify/src/main/kotlin/de/chrgroth/spotify/control/adapter/out/spotify/SpotifyHttpMetrics.kt
+++ b/adapter-out-spotify/src/main/kotlin/de/chrgroth/spotify/control/adapter/out/spotify/SpotifyHttpMetrics.kt
@@ -6,8 +6,9 @@ import de.chrgroth.spotify.control.domain.port.out.infra.OutgoingRequestStatsPor
 import io.micrometer.core.instrument.Gauge
 import io.micrometer.core.instrument.MeterRegistry
 import io.micrometer.core.instrument.Timer
-import jakarta.annotation.PostConstruct
+import io.quarkus.runtime.StartupEvent
 import jakarta.enterprise.context.ApplicationScoped
+import jakarta.enterprise.event.Observes
 import jakarta.enterprise.inject.Any
 import jakarta.enterprise.inject.Instance
 import java.time.Instant
@@ -15,6 +16,7 @@ import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ConcurrentLinkedDeque
 import java.util.concurrent.TimeUnit
 
+// registers eagerly on StartupEvent so this gauge is always visible, even before any Spotify request occurs
 @ApplicationScoped
 class SpotifyHttpMetrics(
   private val meterRegistry: MeterRegistry,
@@ -24,8 +26,7 @@ class SpotifyHttpMetrics(
   private val timers = ConcurrentHashMap<String, Timer>()
   private val requestTimestamps = ConcurrentHashMap<String, ConcurrentLinkedDeque<Instant>>()
 
-  @PostConstruct
-  fun initialize() {
+  fun onStartup(@Observes event: StartupEvent) {
     Gauge.builder("spotify.request.endpoints", requestTimestamps) { it.size.toDouble() }
       .description("Number of tracked Spotify API endpoints with recorded requests")
       .register(meterRegistry)
@@ -52,6 +53,7 @@ class SpotifyHttpMetrics(
       Timer.builder("spotify.request")
         .tag("url", urlTemplate)
         .tag("status", statusCode.toString())
+        .publishPercentileHistogram()
         .register(meterRegistry)
     }.record(durationMs, TimeUnit.MILLISECONDS)
 

--- a/application-quarkus/src/test/kotlin/de/chrgroth/spotify/control/application/quarkus/MetricsTests.kt
+++ b/application-quarkus/src/test/kotlin/de/chrgroth/spotify/control/application/quarkus/MetricsTests.kt
@@ -24,7 +24,7 @@ class MetricsTests {
       .map { it.split("_")[0] }
       .distinct()
       .sorted()
-    assertThat(topLevelGroups).isEqualTo(listOf("app", "http", "jvm", "mongodb", "netty", "outbox", "process", "spotify", "system", "worker"))
+    assertThat(topLevelGroups).isEqualTo(listOf("app", "application", "http", "jvm", "mongodb", "netty", "outbox", "process", "spotify", "system", "worker"))
   }
 
   @Test

--- a/docs/releasenotes/snippets/issue-693-20260706-0520-feature.md
+++ b/docs/releasenotes/snippets/issue-693-20260706-0520-feature.md
@@ -1,0 +1,2 @@
+* Fixed several panels in the Technical Metrics Grafana dashboard that never showed any data (app version, scheduled job timings, paused outbox tasks).
+* Removed a broken log panel from the Technical Metrics dashboard and added quick links between the Overview, Technical Metrics and Logs dashboards instead.

--- a/domain-impl/src/main/kotlin/de/chrgroth/spotify/control/domain/infra/ApplicationInfoMetrics.kt
+++ b/domain-impl/src/main/kotlin/de/chrgroth/spotify/control/domain/infra/ApplicationInfoMetrics.kt
@@ -1,0 +1,26 @@
+package de.chrgroth.spotify.control.domain.infra
+
+import io.micrometer.core.instrument.Gauge
+import io.micrometer.core.instrument.MeterRegistry
+import io.quarkus.runtime.StartupEvent
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.enterprise.event.Observes
+import org.eclipse.microprofile.config.inject.ConfigProperty
+
+// registers eagerly on StartupEvent so this gauge is always visible, even before any user activity occurs
+@ApplicationScoped
+@Suppress("Unused", "UnusedParameter")
+class ApplicationInfoMetrics(
+  private val meterRegistry: MeterRegistry,
+) {
+
+  @field:ConfigProperty(name = "quarkus.application.version")
+  lateinit var version: String
+
+  fun onStartup(@Observes event: StartupEvent) {
+    Gauge.builder("application.info", this) { 1.0 }
+      .tag("version", version)
+      .description("Static info metric carrying the running application version as a label")
+      .register(meterRegistry)
+  }
+}

--- a/monitoring/grafana/quarkus-logs.json
+++ b/monitoring/grafana/quarkus-logs.json
@@ -20,6 +20,22 @@
   "graphTooltip": 0,
   "links": [
     {
+      "icon": "external link",
+      "tags": [],
+      "targetBlank": true,
+      "title": "Overview",
+      "type": "link",
+      "url": "/d/spotify-control-overview/overview"
+    },
+    {
+      "icon": "external link",
+      "tags": [],
+      "targetBlank": true,
+      "title": "Quarkus Metrics",
+      "type": "link",
+      "url": "/d/quarkus-spotify-control/quarkus-metrics"
+    },
+    {
       "icon": "bolt",
       "includeVars": true,
       "keepTime": true,

--- a/monitoring/grafana/quarkus-metrics.json
+++ b/monitoring/grafana/quarkus-metrics.json
@@ -19,7 +19,24 @@
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
   "id": null,
-  "links": [],
+  "links": [
+    {
+      "icon": "external link",
+      "tags": [],
+      "targetBlank": true,
+      "title": "Overview",
+      "type": "link",
+      "url": "/d/spotify-control-overview/overview"
+    },
+    {
+      "icon": "external link",
+      "tags": [],
+      "targetBlank": true,
+      "title": "Quarkus Logs",
+      "type": "link",
+      "url": "/d/sadlil-loki-apps-dashboard/quarkus-logs"
+    }
+  ],
   "panels": [
     {
       "collapsed": false,
@@ -758,108 +775,6 @@
         "x": 0,
         "y": 23
       },
-      "id": 30,
-      "panels": [],
-      "title": "Logging",
-      "type": "row"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 5,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "never",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          },
-          "unit": "ops"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 24,
-        "x": 0,
-        "y": 24
-      },
-      "id": 31,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "expr": "rate(log4j2_events_total{job=\"prometheus.scrape.spotify_control\"}[$__rate_interval])",
-          "legendFormat": "{{level}}",
-          "refId": "A",
-          "instant": false,
-          "range": true
-        }
-      ],
-      "title": "Log Events per Level",
-      "type": "timeseries"
-    },
-    {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 32
-      },
       "id": 40,
       "panels": [],
       "title": "HTTP Server (Incoming Requests)",
@@ -923,7 +838,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 33
+        "y": 24
       },
       "id": 41,
       "options": {
@@ -1012,9 +927,15 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 33
+        "y": 24
       },
       "id": 42,
+      "links": [
+        {
+          "title": "View error logs",
+          "url": "/d/sadlil-loki-apps-dashboard/quarkus-logs?${__url_time_range}&var-search=ERROR"
+        }
+      ],
       "options": {
         "legend": {
           "calcs": [],
@@ -1101,7 +1022,7 @@
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 41
+        "y": 32
       },
       "id": 43,
       "options": {
@@ -1160,7 +1081,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 49
+        "y": 40
       },
       "id": 50,
       "panels": [],
@@ -1225,7 +1146,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 50
+        "y": 41
       },
       "id": 51,
       "options": {
@@ -1314,7 +1235,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 50
+        "y": 41
       },
       "id": 52,
       "options": {
@@ -1373,7 +1294,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 58
+        "y": 49
       },
       "id": 60,
       "panels": [],
@@ -1438,7 +1359,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 59
+        "y": 50
       },
       "id": 61,
       "options": {
@@ -1549,7 +1470,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 59
+        "y": 50
       },
       "id": 62,
       "options": {
@@ -1586,7 +1507,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 67
+        "y": 58
       },
       "id": 70,
       "panels": [],
@@ -1651,7 +1572,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 68
+        "y": 59
       },
       "id": 71,
       "options": {
@@ -1740,7 +1661,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 68
+        "y": 59
       },
       "id": 74,
       "options": {
@@ -1829,7 +1750,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 76
+        "y": 67
       },
       "id": 72,
       "options": {
@@ -1861,14 +1782,14 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "rate(outbox_tasks_rate_limited_total{job=\"prometheus.scrape.spotify_control\"}[$__rate_interval]) or on() vector(0)",
-          "legendFormat": "rate-limited [{{partition}}]",
+          "expr": "rate(outbox_tasks_paused_total{job=\"prometheus.scrape.spotify_control\"}[$__rate_interval]) or on() vector(0)",
+          "legendFormat": "paused [{{partition}}]",
           "refId": "B",
           "instant": false,
           "range": true
         }
       ],
-      "title": "Failed & Rate-Limited Task Rates",
+      "title": "Failed & Paused Task Rates",
       "type": "timeseries"
     },
     {
@@ -1919,7 +1840,7 @@
         "h": 4,
         "w": 12,
         "x": 12,
-        "y": 76
+        "y": 67
       },
       "id": 73,
       "options": {
@@ -1958,7 +1879,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 84
+        "y": 75
       },
       "id": 80,
       "panels": [],
@@ -2023,7 +1944,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 85
+        "y": 76
       },
       "id": 81,
       "options": {
@@ -2044,7 +1965,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "histogram_quantile(0.50, sum(rate(quarkus_scheduler_scheduled_methods_seconds_bucket{job=\"prometheus.scrape.spotify_control\"}[$__rate_interval])) by (le, invoker))",
+          "expr": "histogram_quantile(0.50, sum(rate(scheduler_job_seconds_bucket{job=\"prometheus.scrape.spotify_control\"}[$__rate_interval])) by (le, invoker))",
           "legendFormat": "p50 {{invoker}}",
           "refId": "A",
           "instant": false,
@@ -2055,7 +1976,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "histogram_quantile(0.95, sum(rate(quarkus_scheduler_scheduled_methods_seconds_bucket{job=\"prometheus.scrape.spotify_control\"}[$__rate_interval])) by (le, invoker))",
+          "expr": "histogram_quantile(0.95, sum(rate(scheduler_job_seconds_bucket{job=\"prometheus.scrape.spotify_control\"}[$__rate_interval])) by (le, invoker))",
           "legendFormat": "p95 {{invoker}}",
           "refId": "B",
           "instant": false,
@@ -2066,7 +1987,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "histogram_quantile(0.99, sum(rate(quarkus_scheduler_scheduled_methods_seconds_bucket{job=\"prometheus.scrape.spotify_control\"}[$__rate_interval])) by (le, invoker))",
+          "expr": "histogram_quantile(0.99, sum(rate(scheduler_job_seconds_bucket{job=\"prometheus.scrape.spotify_control\"}[$__rate_interval])) by (le, invoker))",
           "legendFormat": "p99 {{invoker}}",
           "refId": "C",
           "instant": false,
@@ -2134,7 +2055,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 85
+        "y": 76
       },
       "id": 82,
       "options": {
@@ -2155,7 +2076,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "rate(quarkus_scheduler_scheduled_methods_seconds_count{job=\"prometheus.scrape.spotify_control\"}[$__rate_interval])",
+          "expr": "rate(scheduler_job_seconds_count{job=\"prometheus.scrape.spotify_control\"}[$__rate_interval])",
           "legendFormat": "{{invoker}}",
           "refId": "A",
           "instant": false,
@@ -2171,7 +2092,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 93
+        "y": 84
       },
       "id": 90,
       "panels": [],
@@ -2226,7 +2147,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 94
+        "y": 85
       },
       "id": 92,
       "options": {


### PR DESCRIPTION
## Summary
- Verified every metric name in the Technical Metrics Grafana dashboard against a real /q/metrics output and fixed several panels that never showed data (app version, outbox paused tasks, scheduled job timing, duration percentiles).
- Removed the broken Logging row (referenced a non-existent log4j2 metric) and replaced it with cross-links between the Overview, Technical Metrics and Logs dashboards.
- Tools menu link to this dashboard already existed, no change needed.

Closes #693.

## Test plan
- [x] `./gradlew build` passes (tests + static analysis)
- [x] Verified metric names via a Quarkus @QuarkusTest hitting /q/metrics
- [ ] Manually eyeball the dashboard in Grafana after deploy

🤖 Generated with [Claude Code](https://claude.ai/code)