### PR TITLE
fix: avoid full-document fetch for playback aggregation event counts

### DIFF
--- a/adapter-out-mongodb/src/main/kotlin/de/chrgroth/spotify/control/adapter/out/mongodb/PlaybackAggregationRepositoryAdapter.kt
+++ b/adapter-out-mongodb/src/main/kotlin/de/chrgroth/spotify/control/adapter/out/mongodb/PlaybackAggregationRepositoryAdapter.kt
@@ -1,7 +1,10 @@
 package de.chrgroth.spotify.control.adapter.out.mongodb
 
+import com.mongodb.client.model.Filters
+import com.mongodb.client.model.Projections
 import de.chrgroth.spotify.control.domain.model.playback.aggregation.ActivityEntry
 import de.chrgroth.spotify.control.domain.model.playback.aggregation.ActivityTimeWindow
+import de.chrgroth.spotify.control.domain.model.playback.aggregation.AggregationEventCount
 import de.chrgroth.spotify.control.domain.model.playback.aggregation.AggregationPeriodType
 import de.chrgroth.spotify.control.domain.model.playback.aggregation.AggregationRankEntry
 import de.chrgroth.spotify.control.domain.model.playback.aggregation.PlaybackAggregation
@@ -49,9 +52,28 @@ class PlaybackAggregationRepositoryAdapter(
       ).map { it.toDomain() }
     }
 
+  override fun countEventsByUserTypeAndPeriodRange(userId: UserId, type: AggregationPeriodType, from: LocalDate, to: LocalDate): List<AggregationEventCount> =
+    mongoQueryMetrics.timed("app_playback_aggregation.countEventsByUserTypeAndPeriodRange") {
+      repository.mongoCollection()
+        .find(
+          Filters.and(
+            Filters.eq(SPOTIFY_USER_ID_FIELD, userId.value),
+            Filters.eq(TYPE_FIELD, type.name),
+            Filters.gte(PERIOD_START_FIELD, from.toString()),
+            Filters.lte(PERIOD_START_FIELD, to.toString()),
+          ),
+        )
+        .projection(Projections.include(PERIOD_START_FIELD, EVENT_COUNT_FIELD))
+        .toList()
+        .map { AggregationEventCount(periodStart = LocalDate.parse(it.periodStart), eventCount = it.eventCount) }
+    }
+
   override fun sumEventCountByUser(userId: UserId): Long =
     mongoQueryMetrics.timed("app_playback_aggregation.sumEventCountByUser") {
-      repository.list("$SPOTIFY_USER_ID_FIELD = ?1 and $TYPE_FIELD = ?2", userId.value, AggregationPeriodType.DAY.name)
+      repository.mongoCollection()
+        .find(Filters.and(Filters.eq(SPOTIFY_USER_ID_FIELD, userId.value), Filters.eq(TYPE_FIELD, AggregationPeriodType.DAY.name)))
+        .projection(Projections.include(EVENT_COUNT_FIELD))
+        .toList()
         .sumOf { it.eventCount }
     }
 
@@ -114,6 +136,7 @@ class PlaybackAggregationRepositoryAdapter(
     internal const val SPOTIFY_USER_ID_FIELD = "spotifyUserId"
     internal const val TYPE_FIELD = "type"
     internal const val PERIOD_START_FIELD = "periodStart"
+    internal const val EVENT_COUNT_FIELD = "eventCount"
 
     internal fun documentId(userId: UserId, type: AggregationPeriodType, periodStart: LocalDate): String =
       "${userId.value}:${type.name}:$periodStart"

--- a/docs/releasenotes/snippets/0858-bugfix.md
+++ b/docs/releasenotes/snippets/0858-bugfix.md
@@ -1,0 +1,1 @@
+* Fixed slow dashboard loading caused by inefficient playback statistics queries.

--- a/domain-api/src/main/kotlin/de/chrgroth/spotify/control/domain/model/playback/aggregation/AggregationEventCount.kt
+++ b/domain-api/src/main/kotlin/de/chrgroth/spotify/control/domain/model/playback/aggregation/AggregationEventCount.kt
@@ -1,0 +1,8 @@
+package de.chrgroth.spotify.control.domain.model.playback.aggregation
+
+import kotlinx.datetime.LocalDate
+
+data class AggregationEventCount(
+  val periodStart: LocalDate,
+  val eventCount: Long,
+)

--- a/domain-api/src/main/kotlin/de/chrgroth/spotify/control/domain/port/out/playback/PlaybackAggregationRepositoryPort.kt
+++ b/domain-api/src/main/kotlin/de/chrgroth/spotify/control/domain/port/out/playback/PlaybackAggregationRepositoryPort.kt
@@ -1,5 +1,6 @@
 package de.chrgroth.spotify.control.domain.port.out.playback
 
+import de.chrgroth.spotify.control.domain.model.playback.aggregation.AggregationEventCount
 import de.chrgroth.spotify.control.domain.model.playback.aggregation.AggregationPeriodType
 import de.chrgroth.spotify.control.domain.model.playback.aggregation.PlaybackAggregation
 import de.chrgroth.spotify.control.domain.model.user.UserId
@@ -10,5 +11,6 @@ interface PlaybackAggregationRepositoryPort {
   fun deleteAll()
   fun findByUserAndPeriod(userId: UserId, type: AggregationPeriodType, periodStart: LocalDate): PlaybackAggregation?
   fun findByUserTypeAndPeriodRange(userId: UserId, type: AggregationPeriodType, from: LocalDate, to: LocalDate): List<PlaybackAggregation>
+  fun countEventsByUserTypeAndPeriodRange(userId: UserId, type: AggregationPeriodType, from: LocalDate, to: LocalDate): List<AggregationEventCount>
   fun sumEventCountByUser(userId: UserId): Long
 }

--- a/domain-impl/src/main/kotlin/de/chrgroth/spotify/control/domain/infra/DashboardService.kt
+++ b/domain-impl/src/main/kotlin/de/chrgroth/spotify/control/domain/infra/DashboardService.kt
@@ -95,11 +95,11 @@ class DashboardService(
   private fun computePlaybackStats(userId: UserId): DashboardStats {
     val today = Clock.System.now().toLocalDateTime(TimeZone.UTC).date
     val from = today - DatePeriod(days = STATS_DAYS - 1)
-    val dailyAggs = aggregationRepository.findByUserTypeAndPeriodRange(userId, AggregationPeriodType.DAY, from, today)
+    val dailyEventCounts = aggregationRepository.countEventsByUserTypeAndPeriodRange(userId, AggregationPeriodType.DAY, from, today)
     val total = aggregationRepository.sumEventCountByUser(userId)
-    val last30Days = dailyAggs.sumOf { it.eventCount }
+    val last30Days = dailyEventCounts.sumOf { it.eventCount }
 
-    val countByDate = dailyAggs.associate { it.periodStart to it.eventCount }
+    val countByDate = dailyEventCounts.associate { it.periodStart to it.eventCount }
     val allDays = ((STATS_DAYS - 1) downTo 0).map { today - DatePeriod(days = it) }
     val maxCount = countByDate.values.maxOrNull() ?: 1L
     val perDay = allDays.map { date ->

--- a/domain-impl/src/test/kotlin/de/chrgroth/spotify/control/domain/infra/DashboardServiceTests.kt
+++ b/domain-impl/src/test/kotlin/de/chrgroth/spotify/control/domain/infra/DashboardServiceTests.kt
@@ -8,6 +8,7 @@ import de.chrgroth.spotify.control.domain.model.catalog.AppTrack
 import de.chrgroth.spotify.control.domain.model.catalog.ArtistId
 import de.chrgroth.spotify.control.domain.model.catalog.CatalogStats
 import de.chrgroth.spotify.control.domain.model.catalog.TrackId
+import de.chrgroth.spotify.control.domain.model.playback.aggregation.AggregationEventCount
 import de.chrgroth.spotify.control.domain.model.playback.aggregation.AggregationPeriodType
 import de.chrgroth.spotify.control.domain.model.playback.aggregation.AggregationRankEntry
 import de.chrgroth.spotify.control.domain.model.playback.aggregation.PlaybackAggregation
@@ -78,6 +79,7 @@ class DashboardServiceTests {
 
   private fun setupCommonMocks() {
     every { aggregationRepository.findByUserTypeAndPeriodRange(userId, AggregationPeriodType.DAY, any(), any()) } returns emptyList()
+    every { aggregationRepository.countEventsByUserTypeAndPeriodRange(userId, AggregationPeriodType.DAY, any(), any()) } returns emptyList()
     every { aggregationRepository.sumEventCountByUser(userId) } returns 0L
     every { appPlaybackRepository.findRecentlyPlayed(userId, any()) } returns emptyList()
     every { playlistRepository.findByUserId(userId) } returns emptyList()
@@ -193,6 +195,7 @@ class DashboardServiceTests {
   @Test
   fun `recently played tracks include duration from secondsPlayed`() {
     every { aggregationRepository.findByUserTypeAndPeriodRange(userId, AggregationPeriodType.DAY, any(), any()) } returns emptyList()
+    every { aggregationRepository.countEventsByUserTypeAndPeriodRange(userId, AggregationPeriodType.DAY, any(), any()) } returns emptyList()
     every { aggregationRepository.sumEventCountByUser(userId) } returns 1L
     every { playlistRepository.findByUserId(userId) } returns emptyList()
     every { playlistCheckRepository.countAll() } returns 0L
@@ -220,8 +223,8 @@ class DashboardServiceTests {
 
   @Test
   fun `getPlaybackStats only queries aggregation repository`() {
-    val agg = emptyAgg().copy(eventCount = 7L)
-    every { aggregationRepository.findByUserTypeAndPeriodRange(userId, AggregationPeriodType.DAY, any(), any()) } returns listOf(agg)
+    val eventCount = AggregationEventCount(periodStart = someDate, eventCount = 7L)
+    every { aggregationRepository.countEventsByUserTypeAndPeriodRange(userId, AggregationPeriodType.DAY, any(), any()) } returns listOf(eventCount)
     every { aggregationRepository.sumEventCountByUser(userId) } returns 42L
 
     val stats = adapter.getPlaybackStats(userId)
@@ -229,6 +232,7 @@ class DashboardServiceTests {
     assertThat(stats.totalPlaybackEvents).isEqualTo(42L)
     assertThat(stats.playbackEventsLast30Days).isEqualTo(7L)
     assertThat(stats.playbackEventsPerDay).hasSize(30)
+    verify(exactly = 0) { aggregationRepository.findByUserTypeAndPeriodRange(any(), any(), any(), any()) }
     verify(exactly = 0) { playlistRepository.findByUserId(any()) }
     verify(exactly = 0) { playlistCheckRepository.countAll() }
     verify(exactly = 0) { catalogBrowser.getCatalogStats() }
@@ -244,6 +248,7 @@ class DashboardServiceTests {
     assertThat(stats.syncedPlaylists).isEqualTo(0L)
     assertThat(stats.totalPlaylists).isEqualTo(0L)
     verify(exactly = 0) { aggregationRepository.findByUserTypeAndPeriodRange(any(), any(), any(), any()) }
+    verify(exactly = 0) { aggregationRepository.countEventsByUserTypeAndPeriodRange(any(), any(), any(), any()) }
     verify(exactly = 0) { aggregationRepository.sumEventCountByUser(any()) }
     verify(exactly = 0) { playlistCheckRepository.countAll() }
     verify(exactly = 0) { catalogBrowser.getCatalogStats() }
@@ -260,6 +265,7 @@ class DashboardServiceTests {
 
     assertThat(stats.recentlyPlayedTracks).isEmpty()
     verify(exactly = 0) { aggregationRepository.findByUserTypeAndPeriodRange(any(), any(), any(), any()) }
+    verify(exactly = 0) { aggregationRepository.countEventsByUserTypeAndPeriodRange(any(), any(), any(), any()) }
     verify(exactly = 0) { aggregationRepository.sumEventCountByUser(any()) }
     verify(exactly = 0) { playlistRepository.findByUserId(any()) }
     verify(exactly = 0) { playlistCheckRepository.countAll() }
@@ -276,6 +282,7 @@ class DashboardServiceTests {
     val stats = adapter.getListeningStats(userId)
 
     assertThat(stats.listeningStats.listenedMinutesLast30Days).isEqualTo(0L)
+    verify(exactly = 0) { aggregationRepository.countEventsByUserTypeAndPeriodRange(any(), any(), any(), any()) }
     verify(exactly = 0) { aggregationRepository.sumEventCountByUser(any()) }
     verify(exactly = 0) { appPlaybackRepository.findRecentlyPlayed(any(), any()) }
     verify(exactly = 0) { playlistRepository.findByUserId(any()) }
@@ -294,6 +301,7 @@ class DashboardServiceTests {
     assertThat(stats.playlistCheckStats.succeededChecks).isEqualTo(3L)
     assertThat(stats.playlistCheckStats.allSucceeded).isTrue()
     verify(exactly = 0) { aggregationRepository.findByUserTypeAndPeriodRange(any(), any(), any(), any()) }
+    verify(exactly = 0) { aggregationRepository.countEventsByUserTypeAndPeriodRange(any(), any(), any(), any()) }
     verify(exactly = 0) { aggregationRepository.sumEventCountByUser(any()) }
     verify(exactly = 0) { playlistRepository.findByUserId(any()) }
     verify(exactly = 0) { catalogBrowser.getCatalogStats() }
@@ -309,6 +317,7 @@ class DashboardServiceTests {
     assertThat(stats.catalogStats.albumCount).isEqualTo(20L)
     assertThat(stats.catalogStats.trackCount).isEqualTo(30L)
     verify(exactly = 0) { aggregationRepository.findByUserTypeAndPeriodRange(any(), any(), any(), any()) }
+    verify(exactly = 0) { aggregationRepository.countEventsByUserTypeAndPeriodRange(any(), any(), any(), any()) }
     verify(exactly = 0) { aggregationRepository.sumEventCountByUser(any()) }
     verify(exactly = 0) { playlistRepository.findByUserId(any()) }
     verify(exactly = 0) { playlistCheckRepository.countAll() }


### PR DESCRIPTION
## Summary
- `app_playback_aggregation.sumEventCountByUser` had no date bound and fetched every DAY-aggregation document ever created for a user (full documents, including uncapped artist/album/track/activity entry arrays) just to sum `eventCount` (9323ms in production).
- `computePlaybackStats` separately duplicated the same 30-day `findByUserTypeAndPeriodRange` fetch already made by `buildListeningStats`, only to read `periodStart`/`eventCount` from it.
- Both now use a MongoDB projection that only transfers the two needed fields; `computePlaybackStats` uses a new lightweight `countEventsByUserTypeAndPeriodRange` port method instead of the full-document range query.
- Investigated the remaining slow queries from the issue and intentionally left them alone (contention symptoms, external library, or a riskier fix needing a product decision) — see issue comment for details.

Follow-up to #701.

## Test plan
- [x] `./gradlew build` green (tests + static analysis)
- [x] `DashboardServiceTests` extended for the new projection-based method
- [ ] Manually confirm dashboard/health pages are faster and the slow-query warnings for these two operations disappear once deployed

🤖 Generated with [Claude Code](https://claude.ai/code)