### PR TITLE
perf: shrink track/album/artist ID lookups on Stats and Dashboard pages

### DIFF
--- a/adapter-in-web/src/main/kotlin/de/chrgroth/spotify/control/adapter/in/web/StatsResource.kt
+++ b/adapter-in-web/src/main/kotlin/de/chrgroth/spotify/control/adapter/in/web/StatsResource.kt
@@ -83,7 +83,7 @@ class StatsResource(
   private fun loadTracksById(tabs: List<AggregationTab>) = appTrackRepository.findByTrackIds(
     tabs.flatMap { tab ->
       tab.aggregations.flatMap { aggregation ->
-        aggregation.data?.trackEntries?.map { TrackId(it.id) } ?: emptyList()
+        aggregation.data?.trackEntries?.take(TOP_ENTRIES_LIMIT)?.map { TrackId(it.id) } ?: emptyList()
       }
     }.toSet(),
   ).associateBy { it.id }
@@ -96,7 +96,7 @@ class StatsResource(
       tracksById.values.mapNotNull { it.albumId } +
         tabs.flatMap { tab ->
           tab.aggregations.flatMap { aggregation ->
-            aggregation.data?.albumEntries?.map { AlbumId(it.id) } ?: emptyList()
+            aggregation.data?.albumEntries?.take(TOP_ENTRIES_LIMIT)?.map { AlbumId(it.id) } ?: emptyList()
           }
         }
       ).toSet(),
@@ -105,7 +105,7 @@ class StatsResource(
   private fun loadArtistsById(tabs: List<AggregationTab>) = appArtistRepository.findByArtistIds(
     tabs.flatMap { tab ->
       tab.aggregations.flatMap { aggregation ->
-        aggregation.data?.artistEntries?.map { ArtistId(it.id) } ?: emptyList()
+        aggregation.data?.artistEntries?.take(TOP_ENTRIES_LIMIT)?.map { ArtistId(it.id) } ?: emptyList()
       }
     }.toSet(),
   ).associateBy { it.id }

--- a/docs/releasenotes/snippets/0927-bugfix.md
+++ b/docs/releasenotes/snippets/0927-bugfix.md
@@ -1,0 +1,1 @@
+* Reduced the number of catalog lookups needed to render the Stats page and the Dashboard's listening stats, cutting slow MongoDB queries for track/album/artist details.

--- a/domain-impl/src/main/kotlin/de/chrgroth/spotify/control/domain/infra/DashboardService.kt
+++ b/domain-impl/src/main/kotlin/de/chrgroth/spotify/control/domain/infra/DashboardService.kt
@@ -1,5 +1,6 @@
 package de.chrgroth.spotify.control.domain.infra
 
+import de.chrgroth.spotify.control.domain.model.catalog.AlbumId
 import de.chrgroth.spotify.control.domain.model.catalog.ArtistId
 import de.chrgroth.spotify.control.domain.model.DashboardStats
 import de.chrgroth.spotify.control.domain.model.playback.DayCount
@@ -187,8 +188,6 @@ class DashboardService(
 
     val allTrackIds = secondsByTrackId.keys.map { TrackId(it) }.toSet()
     val statsTrackMap = appTrackRepository.findByTrackIds(allTrackIds).associateBy { it.id.value }
-    val statsAlbumIds = statsTrackMap.values.mapNotNull { it.albumId }.toSet()
-    val statsArtistIds = secondsByArtistId.keys.map { ArtistId(it) }.toSet()
 
     val secondsByAlbumId = mutableMapOf<String, Long>()
     secondsByTrackId.forEach { (trackId, seconds) ->
@@ -196,10 +195,17 @@ class DashboardService(
       secondsByAlbumId[albumId] = (secondsByAlbumId[albumId] ?: 0L) + seconds
     }
 
+    // only the tracks/albums/artists that actually end up in the top-N lists below need their catalog details resolved
+    val topTrackDetails = secondsByTrackId.entries.sortedByDescending { it.value }.take(topEntriesLimit).mapNotNull { statsTrackMap[it.key] }
+    val topAlbumIds = secondsByAlbumId.entries.sortedByDescending { it.value }.take(topEntriesLimit).map { it.key }
+    val topArtistIds = secondsByArtistId.entries.sortedByDescending { it.value }.take(topEntriesLimit).map { it.key }
+    val neededAlbumIds = (topTrackDetails.mapNotNull { it.albumId } + topAlbumIds.map { AlbumId(it) }).toSet()
+    val neededArtistIds = (topTrackDetails.flatMap { it.allArtistIds() } + topArtistIds).map { ArtistId(it) }.toSet()
+
     return coroutineScope {
-      val statsAlbumMapAsync = async(Dispatchers.IO) { appAlbumRepository.findByAlbumIds(statsAlbumIds).associateBy { it.id.value } }
+      val statsAlbumMapAsync = async(Dispatchers.IO) { appAlbumRepository.findByAlbumIds(neededAlbumIds).associateBy { it.id.value } }
       val statsArtistMapAsync = async(Dispatchers.IO) {
-        appArtistRepository.findByArtistIds(statsArtistIds).associateBy { it.id.value }
+        appArtistRepository.findByArtistIds(neededArtistIds).associateBy { it.id.value }
       }
       val statsAlbumMap = statsAlbumMapAsync.await()
       val statsArtistMap = statsArtistMapAsync.await()


### PR DESCRIPTION
## Summary
- `StatsResource` and `DashboardService` resolved catalog details (title/name/image) for every track/album/artist ID referenced in the underlying playback-aggregation entries, even though only the top 5/N ranked entries are ever displayed.
- Since aggregation entries are always stored pre-sorted by `totalSeconds` descending, the extra IDs never affected what's rendered — they just inflated the `$in` ID sets passed to `app_track.findByTrackIds`/`app_album.findByAlbumIds`/`app_artist.findByArtistIds`, which is what made those queries slow.
- `StatsResource` now only collects IDs from the top 5 entries of each aggregation. `DashboardService.buildListeningStats` still fetches all tracks (needed for correct 30-day per-album totals), but only resolves album/artist details for the top-N actually displayed.

Follow-up to #701.

## Test plan
- [x] `./gradlew build` green (tests + static analysis)
- [ ] Manually confirm the slow-query warnings for these three operations shrink/disappear once deployed

Generated with [Claude Code](https://claude.ai/code)) • [`claude/issue-701-20260707-0927`](https://github.com/christiangroth/spotify-control/tree/claude/issue-701-20260707-0927