### PR TITLE
Fix slow outbox.partition.findAll query by sharing cached stats

### DIFF
--- a/docs/releasenotes/snippets/20260708-0526-bugfix.md
+++ b/docs/releasenotes/snippets/20260708-0526-bugfix.md
@@ -1,0 +1,1 @@
+* Fixed slow `outbox.partition.findAll` queries by having the health page and its live-updating widgets share the same cached outbox partition stats used for metrics, instead of each triggering its own query.

--- a/domain-impl/src/main/kotlin/de/chrgroth/spotify/control/domain/infra/HealthService.kt
+++ b/domain-impl/src/main/kotlin/de/chrgroth/spotify/control/domain/infra/HealthService.kt
@@ -6,7 +6,6 @@ import de.chrgroth.spotify.control.domain.port.`in`.infra.HealthPort
 import de.chrgroth.spotify.control.domain.port.out.infra.ConfigurationInfoPort
 import de.chrgroth.spotify.control.domain.port.out.infra.CronjobInfoPort
 import de.chrgroth.spotify.control.domain.port.out.infra.MongoStatsPort
-import de.chrgroth.spotify.control.domain.port.out.infra.OutboxPort
 import de.chrgroth.spotify.control.domain.port.out.infra.OutgoingRequestStatsPort
 import de.chrgroth.spotify.control.domain.port.out.playback.PlaybackActivityPort
 import jakarta.enterprise.context.ApplicationScoped
@@ -19,7 +18,7 @@ import kotlin.coroutines.CoroutineContext
 @ApplicationScoped
 @Suppress("Unused")
 class HealthService(
-  private val outboxPort: OutboxPort,
+  private val outboxStatsCache: OutboxPartitionStatsCache,
   private val outgoingRequestStats: OutgoingRequestStatsPort,
   private val mongoStats: MongoStatsPort,
   private val cronjobInfo: CronjobInfoPort,
@@ -30,7 +29,6 @@ class HealthService(
   override fun getStats(): HealthStats = runBlocking {
     val dispatcher = Dispatchers.IO + tcclContext()
     val outgoingRequestStatsAsync = async(dispatcher) { outgoingRequestStats.getRequestStats() }
-    val outboxPartitionsAsync = async(dispatcher) { outboxPort.getPartitionStats() }
     val mongoCollectionStatsAsync = async(dispatcher) { mongoStats.getCollectionStats() }
     val mongoQueryStatsAsync = async(dispatcher) { mongoStats.getQueryStats() }
     val cronjobStatsAsync = async(dispatcher) { cronjobInfo.getCronjobStats() }
@@ -39,7 +37,7 @@ class HealthService(
     val configurationStatsAsync = async(dispatcher) { configurationInfo.getConfigurationStats() }
     HealthStats(
       outgoingRequestStats = outgoingRequestStatsAsync.await(),
-      outboxPartitions = outboxPartitionsAsync.await(),
+      outboxPartitions = outboxStatsCache.current(),
       mongoCollectionStats = mongoCollectionStatsAsync.await(),
       mongoQueryStats = mongoQueryStatsAsync.await(),
       cronjobStats = cronjobStatsAsync.await(),

--- a/domain-impl/src/main/kotlin/de/chrgroth/spotify/control/domain/infra/OutboxMetrics.kt
+++ b/domain-impl/src/main/kotlin/de/chrgroth/spotify/control/domain/infra/OutboxMetrics.kt
@@ -1,35 +1,28 @@
 package de.chrgroth.spotify.control.domain.infra
 
-import de.chrgroth.spotify.control.domain.model.infra.OutboxPartitionStats
 import de.chrgroth.spotify.control.domain.outbox.DomainOutboxEvent
 import de.chrgroth.spotify.control.domain.outbox.DomainOutboxPartition
-import de.chrgroth.spotify.control.domain.port.out.infra.OutboxPort
 import io.micrometer.core.instrument.Gauge
 import io.micrometer.core.instrument.MeterRegistry
 import io.quarkus.runtime.StartupEvent
-import io.quarkus.scheduler.Scheduled
 import jakarta.enterprise.context.ApplicationScoped
 import jakarta.enterprise.event.Observes
-import mu.KLogging
 
 // registers eagerly on StartupEvent so these gauges are always visible, even before any outbox activity occurs.
 // backed by the actual persisted document counts rather than an enqueued/processed counter diff, which drifts
 // from reality across app restarts (counters reset, the persisted backlog does not).
-// stats are refreshed on a background schedule rather than during gauge evaluation, so a slow/blocking outbox
-// query can never delay the Prometheus scrape response itself (a scrape timeout drops the whole /q/metrics scrape,
-// not just the affected gauges).
+// reads from OutboxPartitionStatsCache rather than querying the outbox library directly, so a slow/blocking
+// outbox query can never delay the Prometheus scrape response itself (a scrape timeout drops the whole
+// /q/metrics scrape, not just the affected gauges), and the same cached snapshot is shared with HealthService.
 @ApplicationScoped
 @Suppress("Unused", "UnusedParameter")
 class OutboxMetrics(
-  private val outboxPort: OutboxPort,
+  private val statsCache: OutboxPartitionStatsCache,
   private val meterRegistry: MeterRegistry,
 ) {
 
-  @Volatile
-  private var cachedStats: List<OutboxPartitionStats> = emptyList()
-
   fun onStartup(@Observes event: StartupEvent) {
-    refresh()
+    statsCache.refresh()
 
     DomainOutboxPartition.all.forEach { partition ->
       Gauge.builder("outbox.partition.pending", this) { pendingCountForPartition(partition.key).toDouble() }
@@ -46,20 +39,9 @@ class OutboxMetrics(
     }
   }
 
-  @Scheduled(every = "15s")
-  fun refresh() {
-    try {
-      cachedStats = outboxPort.getPartitionStats()
-    } catch (e: Exception) {
-      logger.warn(e) { "Failed to refresh outbox partition stats for metrics, keeping previous values" }
-    }
-  }
-
   private fun pendingCountForPartition(partitionKey: String): Long =
-    cachedStats.firstOrNull { it.name == partitionKey }?.documentCount ?: 0L
+    statsCache.current().firstOrNull { it.name == partitionKey }?.documentCount ?: 0L
 
   private fun pendingCountForEventType(eventType: String): Long =
-    cachedStats.sumOf { partition -> partition.eventTypeCounts.firstOrNull { it.eventType == eventType }?.count ?: 0L }
-
-  companion object : KLogging()
+    statsCache.current().sumOf { partition -> partition.eventTypeCounts.firstOrNull { it.eventType == eventType }?.count ?: 0L }
 }

--- a/domain-impl/src/main/kotlin/de/chrgroth/spotify/control/domain/infra/OutboxPartitionStatsCache.kt
+++ b/domain-impl/src/main/kotlin/de/chrgroth/spotify/control/domain/infra/OutboxPartitionStatsCache.kt
@@ -1,0 +1,32 @@
+package de.chrgroth.spotify.control.domain.infra
+
+import de.chrgroth.spotify.control.domain.model.infra.OutboxPartitionStats
+import de.chrgroth.spotify.control.domain.port.out.infra.OutboxPort
+import io.quarkus.scheduler.Scheduled
+import jakarta.enterprise.context.ApplicationScoped
+import mu.KLogging
+
+// shared by OutboxMetrics and HealthService so that neither gauge reads nor health-page/SSE-triggered
+// requests ever query the outbox library directly; a single refresh serves every reader.
+@ApplicationScoped
+@Suppress("Unused")
+class OutboxPartitionStatsCache(
+  private val outboxPort: OutboxPort,
+) {
+
+  @Volatile
+  private var cachedStats: List<OutboxPartitionStats> = emptyList()
+
+  fun current(): List<OutboxPartitionStats> = cachedStats
+
+  @Scheduled(every = "15s")
+  fun refresh() {
+    try {
+      cachedStats = outboxPort.getPartitionStats()
+    } catch (e: Exception) {
+      logger.warn(e) { "Failed to refresh outbox partition stats, keeping previous values" }
+    }
+  }
+
+  companion object : KLogging()
+}

--- a/domain-impl/src/test/kotlin/de/chrgroth/spotify/control/domain/infra/OutboxMetricsTests.kt
+++ b/domain-impl/src/test/kotlin/de/chrgroth/spotify/control/domain/infra/OutboxMetricsTests.kt
@@ -16,8 +16,9 @@ import org.junit.jupiter.api.Test
 class OutboxMetricsTests {
 
   private val outboxPort: OutboxPort = mockk()
+  private val statsCache = OutboxPartitionStatsCache(outboxPort)
   private val meterRegistry = SimpleMeterRegistry()
-  private val metrics = OutboxMetrics(outboxPort, meterRegistry)
+  private val metrics = OutboxMetrics(statsCache, meterRegistry)
 
   @Test
   fun `gauges expose pending counts per partition and event type`() {
@@ -50,20 +51,5 @@ class OutboxMetricsTests {
     meterRegistry.meters.forEach { meter -> meter.measure().forEach { it.value } }
 
     verify(exactly = 1) { outboxPort.getPartitionStats() }
-  }
-
-  @Test
-  fun `a failed refresh keeps the previously cached values instead of propagating`() {
-    val partition = DomainOutboxPartition.Domain
-    every { outboxPort.getPartitionStats() } returns listOf(
-      OutboxPartitionStats(name = partition.key, status = "ACTIVE", documentCount = 3L, blockedUntil = null, eventTypeCounts = emptyList()),
-    )
-    metrics.onStartup(StartupEvent())
-
-    every { outboxPort.getPartitionStats() } throws IllegalStateException("outbox unreachable")
-    metrics.refresh()
-
-    val partitionGauge = meterRegistry.find("outbox.partition.pending").tag("partition", partition.key).gauge()
-    assertThat(partitionGauge?.value()).isEqualTo(3.0)
   }
 }

--- a/domain-impl/src/test/kotlin/de/chrgroth/spotify/control/domain/infra/OutboxPartitionStatsCacheTests.kt
+++ b/domain-impl/src/test/kotlin/de/chrgroth/spotify/control/domain/infra/OutboxPartitionStatsCacheTests.kt
@@ -1,0 +1,52 @@
+package de.chrgroth.spotify.control.domain.infra
+
+import de.chrgroth.spotify.control.domain.model.infra.OutboxPartitionStats
+import de.chrgroth.spotify.control.domain.port.out.infra.OutboxPort
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class OutboxPartitionStatsCacheTests {
+
+  private val outboxPort: OutboxPort = mockk()
+  private val cache = OutboxPartitionStatsCache(outboxPort)
+
+  @Test
+  fun `current is empty before the first refresh`() {
+    assertThat(cache.current()).isEmpty()
+  }
+
+  @Test
+  fun `refresh populates current with the latest partition stats`() {
+    val stats = listOf(OutboxPartitionStats(name = "partition", status = "ACTIVE", documentCount = 2L, blockedUntil = null, eventTypeCounts = emptyList()))
+    every { outboxPort.getPartitionStats() } returns stats
+
+    cache.refresh()
+
+    assertThat(cache.current()).isEqualTo(stats)
+  }
+
+  @Test
+  fun `a failed refresh keeps the previously cached values instead of propagating`() {
+    val stats = listOf(OutboxPartitionStats(name = "partition", status = "ACTIVE", documentCount = 2L, blockedUntil = null, eventTypeCounts = emptyList()))
+    every { outboxPort.getPartitionStats() } returns stats
+    cache.refresh()
+
+    every { outboxPort.getPartitionStats() } throws IllegalStateException("outbox unreachable")
+    cache.refresh()
+
+    assertThat(cache.current()).isEqualTo(stats)
+  }
+
+  @Test
+  fun `current can be read repeatedly without re-querying the outbox port`() {
+    every { outboxPort.getPartitionStats() } returns emptyList()
+    cache.refresh()
+
+    repeat(5) { cache.current() }
+
+    verify(exactly = 1) { outboxPort.getPartitionStats() }
+  }
+}


### PR DESCRIPTION
Fixes #712.

## Summary
- `HealthService.getStats()` called `outboxPort.getPartitionStats()` uncached on every invocation, and every one of the 9 `/health`/snippet endpoints calls `getStats()` independently.
- `OutboxPartitionEventAdapter` fires a `refresh-outbox-partitions` SSE event on every single outbox task lifecycle event, triggering frequent refetches from connected clients.
- This meant `outbox.partition.findAll` (and `outbox.task.countByEventType`) were queried far more often than the 15s cache already used by the Prometheus gauges, since `HealthService` bypassed that cache entirely.
- Extracted a shared `OutboxPartitionStatsCache` used by both `OutboxMetrics` and `HealthService`, so all health-page reads share one 15s-refreshed snapshot instead of querying the outbox library directly.

## Test plan
- `./gradlew build` passes (tests + static analysis).
- Added `OutboxPartitionStatsCacheTests` and updated `OutboxMetricsTests`.

Generated with [Claude Code](https://claude.ai/code)