### PR TITLE
Fix slow dashboard queries: fast aggregation lookup, dedup query, lighter track fetch

### DIFF
--- a/adapter-out-mongodb/src/main/kotlin/de/chrgroth/spotify/control/adapter/out/mongodb/AppTrackDataRepositoryAdapter.kt
+++ b/adapter-out-mongodb/src/main/kotlin/de/chrgroth/spotify/control/adapter/out/mongodb/AppTrackDataRepositoryAdapter.kt
@@ -2,6 +2,7 @@ package de.chrgroth.spotify.control.adapter.out.mongodb
 
 import com.mongodb.client.model.BulkWriteOptions
 import com.mongodb.client.model.Filters
+import com.mongodb.client.model.Projections
 import com.mongodb.client.model.UpdateOneModel
 import com.mongodb.client.model.UpdateOptions
 import com.mongodb.client.model.Updates
@@ -67,6 +68,17 @@ class AppTrackRepositoryAdapter(
         .find(Filters.`in`("_id", trackIds.map { it.value }))
         .toList()
         .map { it.toDomain() }
+    }
+  }
+
+  override fun findAlbumIdsByTrackIds(trackIds: Set<TrackId>): Map<TrackId, AlbumId?> {
+    if (trackIds.isEmpty()) return emptyMap()
+    return mongoQueryMetrics.timed("app_track.findAlbumIdsByTrackIds") {
+      appTrackDocumentRepository.mongoCollection()
+        .find(Filters.`in`("_id", trackIds.map { it.value }))
+        .projection(Projections.include(ID_FIELD, ALBUM_ID_FIELD))
+        .toList()
+        .associate { TrackId(it.id) to it.albumId?.let { albumId -> AlbumId(albumId) } }
     }
   }
 

--- a/adapter-out-mongodb/src/main/kotlin/de/chrgroth/spotify/control/adapter/out/mongodb/PlaybackAggregationRepositoryAdapter.kt
+++ b/adapter-out-mongodb/src/main/kotlin/de/chrgroth/spotify/control/adapter/out/mongodb/PlaybackAggregationRepositoryAdapter.kt
@@ -4,7 +4,6 @@ import com.mongodb.client.model.Filters
 import com.mongodb.client.model.Projections
 import de.chrgroth.spotify.control.domain.model.playback.aggregation.ActivityEntry
 import de.chrgroth.spotify.control.domain.model.playback.aggregation.ActivityTimeWindow
-import de.chrgroth.spotify.control.domain.model.playback.aggregation.AggregationEventCount
 import de.chrgroth.spotify.control.domain.model.playback.aggregation.AggregationPeriodType
 import de.chrgroth.spotify.control.domain.model.playback.aggregation.AggregationRankEntry
 import de.chrgroth.spotify.control.domain.model.playback.aggregation.PlaybackAggregation
@@ -43,17 +42,6 @@ class PlaybackAggregationRepositoryAdapter(
 
   override fun findByUserTypeAndPeriodRange(userId: UserId, type: AggregationPeriodType, from: LocalDate, to: LocalDate): List<PlaybackAggregation> =
     mongoQueryMetrics.timed("app_playback_aggregation.findByUserTypeAndPeriodRange") {
-      repository.list(
-        "$SPOTIFY_USER_ID_FIELD = ?1 and $TYPE_FIELD = ?2 and $PERIOD_START_FIELD >= ?3 and $PERIOD_START_FIELD <= ?4",
-        userId.value,
-        type.name,
-        from.toString(),
-        to.toString(),
-      ).map { it.toDomain() }
-    }
-
-  override fun countEventsByUserTypeAndPeriodRange(userId: UserId, type: AggregationPeriodType, from: LocalDate, to: LocalDate): List<AggregationEventCount> =
-    mongoQueryMetrics.timed("app_playback_aggregation.countEventsByUserTypeAndPeriodRange") {
       repository.mongoCollection()
         .find(
           Filters.and(
@@ -63,9 +51,8 @@ class PlaybackAggregationRepositoryAdapter(
             Filters.lte(PERIOD_START_FIELD, to.toString()),
           ),
         )
-        .projection(Projections.include(PERIOD_START_FIELD, EVENT_COUNT_FIELD))
         .toList()
-        .map { AggregationEventCount(periodStart = LocalDate.parse(it.periodStart), eventCount = it.eventCount) }
+        .map { it.toDomain() }
     }
 
   override fun sumEventCountByUser(userId: UserId): Long =

--- a/application-quarkus/src/test/kotlin/de/chrgroth/spotify/control/adapter/out/mongodb/AppTrackDataRepositoryTests.kt
+++ b/application-quarkus/src/test/kotlin/de/chrgroth/spotify/control/adapter/out/mongodb/AppTrackDataRepositoryTests.kt
@@ -120,6 +120,30 @@ class AppTrackDataRepositoryTests {
   }
 
   @Test
+  fun `findAlbumIdsByTrackIds returns album id per track`() {
+    val withAlbum = trackData("album-lookup").copy(albumId = AlbumId("album-lookup"))
+    val withoutAlbum = trackData("no-album-lookup")
+    appTrackRepository.upsertAll(listOf(withAlbum, withoutAlbum))
+
+    val result = appTrackRepository.findAlbumIdsByTrackIds(setOf(withAlbum.id, withoutAlbum.id))
+
+    assertThat(result).containsEntry(withAlbum.id, AlbumId("album-lookup"))
+    assertThat(result).containsEntry(withoutAlbum.id, null)
+  }
+
+  @Test
+  fun `findAlbumIdsByTrackIds returns empty map for unknown trackIds`() {
+    val result = appTrackRepository.findAlbumIdsByTrackIds(setOf(TrackId("unknown-track-id-${UUID.randomUUID()}")))
+    assertThat(result).isEmpty()
+  }
+
+  @Test
+  fun `findAlbumIdsByTrackIds returns empty map for empty input`() {
+    val result = appTrackRepository.findAlbumIdsByTrackIds(emptySet())
+    assertThat(result).isEmpty()
+  }
+
+  @Test
   fun `findByArtistId returns tracks for the given artist`() {
     val artistId = ArtistId("artist-find-${UUID.randomUUID()}")
     val track1 = trackData("t1").copy(artistId = artistId)

--- a/application-quarkus/src/test/kotlin/de/chrgroth/spotify/control/adapter/out/mongodb/PlaybackAggregationRepositoryTests.kt
+++ b/application-quarkus/src/test/kotlin/de/chrgroth/spotify/control/adapter/out/mongodb/PlaybackAggregationRepositoryTests.kt
@@ -1,0 +1,97 @@
+package de.chrgroth.spotify.control.adapter.out.mongodb
+
+import de.chrgroth.spotify.control.domain.model.playback.aggregation.AggregationPeriodType
+import de.chrgroth.spotify.control.domain.model.playback.aggregation.PlaybackAggregation
+import de.chrgroth.spotify.control.domain.model.user.UserId
+import de.chrgroth.spotify.control.domain.port.out.playback.PlaybackAggregationRepositoryPort
+import io.quarkus.test.junit.QuarkusTest
+import jakarta.inject.Inject
+import kotlinx.datetime.LocalDate
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.util.UUID
+
+@QuarkusTest
+class PlaybackAggregationRepositoryTests {
+
+  @Inject
+  lateinit var aggregationRepository: PlaybackAggregationRepositoryPort
+
+  private fun aggregation(userId: UserId, type: AggregationPeriodType, periodStart: LocalDate, eventCount: Long = 1L) = PlaybackAggregation(
+    userId = userId,
+    type = type,
+    periodStart = periodStart,
+    totalPlaybackSeconds = eventCount * SECONDS_PER_EVENT,
+    eventCount = eventCount,
+    distinctArtistCount = 0,
+    distinctTrackCount = 0,
+    distinctAlbumCount = 0,
+    artistEntries = emptyList(),
+    albumEntries = emptyList(),
+    trackEntries = emptyList(),
+    activityEntries = emptyList(),
+  )
+
+  @Test
+  fun `save persists aggregation and findByUserAndPeriod returns it`() {
+    val userId = UserId("user-${UUID.randomUUID()}")
+    val periodStart = LocalDate(2024, 1, 10)
+    aggregationRepository.save(aggregation(userId, AggregationPeriodType.DAY, periodStart, eventCount = 5L))
+
+    val result = aggregationRepository.findByUserAndPeriod(userId, AggregationPeriodType.DAY, periodStart)
+
+    assertThat(result).isNotNull()
+    assertThat(result!!.eventCount).isEqualTo(5L)
+  }
+
+  @Test
+  fun `findByUserAndPeriod returns null when no aggregation exists`() {
+    val result = aggregationRepository.findByUserAndPeriod(UserId("user-${UUID.randomUUID()}"), AggregationPeriodType.DAY, LocalDate(2024, 1, 1))
+    assertThat(result).isNull()
+  }
+
+  @Test
+  fun `findByUserTypeAndPeriodRange returns only aggregations within range for the given user and type`() {
+    val userId = UserId("user-${UUID.randomUUID()}")
+    val otherUserId = UserId("user-${UUID.randomUUID()}")
+    aggregationRepository.save(aggregation(userId, AggregationPeriodType.DAY, LocalDate(2024, 1, 10)))
+    aggregationRepository.save(aggregation(userId, AggregationPeriodType.DAY, LocalDate(2024, 1, 15)))
+    aggregationRepository.save(aggregation(userId, AggregationPeriodType.DAY, LocalDate(2024, 2, 1)))
+    aggregationRepository.save(aggregation(userId, AggregationPeriodType.WEEK, LocalDate(2024, 1, 15)))
+    aggregationRepository.save(aggregation(otherUserId, AggregationPeriodType.DAY, LocalDate(2024, 1, 15)))
+
+    val result = aggregationRepository.findByUserTypeAndPeriodRange(userId, AggregationPeriodType.DAY, LocalDate(2024, 1, 1), LocalDate(2024, 1, 31))
+
+    assertThat(result.map { it.periodStart }).containsExactlyInAnyOrder(LocalDate(2024, 1, 10), LocalDate(2024, 1, 15))
+  }
+
+  @Test
+  fun `findByUserTypeAndPeriodRange returns empty list when nothing matches`() {
+    val result = aggregationRepository.findByUserTypeAndPeriodRange(
+      UserId("user-${UUID.randomUUID()}"), AggregationPeriodType.DAY, LocalDate(2024, 1, 1), LocalDate(2024, 1, 31),
+    )
+    assertThat(result).isEmpty()
+  }
+
+  @Test
+  fun `sumEventCountByUser sums event counts across all DAY aggregations for the user`() {
+    val userId = UserId("user-${UUID.randomUUID()}")
+    aggregationRepository.save(aggregation(userId, AggregationPeriodType.DAY, LocalDate(2024, 1, 10), eventCount = 3L))
+    aggregationRepository.save(aggregation(userId, AggregationPeriodType.DAY, LocalDate(2024, 1, 11), eventCount = 4L))
+    aggregationRepository.save(aggregation(userId, AggregationPeriodType.WEEK, LocalDate(2024, 1, 8), eventCount = 100L))
+
+    val result = aggregationRepository.sumEventCountByUser(userId)
+
+    assertThat(result).isEqualTo(7L)
+  }
+
+  @Test
+  fun `sumEventCountByUser returns zero when user has no aggregations`() {
+    val result = aggregationRepository.sumEventCountByUser(UserId("user-${UUID.randomUUID()}"))
+    assertThat(result).isEqualTo(0L)
+  }
+
+  companion object {
+    private const val SECONDS_PER_EVENT = 60L
+  }
+}

--- a/docs/releasenotes/snippets/issue-712-20260708-0642-bugfix.md
+++ b/docs/releasenotes/snippets/issue-712-20260708-0642-bugfix.md
@@ -1,0 +1,1 @@
+* Sped up the dashboard by switching a slow aggregation query to a fast, index-backed lookup, removing a redundant query, and only fetching full track details for the tracks actually shown in the top lists.

--- a/domain-api/src/main/kotlin/de/chrgroth/spotify/control/domain/model/playback/aggregation/AggregationEventCount.kt
+++ b/domain-api/src/main/kotlin/de/chrgroth/spotify/control/domain/model/playback/aggregation/AggregationEventCount.kt
@@ -1,8 +1,0 @@
-package de.chrgroth.spotify.control.domain.model.playback.aggregation
-
-import kotlinx.datetime.LocalDate
-
-data class AggregationEventCount(
-  val periodStart: LocalDate,
-  val eventCount: Long,
-)

--- a/domain-api/src/main/kotlin/de/chrgroth/spotify/control/domain/port/out/catalog/AppTrackRepositoryPort.kt
+++ b/domain-api/src/main/kotlin/de/chrgroth/spotify/control/domain/port/out/catalog/AppTrackRepositoryPort.kt
@@ -10,6 +10,7 @@ interface AppTrackRepositoryPort {
   fun countAll(): Long
   fun findAll(): List<AppTrack>
   fun findByTrackIds(trackIds: Set<TrackId>): List<AppTrack>
+  fun findAlbumIdsByTrackIds(trackIds: Set<TrackId>): Map<TrackId, AlbumId?>
   fun findByArtistId(artistId: ArtistId): List<AppTrack>
   fun findByAlbumId(albumId: AlbumId): List<AppTrack>
   fun deleteAll()

--- a/domain-api/src/main/kotlin/de/chrgroth/spotify/control/domain/port/out/playback/PlaybackAggregationRepositoryPort.kt
+++ b/domain-api/src/main/kotlin/de/chrgroth/spotify/control/domain/port/out/playback/PlaybackAggregationRepositoryPort.kt
@@ -1,6 +1,5 @@
 package de.chrgroth.spotify.control.domain.port.out.playback
 
-import de.chrgroth.spotify.control.domain.model.playback.aggregation.AggregationEventCount
 import de.chrgroth.spotify.control.domain.model.playback.aggregation.AggregationPeriodType
 import de.chrgroth.spotify.control.domain.model.playback.aggregation.PlaybackAggregation
 import de.chrgroth.spotify.control.domain.model.user.UserId
@@ -11,6 +10,5 @@ interface PlaybackAggregationRepositoryPort {
   fun deleteAll()
   fun findByUserAndPeriod(userId: UserId, type: AggregationPeriodType, periodStart: LocalDate): PlaybackAggregation?
   fun findByUserTypeAndPeriodRange(userId: UserId, type: AggregationPeriodType, from: LocalDate, to: LocalDate): List<PlaybackAggregation>
-  fun countEventsByUserTypeAndPeriodRange(userId: UserId, type: AggregationPeriodType, from: LocalDate, to: LocalDate): List<AggregationEventCount>
   fun sumEventCountByUser(userId: UserId): Long
 }

--- a/domain-impl/src/main/kotlin/de/chrgroth/spotify/control/domain/infra/DashboardService.kt
+++ b/domain-impl/src/main/kotlin/de/chrgroth/spotify/control/domain/infra/DashboardService.kt
@@ -8,6 +8,7 @@ import de.chrgroth.spotify.control.domain.model.catalog.AppTrack
 import de.chrgroth.spotify.control.domain.model.catalog.displayArtistName
 import de.chrgroth.spotify.control.domain.model.playback.ListeningStats
 import de.chrgroth.spotify.control.domain.model.playback.aggregation.AggregationPeriodType
+import de.chrgroth.spotify.control.domain.model.playback.aggregation.PlaybackAggregation
 import de.chrgroth.spotify.control.domain.model.playlist.PlaylistCheckStats
 import de.chrgroth.spotify.control.domain.model.playlist.PlaylistSyncStatus
 import de.chrgroth.spotify.control.domain.model.playback.RecentlyPlayedItem
@@ -55,13 +56,16 @@ class DashboardService(
 
   override fun getStats(userId: UserId): DashboardStats {
     return runBlocking {
-      val playbackStatsAsync = async(Dispatchers.IO) { computePlaybackStats(userId) }
+      val dailyAggsAsync = async(Dispatchers.IO) { fetchDailyAggregations(userId) }
+      val totalPlaybackEventsAsync = async(Dispatchers.IO) { aggregationRepository.sumEventCountByUser(userId) }
       val playlistMetadataAsync = async(Dispatchers.IO) { computePlaylistMetadata(userId) }
       val playlistCheckStatsAsync = async(Dispatchers.IO) { computePlaylistCheckStats() }
       val recentlyPlayedAsync = async(Dispatchers.IO) { buildRecentlyPlayedTracks(userId) }
-      val listeningStatsAsync = async(Dispatchers.IO) { buildListeningStats(userId) }
       val catalogStatsAsync = async(Dispatchers.IO) { catalogBrowser.getCatalogStats() }
-      val playbackStats = playbackStatsAsync.await()
+
+      val dailyAggs = dailyAggsAsync.await()
+      val listeningStatsAsync = async(Dispatchers.IO) { buildListeningStats(dailyAggs) }
+      val playbackStats = buildPlaybackStats(dailyAggs, totalPlaybackEventsAsync.await())
       val playlistMetadata = playlistMetadataAsync.await()
       DashboardStats(
         syncedPlaylists = playlistMetadata.syncedPlaylists,
@@ -77,7 +81,8 @@ class DashboardService(
     }
   }
 
-  override fun getPlaybackStats(userId: UserId): DashboardStats = computePlaybackStats(userId)
+  override fun getPlaybackStats(userId: UserId): DashboardStats =
+    buildPlaybackStats(fetchDailyAggregations(userId), aggregationRepository.sumEventCountByUser(userId))
 
   override fun getPlaylistMetadata(userId: UserId): DashboardStats = computePlaylistMetadata(userId)
 
@@ -85,7 +90,7 @@ class DashboardService(
     DashboardStats.EMPTY.copy(recentlyPlayedTracks = runBlocking { buildRecentlyPlayedTracks(userId) })
 
   override fun getListeningStats(userId: UserId): DashboardStats =
-    DashboardStats.EMPTY.copy(listeningStats = runBlocking { buildListeningStats(userId) })
+    DashboardStats.EMPTY.copy(listeningStats = runBlocking { buildListeningStats(fetchDailyAggregations(userId)) })
 
   override fun getPlaylistCheckStats(): DashboardStats =
     DashboardStats.EMPTY.copy(playlistCheckStats = runBlocking { computePlaylistCheckStats() })
@@ -93,14 +98,21 @@ class DashboardService(
   override fun getCatalogStats(): DashboardStats =
     DashboardStats.EMPTY.copy(catalogStats = catalogBrowser.getCatalogStats())
 
-  private fun computePlaybackStats(userId: UserId): DashboardStats {
+  private fun statsDateRange(): Pair<LocalDate, LocalDate> {
     val today = Clock.System.now().toLocalDateTime(TimeZone.UTC).date
-    val from = today - DatePeriod(days = STATS_DAYS - 1)
-    val dailyEventCounts = aggregationRepository.countEventsByUserTypeAndPeriodRange(userId, AggregationPeriodType.DAY, from, today)
-    val total = aggregationRepository.sumEventCountByUser(userId)
-    val last30Days = dailyEventCounts.sumOf { it.eventCount }
+    return (today - DatePeriod(days = STATS_DAYS - 1)) to today
+  }
 
-    val countByDate = dailyEventCounts.associate { it.periodStart to it.eventCount }
+  private fun fetchDailyAggregations(userId: UserId): List<PlaybackAggregation> {
+    val (from, to) = statsDateRange()
+    return aggregationRepository.findByUserTypeAndPeriodRange(userId, AggregationPeriodType.DAY, from, to)
+  }
+
+  private fun buildPlaybackStats(dailyAggs: List<PlaybackAggregation>, total: Long): DashboardStats {
+    val (_, today) = statsDateRange()
+    val last30Days = dailyAggs.sumOf { it.eventCount }
+
+    val countByDate = dailyAggs.associate { it.periodStart to it.eventCount }
     val allDays = ((STATS_DAYS - 1) downTo 0).map { today - DatePeriod(days = it) }
     val maxCount = countByDate.values.maxOrNull() ?: 1L
     val perDay = allDays.map { date ->
@@ -173,11 +185,7 @@ class DashboardService(
     }
   }
 
-  private suspend fun buildListeningStats(userId: UserId): ListeningStats {
-    val today = Clock.System.now().toLocalDateTime(TimeZone.UTC).date
-    val from = today - DatePeriod(days = STATS_DAYS - 1)
-    val dailyAggs = aggregationRepository.findByUserTypeAndPeriodRange(userId, AggregationPeriodType.DAY, from, today)
-
+  private suspend fun buildListeningStats(dailyAggs: List<PlaybackAggregation>): ListeningStats {
     val secondsByTrackId = dailyAggs.flatMap { it.trackEntries }
       .groupBy { it.id }
       .mapValues { (_, entries) -> entries.sumOf { it.totalSeconds } }
@@ -186,17 +194,21 @@ class DashboardService(
       .mapValues { (_, entries) -> entries.sumOf { it.totalSeconds } }
     val listenedMinutes = dailyAggs.sumOf { it.totalPlaybackSeconds } / SECONDS_PER_MINUTE
 
+    // resolving the album for every track played in the period is unavoidable (needed for per-album totals below),
+    // but full track details (title, artists, duration, ...) are only ever displayed for the top-N tracks
     val allTrackIds = secondsByTrackId.keys.map { TrackId(it) }.toSet()
-    val statsTrackMap = appTrackRepository.findByTrackIds(allTrackIds).associateBy { it.id.value }
+    val albumIdsByTrackId = appTrackRepository.findAlbumIdsByTrackIds(allTrackIds)
+    val topTrackIds = secondsByTrackId.entries.sortedByDescending { it.value }.take(topEntriesLimit).map { TrackId(it.key) }.toSet()
+    val statsTrackMap = appTrackRepository.findByTrackIds(topTrackIds).associateBy { it.id.value }
 
     val secondsByAlbumId = mutableMapOf<String, Long>()
     secondsByTrackId.forEach { (trackId, seconds) ->
-      val albumId = statsTrackMap[trackId]?.albumId?.value ?: return@forEach
+      val albumId = albumIdsByTrackId[TrackId(trackId)]?.value ?: return@forEach
       secondsByAlbumId[albumId] = (secondsByAlbumId[albumId] ?: 0L) + seconds
     }
 
     // only the tracks/albums/artists that actually end up in the top-N lists below need their catalog details resolved
-    val topTrackDetails = secondsByTrackId.entries.sortedByDescending { it.value }.take(topEntriesLimit).mapNotNull { statsTrackMap[it.key] }
+    val topTrackDetails = topTrackIds.mapNotNull { statsTrackMap[it.value] }
     val topAlbumIds = secondsByAlbumId.entries.sortedByDescending { it.value }.take(topEntriesLimit).map { it.key }
     val topArtistIds = secondsByArtistId.entries.sortedByDescending { it.value }.take(topEntriesLimit).map { it.key }
     val neededAlbumIds = (topTrackDetails.mapNotNull { it.albumId } + topAlbumIds.map { AlbumId(it) }).toSet()

--- a/domain-impl/src/test/kotlin/de/chrgroth/spotify/control/domain/infra/DashboardServiceTests.kt
+++ b/domain-impl/src/test/kotlin/de/chrgroth/spotify/control/domain/infra/DashboardServiceTests.kt
@@ -8,7 +8,6 @@ import de.chrgroth.spotify.control.domain.model.catalog.AppTrack
 import de.chrgroth.spotify.control.domain.model.catalog.ArtistId
 import de.chrgroth.spotify.control.domain.model.catalog.CatalogStats
 import de.chrgroth.spotify.control.domain.model.catalog.TrackId
-import de.chrgroth.spotify.control.domain.model.playback.aggregation.AggregationEventCount
 import de.chrgroth.spotify.control.domain.model.playback.aggregation.AggregationPeriodType
 import de.chrgroth.spotify.control.domain.model.playback.aggregation.AggregationRankEntry
 import de.chrgroth.spotify.control.domain.model.playback.aggregation.PlaybackAggregation
@@ -79,7 +78,6 @@ class DashboardServiceTests {
 
   private fun setupCommonMocks() {
     every { aggregationRepository.findByUserTypeAndPeriodRange(userId, AggregationPeriodType.DAY, any(), any()) } returns emptyList()
-    every { aggregationRepository.countEventsByUserTypeAndPeriodRange(userId, AggregationPeriodType.DAY, any(), any()) } returns emptyList()
     every { aggregationRepository.sumEventCountByUser(userId) } returns 0L
     every { appPlaybackRepository.findRecentlyPlayed(userId, any()) } returns emptyList()
     every { playlistRepository.findByUserId(userId) } returns emptyList()
@@ -87,6 +85,7 @@ class DashboardServiceTests {
     every { playlistCheckRepository.countSucceeded() } returns 0L
     every { catalogBrowser.getCatalogStats() } returns CatalogStats(0, 0, 0)
     every { appTrackRepository.findByTrackIds(any()) } returns emptyList()
+    every { appTrackRepository.findAlbumIdsByTrackIds(any()) } returns emptyMap()
     every { appAlbumRepository.findByAlbumIds(any()) } returns emptyList()
     every { appArtistRepository.findByArtistIds(any()) } returns emptyList()
   }
@@ -101,6 +100,7 @@ class DashboardServiceTests {
       artistEntries = listOf(AggregationRankEntry(id = "artist-1", name = "Artist One", totalSeconds = 180L)),
     )
     every { aggregationRepository.findByUserTypeAndPeriodRange(userId, AggregationPeriodType.DAY, any(), any()) } returns listOf(agg)
+    every { appTrackRepository.findAlbumIdsByTrackIds(setOf(TrackId("track-1"))) } returns mapOf(TrackId("track-1") to AlbumId("album-1"))
     every { appTrackRepository.findByTrackIds(setOf(TrackId("track-1"))) } returns listOf(track1)
     every { appArtistRepository.findByArtistIds(setOf(ArtistId("artist-1"))) } returns listOf(artist1)
     every { appAlbumRepository.findByAlbumIds(any()) } returns emptyList()
@@ -143,6 +143,8 @@ class DashboardServiceTests {
       artistEntries = listOf(AggregationRankEntry(id = "artist-1", name = "Artist One", totalSeconds = 180L)),
     )
     every { aggregationRepository.findByUserTypeAndPeriodRange(userId, AggregationPeriodType.DAY, any(), any()) } returns listOf(agg1, agg2)
+    every { appTrackRepository.findAlbumIdsByTrackIds(setOf(TrackId("track-1"), TrackId("track-2"))) } returns
+      mapOf(TrackId("track-1") to AlbumId("album-1"), TrackId("track-2") to null)
     every { appTrackRepository.findByTrackIds(setOf(TrackId("track-1"), TrackId("track-2"))) } returns listOf(track1, track2)
     every { appArtistRepository.findByArtistIds(setOf(ArtistId("artist-1"))) } returns listOf(artist1)
     every { appAlbumRepository.findByAlbumIds(any()) } returns emptyList()
@@ -176,6 +178,8 @@ class DashboardServiceTests {
       artistEntries = listOf(AggregationRankEntry(id = "artist-1", name = "Artist One", totalSeconds = 480L)),
     )
     every { aggregationRepository.findByUserTypeAndPeriodRange(userId, AggregationPeriodType.DAY, any(), any()) } returns listOf(agg)
+    every { appTrackRepository.findAlbumIdsByTrackIds(any()) } returns
+      mapOf(TrackId("track-1") to AlbumId("album-1"), TrackId("track-2") to AlbumId("album-2"))
     every { appTrackRepository.findByTrackIds(any()) } returns listOf(track1, track2)
     every { appArtistRepository.findByArtistIds(any()) } returns listOf(artist1)
     every { appAlbumRepository.findByAlbumIds(any()) } returns listOf(album1, album2)
@@ -193,9 +197,50 @@ class DashboardServiceTests {
   }
 
   @Test
+  fun `listening stats only fetch full track details for the top-N tracks`() {
+    setupCommonMocks()
+
+    val track2 = AppTrack(
+      id = TrackId("track-2"), title = "Track Two",
+      artistId = ArtistId("artist-1"), durationMs = 120_000L,
+      lastSync = syncTimestamp,
+    )
+    val track3 = AppTrack(
+      id = TrackId("track-3"), title = "Track Three",
+      artistId = ArtistId("artist-1"), durationMs = 90_000L,
+      lastSync = syncTimestamp,
+    )
+    val track4 = AppTrack(
+      id = TrackId("track-4"), title = "Track Four",
+      artistId = ArtistId("artist-1"), durationMs = 60_000L,
+      lastSync = syncTimestamp,
+    )
+    val agg = emptyAgg().copy(
+      totalPlaybackSeconds = 600L,
+      trackEntries = listOf(
+        AggregationRankEntry(id = "track-1", name = "Track One", totalSeconds = 300L),
+        AggregationRankEntry(id = "track-2", name = "Track Two", totalSeconds = 150L),
+        AggregationRankEntry(id = "track-3", name = "Track Three", totalSeconds = 100L),
+        AggregationRankEntry(id = "track-4", name = "Track Four", totalSeconds = 50L),
+      ),
+    )
+    every { aggregationRepository.findByUserTypeAndPeriodRange(userId, AggregationPeriodType.DAY, any(), any()) } returns listOf(agg)
+    val allTrackIds = setOf(TrackId("track-1"), TrackId("track-2"), TrackId("track-3"), TrackId("track-4"))
+    every { appTrackRepository.findAlbumIdsByTrackIds(allTrackIds) } returns emptyMap()
+    val topTrackIds = setOf(TrackId("track-1"), TrackId("track-2"), TrackId("track-3"))
+    every { appTrackRepository.findByTrackIds(topTrackIds) } returns listOf(track1, track2, track3)
+
+    val stats = adapter.getStats(userId)
+
+    assertThat(stats.listeningStats.topTracksLast30Days).hasSize(3)
+    verify { appTrackRepository.findAlbumIdsByTrackIds(allTrackIds) }
+    verify { appTrackRepository.findByTrackIds(topTrackIds) }
+    verify(exactly = 0) { appTrackRepository.findByTrackIds(match { it.contains(track4.id) }) }
+  }
+
+  @Test
   fun `recently played tracks include duration from secondsPlayed`() {
     every { aggregationRepository.findByUserTypeAndPeriodRange(userId, AggregationPeriodType.DAY, any(), any()) } returns emptyList()
-    every { aggregationRepository.countEventsByUserTypeAndPeriodRange(userId, AggregationPeriodType.DAY, any(), any()) } returns emptyList()
     every { aggregationRepository.sumEventCountByUser(userId) } returns 1L
     every { playlistRepository.findByUserId(userId) } returns emptyList()
     every { playlistCheckRepository.countAll() } returns 0L
@@ -203,6 +248,7 @@ class DashboardServiceTests {
     every { catalogBrowser.getCatalogStats() } returns CatalogStats(0, 0, 0)
     every { appAlbumRepository.findByAlbumIds(any()) } returns emptyList()
     every { appTrackRepository.findByTrackIds(any()) } returns emptyList()
+    every { appTrackRepository.findAlbumIdsByTrackIds(any()) } returns emptyMap()
     every { appArtistRepository.findByArtistIds(any()) } returns emptyList()
 
     val playbackItem = AppPlaybackItem(
@@ -223,8 +269,8 @@ class DashboardServiceTests {
 
   @Test
   fun `getPlaybackStats only queries aggregation repository`() {
-    val eventCount = AggregationEventCount(periodStart = someDate, eventCount = 7L)
-    every { aggregationRepository.countEventsByUserTypeAndPeriodRange(userId, AggregationPeriodType.DAY, any(), any()) } returns listOf(eventCount)
+    val agg = emptyAgg().copy(eventCount = 7L)
+    every { aggregationRepository.findByUserTypeAndPeriodRange(userId, AggregationPeriodType.DAY, any(), any()) } returns listOf(agg)
     every { aggregationRepository.sumEventCountByUser(userId) } returns 42L
 
     val stats = adapter.getPlaybackStats(userId)
@@ -232,7 +278,6 @@ class DashboardServiceTests {
     assertThat(stats.totalPlaybackEvents).isEqualTo(42L)
     assertThat(stats.playbackEventsLast30Days).isEqualTo(7L)
     assertThat(stats.playbackEventsPerDay).hasSize(30)
-    verify(exactly = 0) { aggregationRepository.findByUserTypeAndPeriodRange(any(), any(), any(), any()) }
     verify(exactly = 0) { playlistRepository.findByUserId(any()) }
     verify(exactly = 0) { playlistCheckRepository.countAll() }
     verify(exactly = 0) { catalogBrowser.getCatalogStats() }
@@ -248,7 +293,6 @@ class DashboardServiceTests {
     assertThat(stats.syncedPlaylists).isEqualTo(0L)
     assertThat(stats.totalPlaylists).isEqualTo(0L)
     verify(exactly = 0) { aggregationRepository.findByUserTypeAndPeriodRange(any(), any(), any(), any()) }
-    verify(exactly = 0) { aggregationRepository.countEventsByUserTypeAndPeriodRange(any(), any(), any(), any()) }
     verify(exactly = 0) { aggregationRepository.sumEventCountByUser(any()) }
     verify(exactly = 0) { playlistCheckRepository.countAll() }
     verify(exactly = 0) { catalogBrowser.getCatalogStats() }
@@ -265,7 +309,6 @@ class DashboardServiceTests {
 
     assertThat(stats.recentlyPlayedTracks).isEmpty()
     verify(exactly = 0) { aggregationRepository.findByUserTypeAndPeriodRange(any(), any(), any(), any()) }
-    verify(exactly = 0) { aggregationRepository.countEventsByUserTypeAndPeriodRange(any(), any(), any(), any()) }
     verify(exactly = 0) { aggregationRepository.sumEventCountByUser(any()) }
     verify(exactly = 0) { playlistRepository.findByUserId(any()) }
     verify(exactly = 0) { playlistCheckRepository.countAll() }
@@ -276,13 +319,13 @@ class DashboardServiceTests {
   fun `getListeningStats only queries aggregation and catalog repositories for stats`() {
     every { aggregationRepository.findByUserTypeAndPeriodRange(userId, AggregationPeriodType.DAY, any(), any()) } returns emptyList()
     every { appTrackRepository.findByTrackIds(any()) } returns emptyList()
+    every { appTrackRepository.findAlbumIdsByTrackIds(any()) } returns emptyMap()
     every { appAlbumRepository.findByAlbumIds(any()) } returns emptyList()
     every { appArtistRepository.findByArtistIds(any()) } returns emptyList()
 
     val stats = adapter.getListeningStats(userId)
 
     assertThat(stats.listeningStats.listenedMinutesLast30Days).isEqualTo(0L)
-    verify(exactly = 0) { aggregationRepository.countEventsByUserTypeAndPeriodRange(any(), any(), any(), any()) }
     verify(exactly = 0) { aggregationRepository.sumEventCountByUser(any()) }
     verify(exactly = 0) { appPlaybackRepository.findRecentlyPlayed(any(), any()) }
     verify(exactly = 0) { playlistRepository.findByUserId(any()) }
@@ -301,7 +344,6 @@ class DashboardServiceTests {
     assertThat(stats.playlistCheckStats.succeededChecks).isEqualTo(3L)
     assertThat(stats.playlistCheckStats.allSucceeded).isTrue()
     verify(exactly = 0) { aggregationRepository.findByUserTypeAndPeriodRange(any(), any(), any(), any()) }
-    verify(exactly = 0) { aggregationRepository.countEventsByUserTypeAndPeriodRange(any(), any(), any(), any()) }
     verify(exactly = 0) { aggregationRepository.sumEventCountByUser(any()) }
     verify(exactly = 0) { playlistRepository.findByUserId(any()) }
     verify(exactly = 0) { catalogBrowser.getCatalogStats() }
@@ -317,7 +359,6 @@ class DashboardServiceTests {
     assertThat(stats.catalogStats.albumCount).isEqualTo(20L)
     assertThat(stats.catalogStats.trackCount).isEqualTo(30L)
     verify(exactly = 0) { aggregationRepository.findByUserTypeAndPeriodRange(any(), any(), any(), any()) }
-    verify(exactly = 0) { aggregationRepository.countEventsByUserTypeAndPeriodRange(any(), any(), any(), any()) }
     verify(exactly = 0) { aggregationRepository.sumEventCountByUser(any()) }
     verify(exactly = 0) { playlistRepository.findByUserId(any()) }
     verify(exactly = 0) { playlistCheckRepository.countAll() }


### PR DESCRIPTION
Fixes #712.

## Summary
- `PlaybackAggregationRepositoryAdapter.findByUserTypeAndPeriodRange` was the only one of three identically-filtered methods using Panache's `list()` query string API instead of raw `MongoCollection` `Filters`, which explains why it took 9.5s vs 130-315ms for its siblings on the same index/predicate. Switched it to the same fast approach.
- `DashboardService` was querying the same 30-day `app_playback_aggregation` range twice per dashboard load; now shares one fetch and the now-dead `countEventsByUserTypeAndPeriodRange` method was removed.
- `buildListeningStats` was fetching full `AppTrack` documents for every distinct track played in 30 days just to bucket seconds per album; added a projected `findAlbumIdsByTrackIds` lookup for that, and only fetch full track details for the displayed top-N tracks.

## Test plan
- `./gradlew build` passes (compile, full test suite, static analysis).
- Updated `DashboardServiceTests`, extended `AppTrackDataRepositoryTests`, added new `PlaybackAggregationRepositoryTests` integration tests against real MongoDB.

Generated with [Claude Code](https://claude.ai/code)