### PR TITLE
Fix slow app_playback_aggregation.findByUserAndPeriod on /stats

### DIFF
--- a/adapter-out-mongodb/src/main/kotlin/de/chrgroth/spotify/control/adapter/out/mongodb/MongoIndexInitializer.kt
+++ b/adapter-out-mongodb/src/main/kotlin/de/chrgroth/spotify/control/adapter/out/mongodb/MongoIndexInitializer.kt
@@ -85,6 +85,10 @@ class MongoIndexInitializer(
       Document(AppTrackRepositoryAdapter.ALBUM_ID_FIELD, 1),
       IndexOptions().name("app_track_albumId_1"),
     )
+    appTrackDocumentRepository.mongoCollection().createIndex(
+      Document(AppTrackRepositoryAdapter.ID_FIELD, 1).append(AppTrackRepositoryAdapter.ALBUM_ID_FIELD, 1),
+      IndexOptions().name("app_track_id_1_albumId_1"),
+    )
   }
 
   private fun ensurePlaylistCollectionIndexes() {

--- a/adapter-out-mongodb/src/main/kotlin/de/chrgroth/spotify/control/adapter/out/mongodb/PlaybackAggregationRepositoryAdapter.kt
+++ b/adapter-out-mongodb/src/main/kotlin/de/chrgroth/spotify/control/adapter/out/mongodb/PlaybackAggregationRepositoryAdapter.kt
@@ -6,6 +6,7 @@ import de.chrgroth.spotify.control.domain.model.playback.aggregation.ActivityEnt
 import de.chrgroth.spotify.control.domain.model.playback.aggregation.ActivityTimeWindow
 import de.chrgroth.spotify.control.domain.model.playback.aggregation.AggregationPeriodType
 import de.chrgroth.spotify.control.domain.model.playback.aggregation.AggregationRankEntry
+import de.chrgroth.spotify.control.domain.model.playback.aggregation.DailyPlaybackSummary
 import de.chrgroth.spotify.control.domain.model.playback.aggregation.PlaybackAggregation
 import de.chrgroth.spotify.control.domain.model.user.UserId
 import de.chrgroth.spotify.control.domain.port.out.playback.PlaybackAggregationRepositoryPort
@@ -53,6 +54,22 @@ class PlaybackAggregationRepositoryAdapter(
         )
         .toList()
         .map { it.toDomain() }
+    }
+
+  override fun findDailySummaryByUserAndPeriodRange(userId: UserId, from: LocalDate, to: LocalDate): List<DailyPlaybackSummary> =
+    mongoQueryMetrics.timed("app_playback_aggregation.findDailySummaryByUserAndPeriodRange") {
+      repository.mongoCollection()
+        .find(
+          Filters.and(
+            Filters.eq(SPOTIFY_USER_ID_FIELD, userId.value),
+            Filters.eq(TYPE_FIELD, AggregationPeriodType.DAY.name),
+            Filters.gte(PERIOD_START_FIELD, from.toString()),
+            Filters.lte(PERIOD_START_FIELD, to.toString()),
+          ),
+        )
+        .projection(Projections.include(PERIOD_START_FIELD, EVENT_COUNT_FIELD, TOTAL_PLAYBACK_SECONDS_FIELD, ARTIST_ENTRIES_FIELD, TRACK_ENTRIES_FIELD))
+        .toList()
+        .map { it.toSummary() }
     }
 
   override fun sumEventCountByUser(userId: UserId): Long =
@@ -107,6 +124,14 @@ class PlaybackAggregationRepositoryAdapter(
     activityEntries = activityEntries.map { it.toDomain() },
   )
 
+  private fun PlaybackAggregationDocument.toSummary(): DailyPlaybackSummary = DailyPlaybackSummary(
+    periodStart = LocalDate.parse(periodStart),
+    totalPlaybackSeconds = totalPlaybackSeconds,
+    eventCount = eventCount,
+    artistEntries = artistEntries.map { it.toDomain() },
+    trackEntries = trackEntries.map { it.toDomain() },
+  )
+
   private fun PlaybackAggregationEntryDocument.toDomain(): AggregationRankEntry = AggregationRankEntry(
     id = id,
     name = name,
@@ -124,6 +149,9 @@ class PlaybackAggregationRepositoryAdapter(
     internal const val TYPE_FIELD = "type"
     internal const val PERIOD_START_FIELD = "periodStart"
     internal const val EVENT_COUNT_FIELD = "eventCount"
+    internal const val TOTAL_PLAYBACK_SECONDS_FIELD = "totalPlaybackSeconds"
+    internal const val ARTIST_ENTRIES_FIELD = "artistEntries"
+    internal const val TRACK_ENTRIES_FIELD = "trackEntries"
 
     internal fun documentId(userId: UserId, type: AggregationPeriodType, periodStart: LocalDate): String =
       "${userId.value}:${type.name}:$periodStart"

--- a/application-quarkus/src/test/kotlin/de/chrgroth/spotify/control/adapter/out/mongodb/PlaybackAggregationRepositoryTests.kt
+++ b/application-quarkus/src/test/kotlin/de/chrgroth/spotify/control/adapter/out/mongodb/PlaybackAggregationRepositoryTests.kt
@@ -1,6 +1,7 @@
 package de.chrgroth.spotify.control.adapter.out.mongodb
 
 import de.chrgroth.spotify.control.domain.model.playback.aggregation.AggregationPeriodType
+import de.chrgroth.spotify.control.domain.model.playback.aggregation.AggregationRankEntry
 import de.chrgroth.spotify.control.domain.model.playback.aggregation.PlaybackAggregation
 import de.chrgroth.spotify.control.domain.model.user.UserId
 import de.chrgroth.spotify.control.domain.port.out.playback.PlaybackAggregationRepositoryPort
@@ -26,9 +27,9 @@ class PlaybackAggregationRepositoryTests {
     distinctArtistCount = 0,
     distinctTrackCount = 0,
     distinctAlbumCount = 0,
-    artistEntries = emptyList(),
-    albumEntries = emptyList(),
-    trackEntries = emptyList(),
+    artistEntries = listOf(AggregationRankEntry(id = "artist-1", name = "Artist One", totalSeconds = eventCount * SECONDS_PER_EVENT)),
+    albumEntries = listOf(AggregationRankEntry(id = "album-1", name = "Album One", totalSeconds = eventCount * SECONDS_PER_EVENT)),
+    trackEntries = listOf(AggregationRankEntry(id = "track-1", name = "Track One", totalSeconds = eventCount * SECONDS_PER_EVENT)),
     activityEntries = emptyList(),
   )
 
@@ -69,6 +70,44 @@ class PlaybackAggregationRepositoryTests {
   fun `findByUserTypeAndPeriodRange returns empty list when nothing matches`() {
     val result = aggregationRepository.findByUserTypeAndPeriodRange(
       UserId("user-${UUID.randomUUID()}"), AggregationPeriodType.DAY, LocalDate(2024, 1, 1), LocalDate(2024, 1, 31),
+    )
+    assertThat(result).isEmpty()
+  }
+
+  @Test
+  fun `findDailySummaryByUserAndPeriodRange returns only DAY aggregations within range for the given user`() {
+    val userId = UserId("user-${UUID.randomUUID()}")
+    val otherUserId = UserId("user-${UUID.randomUUID()}")
+    aggregationRepository.save(aggregation(userId, AggregationPeriodType.DAY, LocalDate(2024, 1, 10)))
+    aggregationRepository.save(aggregation(userId, AggregationPeriodType.DAY, LocalDate(2024, 1, 15)))
+    aggregationRepository.save(aggregation(userId, AggregationPeriodType.DAY, LocalDate(2024, 2, 1)))
+    aggregationRepository.save(aggregation(userId, AggregationPeriodType.WEEK, LocalDate(2024, 1, 15)))
+    aggregationRepository.save(aggregation(otherUserId, AggregationPeriodType.DAY, LocalDate(2024, 1, 15)))
+
+    val result = aggregationRepository.findDailySummaryByUserAndPeriodRange(userId, LocalDate(2024, 1, 1), LocalDate(2024, 1, 31))
+
+    assertThat(result.map { it.periodStart }).containsExactlyInAnyOrder(LocalDate(2024, 1, 10), LocalDate(2024, 1, 15))
+  }
+
+  @Test
+  fun `findDailySummaryByUserAndPeriodRange maps event count, playback seconds, track and artist entries`() {
+    val userId = UserId("user-${UUID.randomUUID()}")
+    aggregationRepository.save(aggregation(userId, AggregationPeriodType.DAY, LocalDate(2024, 1, 10), eventCount = 5L))
+
+    val result = aggregationRepository.findDailySummaryByUserAndPeriodRange(userId, LocalDate(2024, 1, 1), LocalDate(2024, 1, 31))
+
+    assertThat(result).hasSize(1)
+    val summary = result.single()
+    assertThat(summary.eventCount).isEqualTo(5L)
+    assertThat(summary.totalPlaybackSeconds).isEqualTo(5L * SECONDS_PER_EVENT)
+    assertThat(summary.trackEntries).extracting("id").containsExactly("track-1")
+    assertThat(summary.artistEntries).extracting("id").containsExactly("artist-1")
+  }
+
+  @Test
+  fun `findDailySummaryByUserAndPeriodRange returns empty list when nothing matches`() {
+    val result = aggregationRepository.findDailySummaryByUserAndPeriodRange(
+      UserId("user-${UUID.randomUUID()}"), LocalDate(2024, 1, 1), LocalDate(2024, 1, 31),
     )
     assertThat(result).isEmpty()
   }

--- a/docs/releasenotes/snippets/0723-bugfix.md
+++ b/docs/releasenotes/snippets/0723-bugfix.md
@@ -1,0 +1,1 @@
+* Sped up the dashboard by trimming the data fetched for the last-30-days playback stats and adding a missing MongoDB index, cutting the two slowest queries behind the "Slow MongoDB query" warnings.

--- a/docs/releasenotes/snippets/20260708-0723-bugfix.md
+++ b/docs/releasenotes/snippets/20260708-0723-bugfix.md
@@ -1,0 +1,1 @@
+* Fixed slow Stats page loading by capping the number of top tracks/artists/albums stored per week/month/quarter/year aggregation, instead of persisting one entry per distinct item ever played in that period.

--- a/domain-api/src/main/kotlin/de/chrgroth/spotify/control/domain/model/playback/aggregation/DailyPlaybackSummary.kt
+++ b/domain-api/src/main/kotlin/de/chrgroth/spotify/control/domain/model/playback/aggregation/DailyPlaybackSummary.kt
@@ -1,0 +1,11 @@
+package de.chrgroth.spotify.control.domain.model.playback.aggregation
+
+import kotlinx.datetime.LocalDate
+
+data class DailyPlaybackSummary(
+  val periodStart: LocalDate,
+  val totalPlaybackSeconds: Long,
+  val eventCount: Long,
+  val artistEntries: List<AggregationRankEntry>,
+  val trackEntries: List<AggregationRankEntry>,
+)

--- a/domain-api/src/main/kotlin/de/chrgroth/spotify/control/domain/port/out/playback/PlaybackAggregationRepositoryPort.kt
+++ b/domain-api/src/main/kotlin/de/chrgroth/spotify/control/domain/port/out/playback/PlaybackAggregationRepositoryPort.kt
@@ -1,6 +1,7 @@
 package de.chrgroth.spotify.control.domain.port.out.playback
 
 import de.chrgroth.spotify.control.domain.model.playback.aggregation.AggregationPeriodType
+import de.chrgroth.spotify.control.domain.model.playback.aggregation.DailyPlaybackSummary
 import de.chrgroth.spotify.control.domain.model.playback.aggregation.PlaybackAggregation
 import de.chrgroth.spotify.control.domain.model.user.UserId
 import kotlinx.datetime.LocalDate
@@ -10,5 +11,6 @@ interface PlaybackAggregationRepositoryPort {
   fun deleteAll()
   fun findByUserAndPeriod(userId: UserId, type: AggregationPeriodType, periodStart: LocalDate): PlaybackAggregation?
   fun findByUserTypeAndPeriodRange(userId: UserId, type: AggregationPeriodType, from: LocalDate, to: LocalDate): List<PlaybackAggregation>
+  fun findDailySummaryByUserAndPeriodRange(userId: UserId, from: LocalDate, to: LocalDate): List<DailyPlaybackSummary>
   fun sumEventCountByUser(userId: UserId): Long
 }

--- a/domain-impl/src/main/kotlin/de/chrgroth/spotify/control/domain/infra/DashboardService.kt
+++ b/domain-impl/src/main/kotlin/de/chrgroth/spotify/control/domain/infra/DashboardService.kt
@@ -7,8 +7,7 @@ import de.chrgroth.spotify.control.domain.model.playback.DayCount
 import de.chrgroth.spotify.control.domain.model.catalog.AppTrack
 import de.chrgroth.spotify.control.domain.model.catalog.displayArtistName
 import de.chrgroth.spotify.control.domain.model.playback.ListeningStats
-import de.chrgroth.spotify.control.domain.model.playback.aggregation.AggregationPeriodType
-import de.chrgroth.spotify.control.domain.model.playback.aggregation.PlaybackAggregation
+import de.chrgroth.spotify.control.domain.model.playback.aggregation.DailyPlaybackSummary
 import de.chrgroth.spotify.control.domain.model.playlist.PlaylistCheckStats
 import de.chrgroth.spotify.control.domain.model.playlist.PlaylistSyncStatus
 import de.chrgroth.spotify.control.domain.model.playback.RecentlyPlayedItem
@@ -103,12 +102,12 @@ class DashboardService(
     return (today - DatePeriod(days = STATS_DAYS - 1)) to today
   }
 
-  private fun fetchDailyAggregations(userId: UserId): List<PlaybackAggregation> {
+  private fun fetchDailyAggregations(userId: UserId): List<DailyPlaybackSummary> {
     val (from, to) = statsDateRange()
-    return aggregationRepository.findByUserTypeAndPeriodRange(userId, AggregationPeriodType.DAY, from, to)
+    return aggregationRepository.findDailySummaryByUserAndPeriodRange(userId, from, to)
   }
 
-  private fun buildPlaybackStats(dailyAggs: List<PlaybackAggregation>, total: Long): DashboardStats {
+  private fun buildPlaybackStats(dailyAggs: List<DailyPlaybackSummary>, total: Long): DashboardStats {
     val (_, today) = statsDateRange()
     val last30Days = dailyAggs.sumOf { it.eventCount }
 
@@ -185,7 +184,7 @@ class DashboardService(
     }
   }
 
-  private suspend fun buildListeningStats(dailyAggs: List<PlaybackAggregation>): ListeningStats {
+  private suspend fun buildListeningStats(dailyAggs: List<DailyPlaybackSummary>): ListeningStats {
     val secondsByTrackId = dailyAggs.flatMap { it.trackEntries }
       .groupBy { it.id }
       .mapValues { (_, entries) -> entries.sumOf { it.totalSeconds } }

--- a/domain-impl/src/main/kotlin/de/chrgroth/spotify/control/domain/playback/PlaybackAggregationService.kt
+++ b/domain-impl/src/main/kotlin/de/chrgroth/spotify/control/domain/playback/PlaybackAggregationService.kt
@@ -284,6 +284,10 @@ class PlaybackAggregationService(
       .groupBy { it.dayOfWeek to it.timeWindow }
       .map { (key, entries) -> ActivityEntry(dayOfWeek = key.first, timeWindow = key.second, totalSeconds = entries.sumOf { it.totalSeconds }) }
 
+    // WEEK/MONTH/QUARTER/YEAR aggregations are only ever read back as a single document for top-N display
+    // (StatsResource), never merged further, so only the top entries need to be persisted. Without this, merging
+    // a full year of daily entries can produce documents with one rank entry per distinct track/artist/album ever
+    // played in that period, which made a single findByUserAndPeriod lookup of such a document slow.
     val aggregation = PlaybackAggregation(
       userId = userId,
       type = type,
@@ -293,9 +297,9 @@ class PlaybackAggregationService(
       distinctArtistCount = mergedArtistEntries.size,
       distinctTrackCount = mergedTrackEntries.size,
       distinctAlbumCount = mergedAlbumEntries.size,
-      artistEntries = mergedArtistEntries,
-      albumEntries = mergedAlbumEntries,
-      trackEntries = mergedTrackEntries,
+      artistEntries = mergedArtistEntries.take(STORED_ENTRIES_LIMIT),
+      albumEntries = mergedAlbumEntries.take(STORED_ENTRIES_LIMIT),
+      trackEntries = mergedTrackEntries.take(STORED_ENTRIES_LIMIT),
       activityEntries = mergedActivityEntries,
     )
     aggregationRepository.save(aggregation)
@@ -361,6 +365,7 @@ class PlaybackAggregationService(
     private const val MONTHS_PER_QUARTER = 3L
     private const val MONTHS_PER_YEAR = 12L
     private const val MILLIS_PER_SECOND = 1_000L
+    private const val STORED_ENTRIES_LIMIT = 25
   }
 
   private data class Rankings(

--- a/domain-impl/src/test/kotlin/de/chrgroth/spotify/control/domain/infra/DashboardServiceTests.kt
+++ b/domain-impl/src/test/kotlin/de/chrgroth/spotify/control/domain/infra/DashboardServiceTests.kt
@@ -8,9 +8,8 @@ import de.chrgroth.spotify.control.domain.model.catalog.AppTrack
 import de.chrgroth.spotify.control.domain.model.catalog.ArtistId
 import de.chrgroth.spotify.control.domain.model.catalog.CatalogStats
 import de.chrgroth.spotify.control.domain.model.catalog.TrackId
-import de.chrgroth.spotify.control.domain.model.playback.aggregation.AggregationPeriodType
 import de.chrgroth.spotify.control.domain.model.playback.aggregation.AggregationRankEntry
-import de.chrgroth.spotify.control.domain.model.playback.aggregation.PlaybackAggregation
+import de.chrgroth.spotify.control.domain.model.playback.aggregation.DailyPlaybackSummary
 import de.chrgroth.spotify.control.domain.model.user.UserId
 import de.chrgroth.spotify.control.domain.port.`in`.catalog.CatalogBrowserPort
 import de.chrgroth.spotify.control.domain.port.out.catalog.AppAlbumRepositoryPort
@@ -61,23 +60,16 @@ class DashboardServiceTests {
     albumId = AlbumId("album-1"), lastSync = syncTimestamp,
   )
 
-  private fun emptyAgg(date: LocalDate = someDate) = PlaybackAggregation(
-    userId = userId,
-    type = AggregationPeriodType.DAY,
+  private fun emptySummary(date: LocalDate = someDate) = DailyPlaybackSummary(
     periodStart = date,
     totalPlaybackSeconds = 0L,
     eventCount = 0L,
-    distinctArtistCount = 0,
-    distinctTrackCount = 0,
-    distinctAlbumCount = 0,
     artistEntries = emptyList(),
-    albumEntries = emptyList(),
     trackEntries = emptyList(),
-    activityEntries = emptyList(),
   )
 
   private fun setupCommonMocks() {
-    every { aggregationRepository.findByUserTypeAndPeriodRange(userId, AggregationPeriodType.DAY, any(), any()) } returns emptyList()
+    every { aggregationRepository.findDailySummaryByUserAndPeriodRange(userId, any(), any()) } returns emptyList()
     every { aggregationRepository.sumEventCountByUser(userId) } returns 0L
     every { appPlaybackRepository.findRecentlyPlayed(userId, any()) } returns emptyList()
     every { playlistRepository.findByUserId(userId) } returns emptyList()
@@ -94,12 +86,12 @@ class DashboardServiceTests {
   fun `listening stats exclude items without tracked duration`() {
     setupCommonMocks()
 
-    val agg = emptyAgg().copy(
+    val summary = emptySummary().copy(
       totalPlaybackSeconds = 180L,
       trackEntries = listOf(AggregationRankEntry(id = "track-1", name = "Track One", totalSeconds = 180L)),
       artistEntries = listOf(AggregationRankEntry(id = "artist-1", name = "Artist One", totalSeconds = 180L)),
     )
-    every { aggregationRepository.findByUserTypeAndPeriodRange(userId, AggregationPeriodType.DAY, any(), any()) } returns listOf(agg)
+    every { aggregationRepository.findDailySummaryByUserAndPeriodRange(userId, any(), any()) } returns listOf(summary)
     every { appTrackRepository.findAlbumIdsByTrackIds(setOf(TrackId("track-1"))) } returns mapOf(TrackId("track-1") to AlbumId("album-1"))
     every { appTrackRepository.findByTrackIds(setOf(TrackId("track-1"))) } returns listOf(track1)
     every { appArtistRepository.findByArtistIds(setOf(ArtistId("artist-1"))) } returns listOf(artist1)
@@ -132,17 +124,17 @@ class DashboardServiceTests {
       artistId = ArtistId("artist-1"), durationMs = 240_000L,
       lastSync = syncTimestamp,
     )
-    val agg1 = emptyAgg(LocalDate(2024, 1, 14)).copy(
+    val summary1 = emptySummary(LocalDate(2024, 1, 14)).copy(
       totalPlaybackSeconds = 120L,
       trackEntries = listOf(AggregationRankEntry(id = "track-1", name = "Track One", totalSeconds = 120L)),
       artistEntries = listOf(AggregationRankEntry(id = "artist-1", name = "Artist One", totalSeconds = 120L)),
     )
-    val agg2 = emptyAgg(LocalDate(2024, 1, 15)).copy(
+    val summary2 = emptySummary(LocalDate(2024, 1, 15)).copy(
       totalPlaybackSeconds = 180L,
       trackEntries = listOf(AggregationRankEntry(id = "track-2", name = "Track Two", totalSeconds = 180L)),
       artistEntries = listOf(AggregationRankEntry(id = "artist-1", name = "Artist One", totalSeconds = 180L)),
     )
-    every { aggregationRepository.findByUserTypeAndPeriodRange(userId, AggregationPeriodType.DAY, any(), any()) } returns listOf(agg1, agg2)
+    every { aggregationRepository.findDailySummaryByUserAndPeriodRange(userId, any(), any()) } returns listOf(summary1, summary2)
     every { appTrackRepository.findAlbumIdsByTrackIds(setOf(TrackId("track-1"), TrackId("track-2"))) } returns
       mapOf(TrackId("track-1") to AlbumId("album-1"), TrackId("track-2") to null)
     every { appTrackRepository.findByTrackIds(setOf(TrackId("track-1"), TrackId("track-2"))) } returns listOf(track1, track2)
@@ -169,7 +161,7 @@ class DashboardServiceTests {
       artistId = ArtistId("artist-1"), durationMs = 120_000L,
       albumId = AlbumId("album-2"), lastSync = syncTimestamp,
     )
-    val agg = emptyAgg().copy(
+    val summary = emptySummary().copy(
       totalPlaybackSeconds = 480L,
       trackEntries = listOf(
         AggregationRankEntry(id = "track-1", name = "Track One", totalSeconds = 300L),
@@ -177,7 +169,7 @@ class DashboardServiceTests {
       ),
       artistEntries = listOf(AggregationRankEntry(id = "artist-1", name = "Artist One", totalSeconds = 480L)),
     )
-    every { aggregationRepository.findByUserTypeAndPeriodRange(userId, AggregationPeriodType.DAY, any(), any()) } returns listOf(agg)
+    every { aggregationRepository.findDailySummaryByUserAndPeriodRange(userId, any(), any()) } returns listOf(summary)
     every { appTrackRepository.findAlbumIdsByTrackIds(any()) } returns
       mapOf(TrackId("track-1") to AlbumId("album-1"), TrackId("track-2") to AlbumId("album-2"))
     every { appTrackRepository.findByTrackIds(any()) } returns listOf(track1, track2)
@@ -215,7 +207,7 @@ class DashboardServiceTests {
       artistId = ArtistId("artist-1"), durationMs = 60_000L,
       lastSync = syncTimestamp,
     )
-    val agg = emptyAgg().copy(
+    val summary = emptySummary().copy(
       totalPlaybackSeconds = 600L,
       trackEntries = listOf(
         AggregationRankEntry(id = "track-1", name = "Track One", totalSeconds = 300L),
@@ -224,7 +216,7 @@ class DashboardServiceTests {
         AggregationRankEntry(id = "track-4", name = "Track Four", totalSeconds = 50L),
       ),
     )
-    every { aggregationRepository.findByUserTypeAndPeriodRange(userId, AggregationPeriodType.DAY, any(), any()) } returns listOf(agg)
+    every { aggregationRepository.findDailySummaryByUserAndPeriodRange(userId, any(), any()) } returns listOf(summary)
     val allTrackIds = setOf(TrackId("track-1"), TrackId("track-2"), TrackId("track-3"), TrackId("track-4"))
     every { appTrackRepository.findAlbumIdsByTrackIds(allTrackIds) } returns emptyMap()
     val topTrackIds = setOf(TrackId("track-1"), TrackId("track-2"), TrackId("track-3"))
@@ -240,7 +232,7 @@ class DashboardServiceTests {
 
   @Test
   fun `recently played tracks include duration from secondsPlayed`() {
-    every { aggregationRepository.findByUserTypeAndPeriodRange(userId, AggregationPeriodType.DAY, any(), any()) } returns emptyList()
+    every { aggregationRepository.findDailySummaryByUserAndPeriodRange(userId, any(), any()) } returns emptyList()
     every { aggregationRepository.sumEventCountByUser(userId) } returns 1L
     every { playlistRepository.findByUserId(userId) } returns emptyList()
     every { playlistCheckRepository.countAll() } returns 0L
@@ -269,8 +261,8 @@ class DashboardServiceTests {
 
   @Test
   fun `getPlaybackStats only queries aggregation repository`() {
-    val agg = emptyAgg().copy(eventCount = 7L)
-    every { aggregationRepository.findByUserTypeAndPeriodRange(userId, AggregationPeriodType.DAY, any(), any()) } returns listOf(agg)
+    val summary = emptySummary().copy(eventCount = 7L)
+    every { aggregationRepository.findDailySummaryByUserAndPeriodRange(userId, any(), any()) } returns listOf(summary)
     every { aggregationRepository.sumEventCountByUser(userId) } returns 42L
 
     val stats = adapter.getPlaybackStats(userId)
@@ -292,7 +284,7 @@ class DashboardServiceTests {
 
     assertThat(stats.syncedPlaylists).isEqualTo(0L)
     assertThat(stats.totalPlaylists).isEqualTo(0L)
-    verify(exactly = 0) { aggregationRepository.findByUserTypeAndPeriodRange(any(), any(), any(), any()) }
+    verify(exactly = 0) { aggregationRepository.findDailySummaryByUserAndPeriodRange(any(), any(), any()) }
     verify(exactly = 0) { aggregationRepository.sumEventCountByUser(any()) }
     verify(exactly = 0) { playlistCheckRepository.countAll() }
     verify(exactly = 0) { catalogBrowser.getCatalogStats() }
@@ -308,7 +300,7 @@ class DashboardServiceTests {
     val stats = adapter.getRecentlyPlayed(userId)
 
     assertThat(stats.recentlyPlayedTracks).isEmpty()
-    verify(exactly = 0) { aggregationRepository.findByUserTypeAndPeriodRange(any(), any(), any(), any()) }
+    verify(exactly = 0) { aggregationRepository.findDailySummaryByUserAndPeriodRange(any(), any(), any()) }
     verify(exactly = 0) { aggregationRepository.sumEventCountByUser(any()) }
     verify(exactly = 0) { playlistRepository.findByUserId(any()) }
     verify(exactly = 0) { playlistCheckRepository.countAll() }
@@ -317,7 +309,7 @@ class DashboardServiceTests {
 
   @Test
   fun `getListeningStats only queries aggregation and catalog repositories for stats`() {
-    every { aggregationRepository.findByUserTypeAndPeriodRange(userId, AggregationPeriodType.DAY, any(), any()) } returns emptyList()
+    every { aggregationRepository.findDailySummaryByUserAndPeriodRange(userId, any(), any()) } returns emptyList()
     every { appTrackRepository.findByTrackIds(any()) } returns emptyList()
     every { appTrackRepository.findAlbumIdsByTrackIds(any()) } returns emptyMap()
     every { appAlbumRepository.findByAlbumIds(any()) } returns emptyList()
@@ -343,7 +335,7 @@ class DashboardServiceTests {
     assertThat(stats.playlistCheckStats.totalChecks).isEqualTo(3L)
     assertThat(stats.playlistCheckStats.succeededChecks).isEqualTo(3L)
     assertThat(stats.playlistCheckStats.allSucceeded).isTrue()
-    verify(exactly = 0) { aggregationRepository.findByUserTypeAndPeriodRange(any(), any(), any(), any()) }
+    verify(exactly = 0) { aggregationRepository.findDailySummaryByUserAndPeriodRange(any(), any(), any()) }
     verify(exactly = 0) { aggregationRepository.sumEventCountByUser(any()) }
     verify(exactly = 0) { playlistRepository.findByUserId(any()) }
     verify(exactly = 0) { catalogBrowser.getCatalogStats() }
@@ -358,7 +350,7 @@ class DashboardServiceTests {
     assertThat(stats.catalogStats.artistCount).isEqualTo(10L)
     assertThat(stats.catalogStats.albumCount).isEqualTo(20L)
     assertThat(stats.catalogStats.trackCount).isEqualTo(30L)
-    verify(exactly = 0) { aggregationRepository.findByUserTypeAndPeriodRange(any(), any(), any(), any()) }
+    verify(exactly = 0) { aggregationRepository.findDailySummaryByUserAndPeriodRange(any(), any(), any()) }
     verify(exactly = 0) { aggregationRepository.sumEventCountByUser(any()) }
     verify(exactly = 0) { playlistRepository.findByUserId(any()) }
     verify(exactly = 0) { playlistCheckRepository.countAll() }

--- a/domain-impl/src/test/kotlin/de/chrgroth/spotify/control/domain/playback/PlaybackAggregationServiceTests.kt
+++ b/domain-impl/src/test/kotlin/de/chrgroth/spotify/control/domain/playback/PlaybackAggregationServiceTests.kt
@@ -136,18 +136,47 @@ class PlaybackAggregationServiceTests {
     verify(exactly = 1) { aggregationRepository.findByUserTypeAndPeriodRange(userId, AggregationPeriodType.DAY, weekStart, LocalDate(2024, 1, 21)) }
   }
 
-  private fun dayAggregation(periodStart: LocalDate, albumEntries: List<AggregationRankEntry>) = PlaybackAggregation(
+  @Test
+  fun `aggregate week persists only top entries but keeps full distinct counts`() {
+    val weekStart = LocalDate(2024, 1, 15)
+    val savedAggregation = slot<PlaybackAggregation>()
+    every { aggregationRepository.save(capture(savedAggregation)) } returns Unit
+    val manyTrackEntries = (1..STORED_ENTRIES_LIMIT_PLUS_MARGIN).map { AggregationRankEntry(id = "track-$it", name = "Track $it", totalSeconds = it.toLong()) }
+    every {
+      aggregationRepository.findByUserTypeAndPeriodRange(userId, AggregationPeriodType.DAY, weekStart, LocalDate(2024, 1, 21))
+    } returns listOf(dayAggregation(weekStart, trackEntries = manyTrackEntries))
+
+    val result = service.handle(DomainOutboxEvent.AggregatePlaybackData(userId, AggregationPeriodType.WEEK, weekStart))
+
+    assertThat(result.isRight()).isTrue()
+    assertThat(savedAggregation.captured.distinctTrackCount).isEqualTo(STORED_ENTRIES_LIMIT_PLUS_MARGIN)
+    assertThat(savedAggregation.captured.trackEntries).hasSize(STORED_ENTRIES_LIMIT)
+    assertThat(savedAggregation.captured.trackEntries.map { it.id }).containsExactly(
+      *manyTrackEntries.sortedByDescending { it.totalSeconds }.take(STORED_ENTRIES_LIMIT).map { it.id }.toTypedArray(),
+    )
+  }
+
+  private fun dayAggregation(
+    periodStart: LocalDate,
+    albumEntries: List<AggregationRankEntry> = emptyList(),
+    trackEntries: List<AggregationRankEntry> = emptyList(),
+  ) = PlaybackAggregation(
     userId = userId,
     type = AggregationPeriodType.DAY,
     periodStart = periodStart,
-    totalPlaybackSeconds = albumEntries.sumOf { it.totalSeconds },
-    eventCount = albumEntries.size.toLong(),
+    totalPlaybackSeconds = albumEntries.sumOf { it.totalSeconds } + trackEntries.sumOf { it.totalSeconds },
+    eventCount = (albumEntries.size + trackEntries.size).toLong(),
     distinctArtistCount = 0,
-    distinctTrackCount = 0,
+    distinctTrackCount = trackEntries.size,
     distinctAlbumCount = albumEntries.size,
     artistEntries = emptyList(),
     albumEntries = albumEntries,
-    trackEntries = emptyList(),
+    trackEntries = trackEntries,
     activityEntries = emptyList(),
   )
+
+  private companion object {
+    private const val STORED_ENTRIES_LIMIT = 25
+    private const val STORED_ENTRIES_LIMIT_PLUS_MARGIN = STORED_ENTRIES_LIMIT + 5
+  }
 }


### PR DESCRIPTION
Fixes #712.

## Summary
- `PlaybackAggregationService.aggregateFromDailyAggregations` merged `trackEntries`/`artistEntries`/`albumEntries` from all underlying daily aggregations with no cap, storing one rank entry per distinct track/artist/album ever played in the whole WEEK/MONTH/QUARTER/YEAR period.
- With a ~40k-track catalog, YEAR/QUARTER aggregation documents could grow to thousands of embedded entries, making a single `findByUserAndPeriod` lookup by `_id` (already index-backed) slow to fetch/deserialize - explaining the `app_playback_aggregation.findByUserAndPeriod` slow query reports on /stats.
- Only the top 5 entries per period are ever displayed, so capped persisted entries at 25 (new `STORED_ENTRIES_LIMIT`) while keeping full distinct counts accurate. Only applied to WEEK/MONTH/QUARTER/YEAR (terminal, display-only), not DAY, since DashboardService's 30-day rollup needs full daily entries.

## Test plan
- `./gradlew build` passes (tests + static analysis).
- Added a `PlaybackAggregationServiceTests` case verifying truncation to top 25 while distinct counts stay accurate.

## Note
Already-persisted WEEK/MONTH/QUARTER/YEAR documents remain oversized until recomputed - use the existing "Recreate Playback Data" button (Settings → Playback) to shrink them.

Generated with [Claude Code](https://claude.ai/code)