### PR TITLE
Add Catalog Sync timeline page to Tools menu

### DIFF
--- a/adapter-in-web/src/main/kotlin/de/chrgroth/spotify/control/adapter/in/web/CatalogSyncResource.kt
+++ b/adapter-in-web/src/main/kotlin/de/chrgroth/spotify/control/adapter/in/web/CatalogSyncResource.kt
@@ -1,0 +1,60 @@
+package de.chrgroth.spotify.control.adapter.`in`.web
+
+import de.chrgroth.spotify.control.domain.port.`in`.catalog.CatalogBrowserPort
+import io.quarkus.qute.Location
+import io.quarkus.qute.Template
+import io.quarkus.security.Authenticated
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.ws.rs.GET
+import jakarta.ws.rs.Path
+import jakarta.ws.rs.Produces
+import jakarta.ws.rs.QueryParam
+import jakarta.ws.rs.core.MediaType
+import jakarta.ws.rs.core.Response
+
+@Path("/catalog-sync")
+@ApplicationScoped
+@Suppress("Unused")
+class CatalogSyncResource(
+  @param:Location("catalog-sync.html")
+  private val template: Template,
+  private val catalogBrowser: CatalogBrowserPort,
+) {
+
+  @GET
+  @Authenticated
+  @Produces(MediaType.TEXT_HTML)
+  fun page(): Response = renderPage(0, 0)
+
+  @GET
+  @Path("/snippet")
+  @Authenticated
+  @Produces(MediaType.TEXT_HTML)
+  fun snippet(
+    @QueryParam("artistOffset") artistOffset: Int?,
+    @QueryParam("albumOffset") albumOffset: Int?,
+  ): Response = renderRows(artistOffset ?: 0, albumOffset ?: 0)
+
+  private fun renderPage(artistOffset: Int, albumOffset: Int): Response {
+    val page = catalogBrowser.getSyncTimeline(artistOffset, albumOffset, PAGE_SIZE)
+    val html = template.data("page", page).data("entries", page.entries).render()
+    return Response.ok(html).build()
+  }
+
+  private fun renderRows(artistOffset: Int, albumOffset: Int): Response {
+    val page = catalogBrowser.getSyncTimeline(artistOffset, albumOffset, PAGE_SIZE)
+    val html = template.getFragment("snippet_rows").data("entries", page.entries).render()
+    return Response.ok(html)
+      .header(NEXT_ARTIST_OFFSET_HEADER, page.nextArtistOffset)
+      .header(NEXT_ALBUM_OFFSET_HEADER, page.nextAlbumOffset)
+      .header(HAS_MORE_HEADER, page.hasMore)
+      .build()
+  }
+
+  companion object {
+    private const val PAGE_SIZE = 200
+    internal const val NEXT_ARTIST_OFFSET_HEADER = "X-Next-Artist-Offset"
+    internal const val NEXT_ALBUM_OFFSET_HEADER = "X-Next-Album-Offset"
+    internal const val HAS_MORE_HEADER = "X-Has-More"
+  }
+}

--- a/adapter-in-web/src/main/resources/templates/catalog-sync.html
+++ b/adapter-in-web/src/main/resources/templates/catalog-sync.html
@@ -1,0 +1,97 @@
+{#include layout.html}
+    {#title}SpCtl – Catalog Sync{/title}
+    {#content}
+    <div class="container-fluid py-4 px-3 px-md-4">
+
+        <h1 class="mb-4 fs-4 fw-semibold">Catalog Sync</h1>
+        <p class="text-secondary small mb-4">Timeline of artists and albums most recently synced from Spotify, newest first.</p>
+
+        <div class="table-responsive">
+            <table class="table table-dark table-hover align-middle mb-0" data-testid="catalog-sync-table">
+                <thead>
+                    <tr class="app-section-label" style="font-size:.8rem;">
+                        <th>Type</th>
+                        <th>Artist</th>
+                        <th>Album</th>
+                        <th class="text-end">Albums</th>
+                        <th class="text-end">Tracks</th>
+                        <th>Synced At</th>
+                    </tr>
+                </thead>
+                <tbody id="catalog-sync-rows">
+                    {#fragment id="snippet_rows"}
+                    {#for entry in entries}
+                    <tr data-testid="catalog-sync-row">
+                        <td>
+                            {#if entry.entityType == "ARTIST"}
+                            <span class="badge" style="background-color:var(--spotify-green);color:#000;">Artist</span>
+                            {#else}
+                            <span class="badge" style="background-color:#555;color:#fff;">Album</span>
+                            {/if}
+                        </td>
+                        <td style="color:#fff;font-size:.9rem;">
+                            {#if entry.artistName}{entry.artistName}{#else}–{/if}
+                            {#if entry.artistId}<span style="color:#666;font-size:.75rem;">({entry.artistId})</span>{/if}
+                        </td>
+                        <td style="color:#ccc;font-size:.9rem;">
+                            {#if entry.entityType == "ALBUM"}
+                            {#if entry.albumName}{entry.albumName}{#else}(untitled){/if}
+                            <span style="color:#666;font-size:.75rem;">({entry.albumId})</span>
+                            {#else}
+                            –
+                            {/if}
+                        </td>
+                        <td class="text-end" style="color:#888;font-size:.85rem;">{#if entry.entityType == "ARTIST"}{entry.albumCount.formatted}{#else}–{/if}</td>
+                        <td class="text-end" style="color:#888;font-size:.85rem;">{#if entry.entityType == "ALBUM"}{entry.trackCount.formatted}{#else}–{/if}</td>
+                        <td style="white-space:nowrap;color:#888;font-size:.85rem;">{entry.syncedAt.formatted}</td>
+                    </tr>
+                    {/for}
+                    {/fragment}
+                </tbody>
+            </table>
+            {#if page.entries.empty}
+            <p style="color:#888;" class="mt-3">No catalog sync activity recorded yet.</p>
+            {/if}
+        </div>
+
+        <div id="catalog-sync-load-more-container" class="text-center my-3"
+             data-next-artist-offset="{page.nextArtistOffset}" data-next-album-offset="{page.nextAlbumOffset}"
+             {#if !page.hasMore}style="display:none;"{/if}>
+            <button id="catalog-sync-load-more-btn" type="button" class="btn btn-outline-secondary btn-sm" data-testid="catalog-sync-load-more">Load more</button>
+        </div>
+
+    </div>
+
+    <script>
+        (function() {
+            var container = document.getElementById('catalog-sync-load-more-container');
+            var btn = document.getElementById('catalog-sync-load-more-btn');
+            var tbody = document.getElementById('catalog-sync-rows');
+            if (!btn || !container || !tbody) return;
+
+            btn.addEventListener('click', function() {
+                btn.disabled = true;
+                var artistOffset = container.dataset.nextArtistOffset;
+                var albumOffset = container.dataset.nextAlbumOffset;
+                fetch('/catalog-sync/snippet?artistOffset=' + encodeURIComponent(artistOffset) + '&albumOffset=' + encodeURIComponent(albumOffset))
+                    .then(function(r) {
+                        container.dataset.nextArtistOffset = r.headers.get('X-Next-Artist-Offset');
+                        container.dataset.nextAlbumOffset = r.headers.get('X-Next-Album-Offset');
+                        container.style.display = r.headers.get('X-Has-More') === 'true' ? '' : 'none';
+                        return r.text();
+                    })
+                    .then(function(html) {
+                        var table = document.createElement('table');
+                        table.innerHTML = '<tbody>' + html + '</tbody>';
+                        var rows = table.querySelectorAll('tr');
+                        rows.forEach(function(row) { tbody.appendChild(row); });
+                        btn.disabled = false;
+                    })
+                    .catch(function() {
+                        btn.disabled = false;
+                    });
+            });
+        })();
+    </script>
+    {/content}
+{/include}

--- a/adapter-in-web/src/main/resources/templates/layout.html
+++ b/adapter-in-web/src/main/resources/templates/layout.html
@@ -176,6 +176,9 @@
             <symbol id="icon-nav-health" viewBox="0 0 16 16">
                 <path d="M6 2a.5.5 0 0 1 .47.33L10 12.036l1.53-4.208A.5.5 0 0 1 12 7.5h3.5a.5.5 0 0 1 0 1h-3.15l-1.88 5.17a.5.5 0 0 1-.94 0L6 3.964 4.47 8.171A.5.5 0 0 1 4 8.5H.5a.5.5 0 0 1 0-1h3.15l1.88-5.17A.5.5 0 0 1 6 2"/>
             </symbol>
+            <symbol id="icon-nav-catalog-sync" viewBox="0 0 16 16">
+                <path d="M11.534 7h3.932a.25.25 0 0 1 .192.41l-1.966 2.36a.25.25 0 0 1-.384 0l-1.966-2.36a.25.25 0 0 1 .192-.41m-11 2h3.932a.25.25 0 0 0 .192-.41L2.692 6.23a.25.25 0 0 0-.384 0L.342 8.59A.25.25 0 0 0 .534 9"/><path fill-rule="evenodd" d="M8 3c-1.552 0-2.94.707-3.857 1.818a.5.5 0 1 1-.771-.636A6.002 6.002 0 0 1 13.917 7H12.9A5 5 0 0 0 8 3M3.1 9a5.002 5.002 0 0 0 8.757 2.182.5.5 0 1 1 .771.636A6.002 6.002 0 0 1 2.083 9z"/>
+            </symbol>
             <symbol id="icon-nav-outbox-viewer" viewBox="0 0 16 16">
                 <path d="M8 3.5a.5.5 0 0 0-1 0V9a.5.5 0 0 0 .252.434l3.5 2a.5.5 0 0 0 .496-.868L8 8.71V3.5z"/><path d="M8 16A8 8 0 1 0 8 0a8 8 0 0 0 0 16zm7-8A7 7 0 1 1 1 8a7 7 0 0 1 14 0z"/>
             </symbol>
@@ -232,6 +235,7 @@
             <button type="button" class="nav-link text-white dropdown-toggle bg-transparent border-0 p-0" data-bs-toggle="dropdown" aria-expanded="false" data-testid="technical-menu" title="Technical"><svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="currentColor" viewBox="0 0 16 16"><use href="#icon-nav-tools"/></svg></button>
             <ul class="dropdown-menu dropdown-menu-dark dropdown-menu-end">
                 <li><a href="/health" class="dropdown-item" data-testid="health-link"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="me-2" viewBox="0 0 16 16"><use href="#icon-nav-health"/></svg>Health</a></li>
+                <li><a href="/catalog-sync" class="dropdown-item" data-testid="catalog-sync-link"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="me-2" viewBox="0 0 16 16"><use href="#icon-nav-catalog-sync"/></svg>Catalog Sync</a></li>
                 <li><a href="/outbox-viewer" class="dropdown-item" data-testid="outbox-viewer-link"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="me-2" viewBox="0 0 16 16"><use href="#icon-nav-outbox-viewer"/></svg>Outbox</a></li>
                 <li><a href="/config" class="dropdown-item" data-testid="config-link"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="me-2" viewBox="0 0 16 16"><use href="#icon-nav-config"/></svg>Config</a></li>
                 <li><a href="/logs-viewer" class="dropdown-item" data-testid="logs-viewer-link"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="me-2" viewBox="0 0 16 16"><use href="#icon-nav-local-logs"/></svg>Logs UI</a></li>

--- a/adapter-out-mongodb/src/main/kotlin/de/chrgroth/spotify/control/adapter/out/mongodb/AppAlbumRepositoryAdapter.kt
+++ b/adapter-out-mongodb/src/main/kotlin/de/chrgroth/spotify/control/adapter/out/mongodb/AppAlbumRepositoryAdapter.kt
@@ -2,6 +2,7 @@ package de.chrgroth.spotify.control.adapter.out.mongodb
 
 import com.mongodb.client.model.BulkWriteOptions
 import com.mongodb.client.model.Filters
+import com.mongodb.client.model.Sorts
 import com.mongodb.client.model.UpdateOneModel
 import com.mongodb.client.model.UpdateOptions
 import com.mongodb.client.model.Updates
@@ -71,6 +72,27 @@ class AppAlbumRepositoryAdapter(
   override fun findByArtistId(artistId: ArtistId): List<AppAlbum> =
     mongoQueryMetrics.timed("app_album.findByArtistId") {
       appAlbumDocumentRepository.list("artistId = ?1", artistId.value).map { it.toDomain() }
+    }
+
+  override fun findByArtistIds(artistIds: Set<ArtistId>): List<AppAlbum> {
+    if (artistIds.isEmpty()) return emptyList()
+    return mongoQueryMetrics.timed("app_album.findByArtistIds") {
+      appAlbumDocumentRepository.mongoCollection()
+        .find(Filters.`in`(ARTIST_ID_FIELD, artistIds.map { it.value }))
+        .toList()
+        .map { it.toDomain() }
+    }
+  }
+
+  override fun findRecentlySynced(offset: Int, limit: Int): List<AppAlbum> =
+    mongoQueryMetrics.timed("app_album.findRecentlySynced") {
+      appAlbumDocumentRepository.mongoCollection()
+        .find()
+        .sort(Sorts.descending(LAST_SYNC_FIELD))
+        .skip(offset)
+        .limit(limit)
+        .toList()
+        .map { it.toDomain() }
     }
 
   override fun deleteAll() {

--- a/adapter-out-mongodb/src/main/kotlin/de/chrgroth/spotify/control/adapter/out/mongodb/AppArtistRepositoryAdapter.kt
+++ b/adapter-out-mongodb/src/main/kotlin/de/chrgroth/spotify/control/adapter/out/mongodb/AppArtistRepositoryAdapter.kt
@@ -2,6 +2,7 @@ package de.chrgroth.spotify.control.adapter.out.mongodb
 
 import com.mongodb.client.model.BulkWriteOptions
 import com.mongodb.client.model.Filters
+import com.mongodb.client.model.Sorts
 import com.mongodb.client.model.UpdateOneModel
 import com.mongodb.client.model.UpdateOptions
 import com.mongodb.client.model.Updates
@@ -73,6 +74,17 @@ class AppArtistRepositoryAdapter(
             ),
           ),
         )
+        .toList()
+        .map { it.toDomain() }
+    }
+
+  override fun findRecentlySynced(offset: Int, limit: Int): List<AppArtist> =
+    mongoQueryMetrics.timed("app_artist.findRecentlySynced") {
+      appArtistDocumentRepository.mongoCollection()
+        .find()
+        .sort(Sorts.descending(LAST_SYNC_FIELD))
+        .skip(offset)
+        .limit(limit)
         .toList()
         .map { it.toDomain() }
     }

--- a/adapter-out-mongodb/src/main/kotlin/de/chrgroth/spotify/control/adapter/out/mongodb/MongoIndexInitializer.kt
+++ b/adapter-out-mongodb/src/main/kotlin/de/chrgroth/spotify/control/adapter/out/mongodb/MongoIndexInitializer.kt
@@ -73,9 +73,17 @@ class MongoIndexInitializer(
   }
 
   private fun ensureCatalogCollectionIndexes() {
+    appArtistDocumentRepository.mongoCollection().createIndex(
+      Document(AppArtistRepositoryAdapter.LAST_SYNC_FIELD, -1),
+      IndexOptions().name("app_artist_lastSync_-1"),
+    )
     appAlbumDocumentRepository.mongoCollection().createIndex(
       Document(AppAlbumRepositoryAdapter.ARTIST_ID_FIELD, 1),
       IndexOptions().name("app_album_artistId_1"),
+    )
+    appAlbumDocumentRepository.mongoCollection().createIndex(
+      Document(AppAlbumRepositoryAdapter.LAST_SYNC_FIELD, -1),
+      IndexOptions().name("app_album_lastSync_-1"),
     )
     appTrackDocumentRepository.mongoCollection().createIndex(
       Document(AppTrackRepositoryAdapter.ARTIST_ID_FIELD, 1),

--- a/application-quarkus/src/test/kotlin/de/chrgroth/spotify/control/adapter/out/mongodb/AppAlbumRepositoryTests.kt
+++ b/application-quarkus/src/test/kotlin/de/chrgroth/spotify/control/adapter/out/mongodb/AppAlbumRepositoryTests.kt
@@ -114,6 +114,39 @@ class AppAlbumRepositoryTests {
   }
 
   @Test
+  fun `findByArtistIds returns albums for all given artists in a single batch`() {
+    val artistId1 = ArtistId("artist-bulk1-${UUID.randomUUID()}")
+    val artistId2 = ArtistId("artist-bulk2-${UUID.randomUUID()}")
+    val album1 = album("bulk1").copy(artistId = artistId1)
+    val album2 = album("bulk2").copy(artistId = artistId2)
+    val other = album("bulk-other").copy(artistId = ArtistId("other-artist-${UUID.randomUUID()}"))
+    appAlbumRepository.upsertAll(listOf(album1, album2, other))
+
+    val result = appAlbumRepository.findByArtistIds(setOf(artistId1, artistId2))
+
+    assertThat(result.map { it.id }).containsExactlyInAnyOrder(album1.id, album2.id)
+  }
+
+  @Test
+  fun `findByArtistIds returns empty list for empty input`() {
+    val result = appAlbumRepository.findByArtistIds(emptySet())
+    assertThat(result).isEmpty()
+  }
+
+  @Test
+  fun `findRecentlySynced returns albums ordered by lastSync descending`() {
+    val older = album("recent-older")
+    appAlbumRepository.upsertAll(listOf(older))
+    Thread.sleep(5)
+    val newer = album("recent-newer")
+    appAlbumRepository.upsertAll(listOf(newer))
+
+    val ids = appAlbumRepository.findRecentlySynced(offset = 0, limit = 10000).map { it.id }
+
+    assertThat(ids.indexOf(newer.id)).isLessThan(ids.indexOf(older.id))
+  }
+
+  @Test
   fun `countAll returns total number of albums`() {
     val before = appAlbumRepository.countAll()
     val album1 = album("count1")

--- a/application-quarkus/src/test/kotlin/de/chrgroth/spotify/control/adapter/out/mongodb/AppArtistRepositoryTests.kt
+++ b/application-quarkus/src/test/kotlin/de/chrgroth/spotify/control/adapter/out/mongodb/AppArtistRepositoryTests.kt
@@ -151,6 +151,25 @@ class AppArtistRepositoryTests {
   }
 
   @Test
+  fun `findRecentlySynced returns artists ordered by lastSync descending`() {
+    val older = artist("recent-older")
+    appArtistRepository.upsertAll(listOf(older))
+    Thread.sleep(5)
+    val newer = artist("recent-newer")
+    appArtistRepository.upsertAll(listOf(newer))
+
+    val ids = appArtistRepository.findRecentlySynced(offset = 0, limit = 10000).map { it.id }
+
+    assertThat(ids.indexOf(newer.id)).isLessThan(ids.indexOf(older.id))
+  }
+
+  @Test
+  fun `findRecentlySynced honors offset and limit`() {
+    val result = appArtistRepository.findRecentlySynced(offset = 0, limit = 1)
+    assertThat(result).hasSizeLessThanOrEqualTo(1)
+  }
+
+  @Test
   fun `countAll returns total number of artists`() {
     val before = appArtistRepository.countAll()
     val artist1 = artist("count1")

--- a/docs/releasenotes/snippets/issue-726-20260708-0706-feature.md
+++ b/docs/releasenotes/snippets/issue-726-20260708-0706-feature.md
@@ -1,0 +1,1 @@
+* Added a "Catalog Sync" page under the Tools menu showing a timeline of the artists and albums most recently synced from Spotify, newest first, with a "load more" button to page through older entries.

--- a/domain-api/src/main/kotlin/de/chrgroth/spotify/control/domain/model/catalog/CatalogSyncTimelineEntry.kt
+++ b/domain-api/src/main/kotlin/de/chrgroth/spotify/control/domain/model/catalog/CatalogSyncTimelineEntry.kt
@@ -1,0 +1,20 @@
+package de.chrgroth.spotify.control.domain.model.catalog
+
+import kotlin.time.Instant
+
+enum class CatalogSyncEntityType { ARTIST, ALBUM }
+
+/**
+ * A single row in the Catalog Sync timeline (Tools > Catalog Sync), representing either an artist or an album
+ * that was recently synced from Spotify. Artist and album fields are mutually exclusive based on [entityType].
+ */
+data class CatalogSyncTimelineEntry(
+  val entityType: CatalogSyncEntityType,
+  val syncedAt: Instant,
+  val artistId: String?,
+  val artistName: String?,
+  val albumCount: Int? = null,
+  val albumId: String? = null,
+  val albumName: String? = null,
+  val trackCount: Int? = null,
+)

--- a/domain-api/src/main/kotlin/de/chrgroth/spotify/control/domain/model/catalog/CatalogSyncTimelinePage.kt
+++ b/domain-api/src/main/kotlin/de/chrgroth/spotify/control/domain/model/catalog/CatalogSyncTimelinePage.kt
@@ -1,0 +1,12 @@
+package de.chrgroth.spotify.control.domain.model.catalog
+
+/**
+ * A page of the Catalog Sync timeline. [nextArtistOffset] and [nextAlbumOffset] must be passed back unchanged
+ * to fetch the next page, since artists and albums are paged independently before being merged by [CatalogSyncTimelineEntry.syncedAt].
+ */
+data class CatalogSyncTimelinePage(
+  val entries: List<CatalogSyncTimelineEntry>,
+  val nextArtistOffset: Int,
+  val nextAlbumOffset: Int,
+  val hasMore: Boolean,
+)

--- a/domain-api/src/main/kotlin/de/chrgroth/spotify/control/domain/port/in/catalog/CatalogBrowserPort.kt
+++ b/domain-api/src/main/kotlin/de/chrgroth/spotify/control/domain/port/in/catalog/CatalogBrowserPort.kt
@@ -3,6 +3,7 @@ package de.chrgroth.spotify.control.domain.port.`in`.catalog
 import de.chrgroth.spotify.control.domain.model.catalog.AlbumBrowseItem
 import de.chrgroth.spotify.control.domain.model.catalog.ArtistBrowseItem
 import de.chrgroth.spotify.control.domain.model.catalog.CatalogStats
+import de.chrgroth.spotify.control.domain.model.catalog.CatalogSyncTimelinePage
 import de.chrgroth.spotify.control.domain.model.catalog.SyncTraceDisplay
 import de.chrgroth.spotify.control.domain.model.catalog.TrackBrowseItem
 
@@ -14,4 +15,5 @@ interface CatalogBrowserPort {
   fun getAlbumTracks(albumId: String): List<TrackBrowseItem>
   fun getArtistSyncTrace(artistId: String): SyncTraceDisplay?
   fun getAlbumSyncTrace(albumId: String): SyncTraceDisplay?
+  fun getSyncTimeline(artistOffset: Int, albumOffset: Int, limit: Int): CatalogSyncTimelinePage
 }

--- a/domain-api/src/main/kotlin/de/chrgroth/spotify/control/domain/port/out/catalog/AppAlbumRepositoryPort.kt
+++ b/domain-api/src/main/kotlin/de/chrgroth/spotify/control/domain/port/out/catalog/AppAlbumRepositoryPort.kt
@@ -10,5 +10,7 @@ interface AppAlbumRepositoryPort {
   fun findAll(): List<AppAlbum>
   fun findByAlbumIds(albumIds: Set<AlbumId>): List<AppAlbum>
   fun findByArtistId(artistId: ArtistId): List<AppAlbum>
+  fun findByArtistIds(artistIds: Set<ArtistId>): List<AppAlbum>
+  fun findRecentlySynced(offset: Int, limit: Int): List<AppAlbum>
   fun deleteAll()
 }

--- a/domain-api/src/main/kotlin/de/chrgroth/spotify/control/domain/port/out/catalog/AppArtistRepositoryPort.kt
+++ b/domain-api/src/main/kotlin/de/chrgroth/spotify/control/domain/port/out/catalog/AppArtistRepositoryPort.kt
@@ -9,6 +9,7 @@ interface AppArtistRepositoryPort {
   fun findAll(): List<AppArtist>
   fun findByArtistIds(artistIds: Set<ArtistId>): List<AppArtist>
   fun findWithImageLinkAndBlankName(): List<AppArtist>
+  fun findRecentlySynced(offset: Int, limit: Int): List<AppArtist>
   fun setBlockedFromAggregation(artistId: ArtistId, blocked: Boolean)
   fun deleteAll()
 }

--- a/domain-impl/src/main/kotlin/de/chrgroth/spotify/control/domain/catalog/CatalogBrowserService.kt
+++ b/domain-impl/src/main/kotlin/de/chrgroth/spotify/control/domain/catalog/CatalogBrowserService.kt
@@ -5,6 +5,9 @@ import de.chrgroth.spotify.control.domain.model.catalog.AlbumId
 import de.chrgroth.spotify.control.domain.model.catalog.ArtistBrowseItem
 import de.chrgroth.spotify.control.domain.model.catalog.ArtistId
 import de.chrgroth.spotify.control.domain.model.catalog.CatalogStats
+import de.chrgroth.spotify.control.domain.model.catalog.CatalogSyncEntityType
+import de.chrgroth.spotify.control.domain.model.catalog.CatalogSyncTimelineEntry
+import de.chrgroth.spotify.control.domain.model.catalog.CatalogSyncTimelinePage
 import de.chrgroth.spotify.control.domain.model.catalog.SyncCause
 import de.chrgroth.spotify.control.domain.model.catalog.SyncTraceDisplay
 import de.chrgroth.spotify.control.domain.model.catalog.SyncTraceEntityType
@@ -145,6 +148,53 @@ class CatalogBrowserService(
       }
     }
     return SyncTraceDisplay(description, trace.triggeredAt)
+  }
+
+  override fun getSyncTimeline(artistOffset: Int, albumOffset: Int, limit: Int): CatalogSyncTimelinePage {
+    val artistCandidates = appArtistRepository.findRecentlySynced(artistOffset, limit + 1)
+    val albumCandidates = appAlbumRepository.findRecentlySynced(albumOffset, limit + 1)
+
+    val artistHasMoreBeyondBatch = artistCandidates.size > limit
+    val albumHasMoreBeyondBatch = albumCandidates.size > limit
+    val boundedArtists = artistCandidates.take(limit)
+    val boundedAlbums = albumCandidates.take(limit)
+
+    val albumCountByArtistId = appAlbumRepository.findByArtistIds(boundedArtists.map { it.id }.toSet())
+      .groupingBy { it.artistId?.value }
+      .eachCount()
+
+    val artistEntries = boundedArtists.map { artist ->
+      CatalogSyncTimelineEntry(
+        entityType = CatalogSyncEntityType.ARTIST,
+        syncedAt = artist.lastSync,
+        artistId = artist.id.value,
+        artistName = artist.artistName,
+        albumCount = albumCountByArtistId[artist.id.value] ?: 0,
+      )
+    }
+    val albumEntries = boundedAlbums.map { album ->
+      CatalogSyncTimelineEntry(
+        entityType = CatalogSyncEntityType.ALBUM,
+        syncedAt = album.lastSync,
+        artistId = album.artistId?.value,
+        artistName = album.artistName,
+        albumId = album.id.value,
+        albumName = album.title,
+        trackCount = album.totalTracks ?: 0,
+      )
+    }
+
+    val merged = (artistEntries + albumEntries).sortedByDescending { it.syncedAt }
+    val page = merged.take(limit)
+    val artistTaken = page.count { it.entityType == CatalogSyncEntityType.ARTIST }
+    val albumTaken = page.count { it.entityType == CatalogSyncEntityType.ALBUM }
+
+    return CatalogSyncTimelinePage(
+      entries = page,
+      nextArtistOffset = artistOffset + artistTaken,
+      nextAlbumOffset = albumOffset + albumTaken,
+      hasMore = merged.size > limit || artistHasMoreBeyondBatch || albumHasMoreBeyondBatch,
+    )
   }
 
   private fun describeCause(cause: SyncCause): String = when (cause) {

--- a/domain-impl/src/test/kotlin/de/chrgroth/spotify/control/domain/catalog/CatalogBrowserServiceTests.kt
+++ b/domain-impl/src/test/kotlin/de/chrgroth/spotify/control/domain/catalog/CatalogBrowserServiceTests.kt
@@ -5,6 +5,7 @@ import de.chrgroth.spotify.control.domain.model.catalog.AppAlbum
 import de.chrgroth.spotify.control.domain.model.catalog.AppArtist
 import de.chrgroth.spotify.control.domain.model.catalog.AppTrack
 import de.chrgroth.spotify.control.domain.model.catalog.ArtistId
+import de.chrgroth.spotify.control.domain.model.catalog.CatalogSyncEntityType
 import de.chrgroth.spotify.control.domain.model.catalog.SyncCause
 import de.chrgroth.spotify.control.domain.model.catalog.SyncTrace
 import de.chrgroth.spotify.control.domain.model.catalog.SyncTraceEntityType
@@ -180,5 +181,51 @@ class CatalogBrowserServiceTests {
     val result = service.getAlbumSyncTrace("album-1")
 
     assertThat(result!!.description).isEqualTo("Synced as part of full discography sync for artist 'Some Artist'")
+  }
+
+  @Test
+  fun `getSyncTimeline merges artists and albums by syncedAt descending and reports correct next offsets`() {
+    val artistA = AppArtist(id = ArtistId("artist-a"), artistName = "Artist A", lastSync = Instant.fromEpochSeconds(100))
+    val artistB = AppArtist(id = ArtistId("artist-b"), artistName = "Artist B", lastSync = Instant.fromEpochSeconds(90))
+    val albumX = AppAlbum(
+      id = AlbumId("album-x"), title = "Album X", artistId = ArtistId("artist-c"), artistName = "Artist C",
+      totalTracks = 12, lastSync = Instant.fromEpochSeconds(95),
+    )
+    every { appArtistRepository.findRecentlySynced(0, 3) } returns listOf(artistA, artistB, AppArtist(id = ArtistId("artist-z"), artistName = "Z", lastSync = Instant.fromEpochSeconds(50)))
+    every { appAlbumRepository.findRecentlySynced(0, 3) } returns listOf(albumX)
+    every { appAlbumRepository.findByArtistIds(setOf(artistA.id, artistB.id)) } returns listOf(
+      AppAlbum(id = AlbumId("album-a1"), artistId = artistA.id, lastSync = triggeredAt),
+      AppAlbum(id = AlbumId("album-a2"), artistId = artistA.id, lastSync = triggeredAt),
+    )
+
+    val result = service.getSyncTimeline(artistOffset = 0, albumOffset = 0, limit = 2)
+
+    assertThat(result.entries).hasSize(2)
+    assertThat(result.entries[0].entityType).isEqualTo(CatalogSyncEntityType.ARTIST)
+    assertThat(result.entries[0].artistId).isEqualTo("artist-a")
+    assertThat(result.entries[0].albumCount).isEqualTo(2)
+    assertThat(result.entries[1].entityType).isEqualTo(CatalogSyncEntityType.ALBUM)
+    assertThat(result.entries[1].albumId).isEqualTo("album-x")
+    assertThat(result.entries[1].artistId).isEqualTo("artist-c")
+    assertThat(result.entries[1].trackCount).isEqualTo(12)
+    assertThat(result.nextArtistOffset).isEqualTo(1)
+    assertThat(result.nextAlbumOffset).isEqualTo(1)
+    assertThat(result.hasMore).isTrue()
+  }
+
+  @Test
+  fun `getSyncTimeline reports hasMore false when both sources are exhausted`() {
+    every { appArtistRepository.findRecentlySynced(0, 3) } returns listOf(
+      AppArtist(id = ArtistId("artist-a"), artistName = "Artist A", lastSync = Instant.fromEpochSeconds(100)),
+    )
+    every { appAlbumRepository.findRecentlySynced(0, 3) } returns emptyList()
+    every { appAlbumRepository.findByArtistIds(setOf(ArtistId("artist-a"))) } returns emptyList()
+
+    val result = service.getSyncTimeline(artistOffset = 0, albumOffset = 0, limit = 2)
+
+    assertThat(result.entries).hasSize(1)
+    assertThat(result.nextArtistOffset).isEqualTo(1)
+    assertThat(result.nextAlbumOffset).isEqualTo(0)
+    assertThat(result.hasMore).isFalse()
   }
 }


### PR DESCRIPTION
## Summary

Adds a new "Catalog Sync" page under Tools (between Health and Outbox) showing a timeline of the artists and albums most recently synced from Spotify, newest first — the latest 200 entries, with a "Load more" button to page further back.

Each row shows:
- **Artist** entries: Id, Name, number of albums
- **Album** entries: Artist Id, Artist Name, Id, Name, number of tracks

No new persistence was needed — it reuses the existing `lastSync` timestamp on `app_artist`/`app_album`, adding sorted+paged MongoDB queries and indexes instead of loading full collections into memory.

Closes #726

## Test plan
- [x] `./gradlew build` passes (unit + @QuarkusTest integration tests, static analysis)
- [ ] Manually verify the /catalog-sync page in a running instance: menu item appears between Health and Outbox, table renders, Load more works

🤖 Generated with [Claude Code](https://claude.ai/code)