### PR TITLE
Fix missing Album fields in Catalog Sync timeline

### DIFF
--- a/adapter-in-web/src/main/resources/templates/catalog-sync.html
+++ b/adapter-in-web/src/main/resources/templates/catalog-sync.html
@@ -23,7 +23,7 @@
                     {#for entry in entries}
                     <tr data-testid="catalog-sync-row">
                         <td>
-                            {#if entry.entityType == "ARTIST"}
+                            {#if entry.entityType.name == "ARTIST"}
                             <span class="badge" style="background-color:var(--spotify-green);color:#000;">Artist</span>
                             {#else}
                             <span class="badge" style="background-color:#555;color:#fff;">Album</span>
@@ -34,15 +34,15 @@
                             {#if entry.artistId}<span style="color:#666;font-size:.75rem;">({entry.artistId})</span>{/if}
                         </td>
                         <td style="color:#ccc;font-size:.9rem;">
-                            {#if entry.entityType == "ALBUM"}
+                            {#if entry.entityType.name == "ALBUM"}
                             {#if entry.albumName}{entry.albumName}{#else}(untitled){/if}
                             <span style="color:#666;font-size:.75rem;">({entry.albumId})</span>
                             {#else}
                             –
                             {/if}
                         </td>
-                        <td class="text-end" style="color:#888;font-size:.85rem;">{#if entry.entityType == "ARTIST"}{entry.albumCount.formatted}{#else}–{/if}</td>
-                        <td class="text-end" style="color:#888;font-size:.85rem;">{#if entry.entityType == "ALBUM"}{entry.trackCount.formatted}{#else}–{/if}</td>
+                        <td class="text-end" style="color:#888;font-size:.85rem;">{#if entry.entityType.name == "ARTIST"}{entry.albumCount.formatted}{#else}–{/if}</td>
+                        <td class="text-end" style="color:#888;font-size:.85rem;">{#if entry.entityType.name == "ALBUM"}{entry.trackCount.formatted}{#else}–{/if}</td>
                         <td style="white-space:nowrap;color:#888;font-size:.85rem;">{entry.syncedAt.formatted}</td>
                     </tr>
                     {/for}

--- a/docs/releasenotes/snippets/0832-bugfix.md
+++ b/docs/releasenotes/snippets/0832-bugfix.md
@@ -1,0 +1,1 @@
+* Fixed the Catalog Sync timeline not showing the album id, album name and track count for album sync entries.


### PR DESCRIPTION
## Summary
- Fixes the Catalog Sync timeline (Tools > Catalog Sync) not showing Album Id, Album Name and Track count for album sync entries.
- Root cause: `catalog-sync.html` compared the Kotlin `entityType` enum directly to a string literal, which Qute never resolves as equal, so the Album-only / Artist-only conditional columns always evaluated to false. Fixed by comparing `entry.entityType.name` instead, matching the existing convention in `mongodb-viewer.html`.
- Fixes #726

## Test plan
- [x] `./gradlew build` passes
- [ ] Manually verify /catalog-sync: Album rows now show Album Id, Name and Track count; Artist rows show the correct badge and Album count

🤖 Generated with [Claude Code](https://claude.ai/code)