### PR TITLE
Add single-user architecture ADR, migration plan, and arc42 update

### DIFF
--- a/docs/adr/0008-single-user-architecture.md
+++ b/docs/adr/0008-single-user-architecture.md
@@ -1,0 +1,114 @@
+# Single-User Architecture
+
+* Status: accepted
+* Deciders: Chris
+* Date: 2026-07-09
+
+## Context and Problem Statement
+
+spotify-control was originally designed to support a small, allow-listed set of Spotify users
+(`APP_ALLOWED_SPOTIFY_USER_IDS`), even though in practice it has only ever run with a single
+operator/user. This assumption of "possibly a few users" threads a `UserId` through nearly every
+port, service, MongoDB collection, and outbox event in the system, without ever being exercised
+beyond one active account.
+
+The [2026-07-08 performance review](../reviews/2026-07-08-performance-review.md) surfaced two
+concrete problems that trace back to this mismatch between the multi-user design and the
+single-user reality:
+
+* **Finding 1** – catalog sync picks an arbitrary user's Spotify token
+  (`userRepository.findAll().firstOrNull()` in `CatalogService`) to sync *shared* catalog data.
+  This already behaves like a single-token design, just without admitting it — a structural
+  single point of failure "that likely came from building for the initial single/dual-user case
+  and not revisiting it as multi-user support was added."
+* **Finding 2** – the `to-spotify-playback` outbox partition has no per-user sub-partitioning,
+  which the review flags as a potential serialization bottleneck "if user count grows."
+
+Both findings, along with two more scalability risks noted in the review's "what breaks first"
+section, are only risks *because* the system is modeled as multi-user. None of them have ever
+materialized, because there has only ever been one user.
+
+Should the application keep the allow-list/multi-user model and harden it against these risks, or
+should it be redesigned as a strict single-user application?
+
+## Decision Drivers
+
+* The original "a few users" assumption was wrong and has never reflected real usage.
+* Multi-user plumbing (`UserId` in ports, services, indexes, outbox events) adds complexity with
+  no corresponding benefit.
+* [ADR-0003](0003-no-separate-frontend-project.md) already leans on "single-user developer tool"
+  as a design driver elsewhere in the system — this decision makes that assumption explicit and
+  consistent everywhere.
+* Simpler code is easier to maintain by a single developer.
+* The performance review's multi-user scaling risks are cheaper to eliminate by removing the
+  premise than to fix by hardening the code.
+
+## Considered Options
+
+1. **Keep the allow-list / multi-user model, harden the scaling risks** (fix the catalog-sync
+   token shortcut, add per-user outbox sub-partitioning, add per-user locking where needed).
+2. **Convert to a strict single-user application** – remove the allow-list and `UserId` plumbing
+   wherever it exists only to distinguish between users, keep a single implicit user throughout.
+
+## Decision Outcome
+
+Chosen option: **"Convert to a strict single-user application"**, because the multi-user
+capability was never used, never requested, and was based on a wrong initial assumption. Removing
+it is simpler than hardening code paths for a scenario that doesn't occur, and it directly
+resolves the performance review's multi-user scaling findings by eliminating their precondition
+rather than defending against it.
+
+This is a large, cross-cutting change (see the [migration plan](../plans/single-user-simplification.md)
+for the phased approach) and will be implemented incrementally across several follow-up PRs, not
+as a single change.
+
+### Positive Consequences
+
+* Removes the allow-list and OAuth "not allowed" error path entirely — login becomes "log in with
+  Spotify, done."
+* Eliminates the arbitrary-user catalog-sync shortcut (performance review Finding 1) by
+  construction, instead of hardening it.
+* Removes the multi-user outbox scaling risk (performance review Finding 2) and the "currently
+  playing scales with user count" risk, since there is exactly one user.
+* Removes `UserId` from ports, services, and outbox events where it only ever distinguished
+  between users that never coexisted, simplifying method signatures across `domain-api` and
+  `domain-impl`.
+* MongoDB documents and indexes keyed by `spotifyUserId` can be simplified once there is no
+  per-user partitioning to maintain.
+
+### Negative Consequences
+
+* Re-introducing multi-user support later would require re-adding this plumbing rather than just
+  enabling a flag.
+* Existing MongoDB data and indexes need a migration path if `userId` is dropped from document
+  keys (see migration plan for the recommended low-risk approach).
+* Touches nearly every module in the system, so the migration must be done incrementally with a
+  green build at every step, per this repository's [CI requirements](../../CLAUDE.md).
+
+## Pros and Cons of the Options
+
+### Keep the allow-list / multi-user model, harden the scaling risks
+
+* Good, because it preserves the theoretical ability to add a second user later.
+* Bad, because it keeps solving a problem ("what if there are multiple users") that has never
+  actually occurred.
+* Bad, because hardening (per-user token selection, per-user outbox sub-partitioning, per-user
+  locking) adds *more* complexity on top of an already-unused abstraction.
+* Bad, because it does nothing to simplify the existing `UserId` plumbing that has no current
+  benefit.
+
+### Convert to a strict single-user application
+
+* Good, because it removes complexity instead of adding to it.
+* Good, because it resolves the performance review's multi-user findings by eliminating their
+  cause.
+* Good, because it aligns the code with how the application has always actually been used.
+* Bad, because it is a large, cross-cutting refactor touching most modules.
+* Bad, because re-adding multi-user support later would require redesigning this plumbing again.
+
+## Links
+
+* [Performance review, 2026-07-08](../reviews/2026-07-08-performance-review.md)
+* [Single-user simplification plan](../plans/single-user-simplification.md)
+* [No Separate Frontend Project ADR](0003-no-separate-frontend-project.md)
+* [arc42.md](../arc42/arc42.md)

--- a/docs/arc42/arc42.md
+++ b/docs/arc42/arc42.md
@@ -4,7 +4,12 @@
 
 ## Requirements Overview
 
-spotify-control is a private Spotify playlist manager for a small, allow-listed set of users.
+spotify-control is a private Spotify playlist manager for a single user. It has always been
+operated by exactly one person; the previous allow-list design supported multiple users in
+theory but that was never actually used (see [ADR-0008](../adr/0008-single-user-architecture.md)).
+The application is being converted to a strict single-user architecture; see the
+[single-user simplification plan](../plans/single-user-simplification.md) for the migration
+approach.
 
 **Implemented features:**
 
@@ -14,7 +19,7 @@ spotify-control is a private Spotify playlist manager for a small, allow-listed 
 
 3. **Catalog Sync** – Artist images, track album references, and album details (title, cover) are fetched from the Spotify API and stored in deduplicated `app_artist`, `app_track`, and `app_album` collections.
 
-4. **Listening Statistics** – Playback data is aggregated into a per-user dashboard showing total play counts, daily play trends, top artists, top tracks, and recently played items.
+4. **Listening Statistics** – Playback data is aggregated into a dashboard showing total play counts, daily play trends, top artists, top tracks, and recently played items.
 
 5. **Artist Playback Filtering** – Users can mark artists as `ACTIVE`, `INACTIVE`, or `UNDECIDED`. Tracks from `INACTIVE` artists are excluded from playback processing.
 
@@ -26,11 +31,11 @@ spotify-control is a private Spotify playlist manager for a small, allow-listed 
 
 | Role/Name         | Contact     | Expectations                                                              |
 |-------------------|-------------|---------------------------------------------------------------------------|
-| Developer / User  | (private)   | Allow-listed user(s); operates and uses the application for personal use  |
+| Developer / User  | (private)   | The single user; operates and uses the application for personal use      |
 
 # Architecture Constraints
 
-- **Allow-listed users** – Multiple users are supported, but access is restricted to a configured allow list of Spotify user IDs. No registration, no user-management UI.
+- **Single user** – The application is built for exactly one user (see [ADR-0008](../adr/0008-single-user-architecture.md)). No registration, no user-management UI, no allow-list.
 - **Login exclusively via Spotify OAuth** – No other authentication mechanism.
 - **External MongoDB** – Data is stored in MongoDB Atlas (two projects: prod + dev). No self-hosted database.
 - **VPS with Docker Swarm** – Deployment target is an existing VPS running Docker Swarm with Traefik for routing and TLS.
@@ -67,7 +72,7 @@ spotify-control interacts with the following external systems:
 - **Hexagonal Architecture** – The application is structured using hexagonal (ports and adapters) architecture to cleanly separate domain logic from infrastructure concerns.
 - **Outbox Pattern** – All Spotify API operations are routed through a persistent outbox to ensure reliability and rate limit handling. No direct Spotify calls are made outside `adapter-out-spotify`.
 - **Server-Side Rendering** – The frontend uses Quarkus Qute templates with vanilla JS (fetch API) for dynamic interactions, eliminating the need for a separate frontend project or JavaScript framework.
-- **Allow-listed User System** – Access is restricted to users whose Spotify user IDs appear in a configured allow list. Multiple users are supported, but no self-service registration exists.
+- **Single-User System** – The application is built for exactly one user, logging in via Spotify OAuth. No allow-list, no self-service registration, no user-management UI. See [ADR-0008](../adr/0008-single-user-architecture.md); the migration is tracked in the [single-user simplification plan](../plans/single-user-simplification.md).
 
 # Building Block View
 
@@ -221,7 +226,7 @@ Raw playback data from `spotify_recently_played` and `spotify_recently_partial_p
 **Append (triggered automatically):** After new raw data arrives, `AppendPlaybackData` is enqueued on the `domain` partition. The adapter first loads all artists with `INACTIVE` playback processing status, then filters raw playback items to skip tracks whose primary artist is inactive. For remaining items it fetches all source items newer than the most recent `app_playback` entry for the user, deduplicates against existing `app_playback` timestamps, then:
 1. Upserts artist metadata into `app_artist` (artistId, artistName) — enriched imageLink is preserved on re-encounter.
 2. Upserts track metadata into `app_track` (trackId, trackTitle, artistId, additionalArtistIds) — albumId is preserved if already enriched.
-3. Appends new entries to `app_playback` (userId, playedAt, trackId, secondsPlayed). The document `_id` is a composite of `${userId}:${playedAt.toEpochMilli()}:${trackId}` for natural deduplication.
+3. Appends new entries to `app_playback` (userId, playedAt, trackId, secondsPlayed). The document `_id` is a composite of `${userId}:${playedAt.toEpochMilli()}` for natural deduplication.
 4. Adds artist IDs to `app_sync_pool` and track IDs to `app_sync_pool` for later bulk sync.
 
 **Catalog Sync (bulk-scheduled, `to-spotify` partition):**
@@ -369,8 +374,8 @@ Layer 5 applies to adapter modules where the logic is pure (e.g. `adapter-in-sta
 ## Authentication and Access Control
 
 - Spotify OAuth 2.0 Authorization Code Flow.
-- In the OAuth callback: the Spotify user ID is checked against `APP_ALLOWED_SPOTIFY_USER_IDS` (environment variable, comma-separated list). If the ID is not present in the list, the session is invalidated and nothing is persisted.
-- A `User` document is upserted in the `app_user` MongoDB collection only after a successful allow-list check. Both access and refresh tokens are stored encrypted (AES-256-GCM) using `APP_TOKEN_ENCRYPTION_KEY`.
+- A `User` document is upserted in the `app_user` MongoDB collection on every successful login. Both access and refresh tokens are stored encrypted (AES-256-GCM) using `APP_TOKEN_ENCRYPTION_KEY`.
+- The application is built for a single user (see [ADR-0008](../adr/0008-single-user-architecture.md)); the allow-list check (`APP_ALLOWED_SPOTIFY_USER_IDS`) that previously gated login is being removed as part of the single-user migration (see [migration plan](../plans/single-user-simplification.md)).
 - Session-based authentication for all endpoints. The session stores only the Spotify user ID – never tokens.
 - `return_to` parameter stored in the session for redirect after login.
 - A CSRF `state` parameter is generated per authorization request and validated in the callback.
@@ -454,6 +459,9 @@ APP_TOKEN_ENCRYPTION_KEY
 SLACK_WEBHOOK_URL
 ```
 
+`APP_ALLOWED_SPOTIFY_USER_IDS` is scheduled for removal as part of the single-user migration
+(see [ADR-0008](../adr/0008-single-user-architecture.md)) once login no longer needs an allow-list check.
+
 # Architecture Decisions
 
 | ADR | Title |
@@ -465,6 +473,7 @@ SLACK_WEBHOOK_URL
 | [0005](../adr/0005-markdown-rendering-library.md) | Markdown Rendering Library: marked |
 | [0006](../adr/0006-error-handling-concept.md) | Error Handling: Arrow Either&lt;DomainError, T&gt; |
 | [0007](../adr/0007-persistent-outbox-pattern.md) | Persistent Outbox for Spotify API Operations |
+| [0008](../adr/0008-single-user-architecture.md) | Single-User Architecture |
 
 # Quality Requirements
 
@@ -509,6 +518,7 @@ SLACK_WEBHOOK_URL
 | Enrichment completeness | `app_artist`, `app_track`, and `app_album` entries that existed before enrichment was introduced may lack imageLink or albumTitle until re-enriched. |
 | Partial-play detection accuracy | Partial play detection relies on polling frequency; very short plays near the end of a track may be missed or misclassified. |
 | Test coverage for domain adapters | Domain adapter integration (e.g. `PlaybackDataAdapter`, `PlaylistSyncAdapter`) is not yet covered by `@QuarkusTest` boundary tests. |
+| Multi-user plumbing | `UserId` is still threaded through ports, services, outbox events, and MongoDB document keys even though the application only ever supports a single user. Tracked by [ADR-0008](../adr/0008-single-user-architecture.md) and the [single-user simplification plan](../plans/single-user-simplification.md). |
 
 # Glossary
 

--- a/docs/plans/single-user-simplification.md
+++ b/docs/plans/single-user-simplification.md
@@ -1,0 +1,161 @@
+# Single-User Simplification Plan
+
+This document is the implementation plan for [ADR-0008](../adr/0008-single-user-architecture.md):
+converting spotify-control from an allow-listed multi-user design to a strict single-user
+application. It only adds this plan; implementation happens in separate, smaller follow-up PRs,
+one phase (or sub-phase) at a time, each with a green build per this repository's
+[CI requirements](../../CLAUDE.md).
+
+The system currently threads `UserId` through almost every module. Because of that, the migration
+is organized module-by-module, in dependency order (`domain-api` → `domain-impl` → adapters →
+schema → cleanup), so each phase can be built and tested independently before the next begins.
+
+---
+
+## Phase 1: Login and allow-list removal
+
+**Goal:** Login no longer checks an allow-list; any Spotify account can log in, and the concept of
+"not allowed" disappears.
+
+* `domain-impl/src/main/kotlin/de/chrgroth/spotify/control/domain/user/LoginService.kt` –
+  remove the injected `app.allowed-spotify-user-ids` property, the `Set<UserId>` allow-list, and
+  `isAllowed(userId)`. `handleCallback` no longer branches on allow-list membership or raises
+  `AuthError.USER_NOT_ALLOWED`.
+* `domain-impl/src/main/resources/application.properties` – remove
+  `app.allowed-spotify-user-ids` (prod/dev/test values).
+* `adapter-in-web/.../OAuthResource.kt` – remove the "user not allowed" error redirect path if it
+  becomes unreachable.
+* Any `AuthError` variant that only existed to represent "not allowed" can be removed once no
+  producer/consumer remains.
+* Update `docs/arc42/arc42.md` "Authentication and Access Control" section (already updated in
+  this PR, see below) and remove `APP_ALLOWED_SPOTIFY_USER_IDS` from deployment configuration
+  once this phase ships.
+
+**Risk:** Low. This is an additive-to-permissive change (fewer checks, not more), and the
+single deployed instance is already only ever logged in by one operator.
+
+---
+
+## Phase 2: Scheduler fan-out and the catalog-sync shortcut
+
+**Goal:** Remove the "for each user" loops in scheduled job enqueuing, since there's only ever one
+user, and remove the arbitrary-user shortcut in catalog sync (performance review Finding 1).
+
+Per-user fan-out loops to collapse to a single call against the one stored user:
+
+* `domain-impl/.../playback/PlaybackService.kt` (`enqueueFetchPlaybackData`, ~line 68-73)
+* `domain-impl/.../playback/PlaybackAggregationService.kt` (four `users.forEach` blocks for
+  daily/weekly/monthly/quarterly/yearly aggregation, ~line 55-84)
+* `domain-impl/.../playlist/PlaylistService.kt` (`enqueueUpdates`, ~line 63-65)
+* `domain-impl/.../user/UserProfileService.kt` (`enqueueUpdates`, ~line 27-33)
+
+Catalog-sync shortcut to remove:
+
+* `domain-impl/.../catalog/CatalogService.kt` (lines ~101-206) currently does
+  `userRepository.findAll().firstOrNull()?.spotifyUserId` to obtain *a* token for catalog-wide
+  sync operations. Once single-user is enforced this becomes `userRepository.findAll().single()`
+  (or an equivalent explicit "the one user" lookup) — the same call, but now correct by
+  construction instead of an arbitrary pick among many.
+* `domain-impl/.../catalog/CatalogBrowserService.kt` (~line 209) — same pattern.
+
+**Risk:** Medium. Touches the busiest scheduled jobs in the system; needs test coverage for the
+"zero users yet" (not logged in) and "one user" cases. No "multiple users" case needs testing
+afterward, since it becomes structurally impossible.
+
+---
+
+## Phase 3: Thread removal of `UserId` through ports and services
+
+**Goal:** Drop `UserId` parameters from ports, services, and outbox events where they only ever
+existed to distinguish between users, once Phase 2 has established that there is exactly one user.
+
+* `domain-api/.../port/out/*` – ports whose only use of `UserId` is to select "which user" (not
+  domain data itself) can drop the parameter: `PlaybackPort`, `PlaybackAggregationPort`,
+  `PlaylistPort`, `UserProfilePort`, `SpotifyAccessTokenPort`, `SpotifyPlaybackPort`,
+  `SpotifyCatalogPort`, `SpotifyPlaylistPort`, `DashboardRefreshPort`.
+  Note that `CatalogPort` needs care — some of the `UserId` usages there are about *which token to
+  use for a Spotify call*, which still needs to resolve to "the one user," not "no user."
+* `domain-api/.../domain/outbox/DomainOutboxEvent.kt` – outbox event payloads that carry `userId`
+  purely to route to "the current user" (`FetchPlaybackData`, `RebuildPlaybackData`,
+  `AppendPlaybackData`, `SyncArtistAlbums`, `UpdateUserProfile`, etc.) can drop the field. Existing
+  in-flight outbox tasks in MongoDB will already contain the old payload shape — deserialization
+  must tolerate (ignore) a stray `userId` field during the transition, or old tasks must be
+  drained before deploying this phase.
+* `adapter-in-web/.../*Resource.kt` – all resources currently resolve "current user" via
+  `UserId(securityIdentity.principal.name)` (`PlaybackResource`, `DashboardSseResource`,
+  `StatsResource`, `PlaylistsResource`, `PlaylistSettingsResource`, `PlaybackSettingsResource`,
+  `PlaylistChecksResource`, `DashboardResource`, `PlaybackEventViewerResource`,
+  `HealthSseResource`). This resolution can stay as-is (it still identifies the logged-in
+  session), but downstream calls no longer need to pass it further than the point where a
+  Spotify token must be selected.
+* SSE: `DashboardSseAdapter` maintains per-user reactive streams (arc42 "SSE" section). This can
+  collapse to a single stream/registry once there is exactly one possible subscriber identity —
+  worth inspecting directly during this phase, since it wasn't fully read during discovery.
+
+**Risk:** High — this phase touches the largest surface area (most of `domain-api` and
+`domain-impl`, and all of `adapter-in-web`). Recommend splitting further into one PR per bounded
+context (playback, playlist, catalog, user profile) rather than one large PR.
+
+---
+
+## Phase 4: MongoDB schema and index cleanup
+
+**Goal:** Simplify collections and indexes that currently exist to disambiguate between users.
+
+| Collection | Current key | Proposed change |
+|---|---|---|
+| `app_user` | `_id = spotifyUserId` | Keep as-is; still the single source of truth for "who is the user," now guaranteed to have at most one document. |
+| `app_playback` | `_id = "${spotifyUserId}:${playedAt.epochMilli}"` | Drop `spotifyUserId` from the key; `_id = playedAt.epochMilli` (or keep the compound key — see risk note below). |
+| `app_playback_aggregation` | `_id = "${spotifyUserId}:${type}:${periodStart}"` | Drop `spotifyUserId` from the key: `_id = "${type}:${periodStart}"`. |
+| `spotify_currently_playing` | `spotifyUserId` field + compound index `(spotifyUserId, trackId, observedAt)` | Drop `spotifyUserId` field and shrink index to `(trackId, observedAt)`. |
+| `spotify_recently_played` | `spotifyUserId` field + index `(spotifyUserId, playedAt)` | Drop field, shrink index to `(playedAt)`. |
+| `spotify_recently_partial_played` | same pattern | Drop field, shrink index to `(playedAt)`. |
+| `spotify_playlist` | `spotifyUserId` field + index `spotify_playlist_spotifyUserId_1` | Drop field and index. |
+| `spotify_playlist_metadata` | `spotifyUserId` field + index | Drop field and index. |
+
+`app_artist`, `app_album`, `app_track` already have no `userId` and are unaffected.
+
+**Migration approach:** use a one-time `Starter` (per the existing pattern in
+`adapter-in-starter`, see arc42 "Starters" section) to strip `spotifyUserId` from existing
+documents and rebuild indexes, rather than a manual migration script — this matches how the
+project already handles one-time schema changes. Because there has only ever been one real user,
+this is a low-risk, single-pass rewrite, not a multi-tenant data migration.
+
+**Risk:** Medium. Requires careful index rebuild sequencing (`MongoIndexInitializer.kt`) to avoid
+downtime, and must run after Phase 3 so no code still reads/writes the dropped field.
+
+---
+
+## Phase 5: Configuration, tests, and deployment cleanup
+
+**Goal:** Remove now-dead configuration, test fixtures, and documentation references.
+
+* Remove `APP_ALLOWED_SPOTIFY_USER_IDS` from `docs/arc42/arc42.md` Configuration section,
+  deployment `.env` templates, and GitHub Actions secrets once Phase 1 has shipped.
+* Test fixtures that currently create multiple `test-user-a` / `test-user-b` accounts (see
+  `domain-impl`'s test profile allow-list default) should be reduced to a single test user.
+  Any test asserting "user B cannot see user A's data" becomes obsolete and should be removed
+  rather than adapted.
+* Review `docs/reviews/2026-07-08-performance-review.md` Findings 1, 2, and the "what breaks
+  first" multi-user scaling section — once this migration completes, note in that review (or a
+  follow-up note) that those risks are resolved by design.
+
+**Risk:** Low. Cleanup only, no behavioral change.
+
+---
+
+## Summary of risks across phases
+
+| Phase | Risk | Mitigation |
+|---|---|---|
+| 1 – Login/allow-list removal | Low | Permissive change; single real operator already unaffected. |
+| 2 – Scheduler fan-out & catalog-sync shortcut | Medium | Test "zero users" and "one user" cases explicitly. |
+| 3 – `UserId` threading removal | High | Split per bounded context; handle in-flight outbox payloads carrying stale `userId` fields during rollout. |
+| 4 – MongoDB schema/index cleanup | Medium | Use a one-time `Starter`; sequence after Phase 3; rebuild indexes without downtime. |
+| 5 – Config/tests/deploy cleanup | Low | Cleanup only. |
+
+## Out of scope
+
+* Any change to the Spotify OAuth flow itself beyond removing the allow-list check — the
+  Authorization Code Flow, token encryption, and session cookie mechanism are unaffected.
+* `app_artist`, `app_album`, `app_track` — already user-agnostic shared catalog data.

--- a/docs/releasenotes/snippets/issue-737-20260709-0702-bugfix.md
+++ b/docs/releasenotes/snippets/issue-737-20260709-0702-bugfix.md
@@ -1,0 +1,1 @@
+* Added a documented plan and architecture decision for simplifying the application to a strict single-user design.


### PR DESCRIPTION
## Summary
- Adds [ADR-0008](docs/adr/0008-single-user-architecture.md) documenting the decision to convert spotify-control to a strict single-user application.
- Adds a phased [migration plan](docs/plans/single-user-simplification.md) covering login/allow-list removal, scheduler/catalog-sync simplification, UserId removal from ports/adapters, MongoDB schema cleanup, and config/test/deploy cleanup.
- Updates [arc42.md](docs/arc42/arc42.md) to reflect the single-user direction and fixes a stale doc detail about the `app_playback` document `_id` format.
- Adds the required release note snippet.

This PR is documentation-only; implementation is left to follow-up PRs per the migration plan.

Closes #737.

Generated with [Claude Code](https://claude.ai/code)