### PR TITLE
Implement remaining Phase 3 slices: playback, playlist, catalog UserId removal

### DIFF
--- a/adapter-in-web/src/main/kotlin/de/chrgroth/spotify/control/adapter/in/web/PlaybackEventViewerResource.kt
+++ b/adapter-in-web/src/main/kotlin/de/chrgroth/spotify/control/adapter/in/web/PlaybackEventViewerResource.kt
@@ -1,12 +1,10 @@
 package de.chrgroth.spotify.control.adapter.`in`.web
 
-import de.chrgroth.spotify.control.domain.model.user.UserId
 import de.chrgroth.spotify.control.domain.port.`in`.playback.PlaybackEventViewerPort
 import io.quarkus.qute.Location
 import io.quarkus.qute.Template
 import io.quarkus.qute.TemplateInstance
 import io.quarkus.security.Authenticated
-import io.quarkus.security.identity.SecurityIdentity
 import jakarta.enterprise.context.ApplicationScoped
 import jakarta.ws.rs.GET
 import jakarta.ws.rs.Path
@@ -27,7 +25,6 @@ import kotlinx.datetime.toLocalDateTime
 class PlaybackEventViewerResource(
   @param:Location("playback-event-viewer.html")
   private val template: Template,
-  private val securityIdentity: SecurityIdentity,
   private val playbackEventViewer: PlaybackEventViewerPort,
 ) {
 
@@ -39,8 +36,7 @@ class PlaybackEventViewerResource(
     val requestedDate = dateParam?.let { runCatching { LocalDate.parse(it) }.getOrNull() } ?: today
     val date = if (requestedDate > today) today else requestedDate
 
-    val userId = UserId(securityIdentity.principal.name)
-    val result = playbackEventViewer.getEvents(userId, date)
+    val result = playbackEventViewer.getEvents(date)
 
     return template
       .data("result", result)

--- a/adapter-in-web/src/main/kotlin/de/chrgroth/spotify/control/adapter/in/web/PlaybackSettingsResource.kt
+++ b/adapter-in-web/src/main/kotlin/de/chrgroth/spotify/control/adapter/in/web/PlaybackSettingsResource.kt
@@ -49,8 +49,7 @@ class PlaybackSettingsResource(
   @Path("/rebuild")
   @Produces(MediaType.APPLICATION_JSON)
   fun rebuildPlaybackData(): Response {
-    val userId = UserId(securityIdentity.principal.name)
-    playback.enqueueRebuildPlaybackData(userId)
+    playback.enqueueRebuildPlaybackData()
     return Response.ok(mapOf("status" to "ok")).build()
   }
 

--- a/adapter-in-web/src/main/kotlin/de/chrgroth/spotify/control/adapter/in/web/PlaylistChecksResource.kt
+++ b/adapter-in-web/src/main/kotlin/de/chrgroth/spotify/control/adapter/in/web/PlaylistChecksResource.kt
@@ -1,13 +1,11 @@
 package de.chrgroth.spotify.control.adapter.`in`.web
 
 import de.chrgroth.spotify.control.domain.model.playlist.AppPlaylistCheck
-import de.chrgroth.spotify.control.domain.model.user.UserId
 import de.chrgroth.spotify.control.domain.port.`in`.playlist.PlaylistCheckPort
 import io.quarkus.qute.Location
 import io.quarkus.qute.Template
 import io.quarkus.qute.TemplateInstance
 import io.quarkus.security.Authenticated
-import io.quarkus.security.identity.SecurityIdentity
 import jakarta.enterprise.context.ApplicationScoped
 import jakarta.ws.rs.GET
 import jakarta.ws.rs.POST
@@ -27,7 +25,6 @@ import kotlin.time.toJavaInstant
 class PlaylistChecksResource(
   @param:Location("playlist-checks.html")
   private val playlistChecksTemplate: Template,
-  private val securityIdentity: SecurityIdentity,
   private val playlistCheckPort: PlaylistCheckPort,
 ) {
 
@@ -35,8 +32,7 @@ class PlaylistChecksResource(
   @Authenticated
   @Produces(MediaType.TEXT_HTML)
   fun playlistChecks(): TemplateInstance {
-    val userId = UserId(securityIdentity.principal.name)
-    val dashboard = playlistCheckPort.getCheckDashboard(userId)
+    val dashboard = playlistCheckPort.getCheckDashboard()
     val groups = dashboard.checks
       .map { check ->
         PlaylistCheckRow(
@@ -64,8 +60,7 @@ class PlaylistChecksResource(
     @PathParam("playlistId") playlistId: String,
     @PathParam("checkType") checkType: String,
   ): Response {
-    val userId = UserId(securityIdentity.principal.name)
-    return playlistCheckPort.runFix(userId, playlistId, checkType).fold(
+    return playlistCheckPort.runFix(playlistId, checkType).fold(
       ifLeft = { error -> Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity(mapOf("error" to error.code)).build() },
       ifRight = { Response.ok(mapOf("status" to "ok")).build() },
     )

--- a/adapter-in-web/src/main/kotlin/de/chrgroth/spotify/control/adapter/in/web/PlaylistSettingsResource.kt
+++ b/adapter-in-web/src/main/kotlin/de/chrgroth/spotify/control/adapter/in/web/PlaylistSettingsResource.kt
@@ -42,9 +42,9 @@ class PlaylistSettingsResource(
   fun playlist(): TemplateInstance {
     val userId = UserId(securityIdentity.principal.name)
     val displayName = userProfile.getDisplayName() ?: userId.value
-    val sortedPlaylists = playlist.getPlaylists(userId).sortedBy { it.name }
+    val sortedPlaylists = playlist.getPlaylists().sortedBy { it.name }
     val padWidth = sortedPlaylists.size.toString().length
-    val trackCounts = playlist.getTrackCounts(userId)
+    val trackCounts = playlist.getTrackCounts()
     val rows = sortedPlaylists.mapIndexed { index, playlistInfo ->
       PlaylistRow(
         lineNumber = (index + 1).toString().padStart(padWidth, '0'),
@@ -77,9 +77,9 @@ class PlaylistSettingsResource(
       ?: return Response.status(Response.Status.BAD_REQUEST)
         .entity(mapOf("error" to "Invalid sync status: ${request.syncStatus}"))
         .build()
-    return when (playlist.updateSyncStatus(userId, playlistId, syncStatus).isRight()) {
+    return when (playlist.updateSyncStatus(playlistId, syncStatus).isRight()) {
       true -> {
-        val updated = playlist.getPlaylists(userId).find { it.spotifyPlaylistId == playlistId }
+        val updated = playlist.getPlaylists().find { it.spotifyPlaylistId == playlistId }
         Response.ok(mapOf("syncStatus" to syncStatus.name, "type" to updated?.type?.name)).build()
       }
       false -> {
@@ -107,7 +107,7 @@ class PlaylistSettingsResource(
       ?: return Response.status(Response.Status.BAD_REQUEST)
         .entity(mapOf("error" to "Invalid playlist type: ${request.type}"))
         .build()
-    return playlist.updatePlaylistType(userId, playlistId, type).fold(
+    return playlist.updatePlaylistType(playlistId, type).fold(
       ifLeft = { error ->
         when (error) {
           PlaylistSyncError.PLAYLIST_TYPE_CONFLICT -> {
@@ -142,7 +142,7 @@ class PlaylistSettingsResource(
   @Produces(MediaType.APPLICATION_JSON)
   fun syncNow(): Response {
     val userId = UserId(securityIdentity.principal.name)
-    return playlist.syncPlaylists(userId).fold(
+    return playlist.syncPlaylists().fold(
       ifLeft = { error ->
         logger.error { "Playlist sync failed for user ${userId.value}: ${error.code}" }
         Response.status(Response.Status.INTERNAL_SERVER_ERROR)
@@ -159,7 +159,7 @@ class PlaylistSettingsResource(
   @Produces(MediaType.APPLICATION_JSON)
   fun syncPlaylist(@PathParam("playlistId") playlistId: String): Response {
     val userId = UserId(securityIdentity.principal.name)
-    return playlist.enqueueSyncPlaylistData(userId, playlistId).fold(
+    return playlist.enqueueSyncPlaylistData(playlistId).fold(
       ifLeft = { error ->
         when (error) {
           PlaylistSyncError.PLAYLIST_SYNC_INACTIVE -> {

--- a/adapter-in-web/src/main/kotlin/de/chrgroth/spotify/control/adapter/in/web/PlaylistsResource.kt
+++ b/adapter-in-web/src/main/kotlin/de/chrgroth/spotify/control/adapter/in/web/PlaylistsResource.kt
@@ -45,9 +45,9 @@ class PlaylistsResource(
   fun settings(): TemplateInstance {
     val userId = UserId(securityIdentity.principal.name)
     val displayName = userProfile.getDisplayName() ?: userId.value
-    val sortedPlaylists = playlist.getPlaylists(userId).sortedBy { it.name }
+    val sortedPlaylists = playlist.getPlaylists().sortedBy { it.name }
     val padWidth = sortedPlaylists.size.toString().length
-    val trackCounts = playlist.getTrackCounts(userId)
+    val trackCounts = playlist.getTrackCounts()
     val rows = sortedPlaylists.mapIndexed { index, playlistInfo ->
       PlaylistSettingsResource.PlaylistRow(
         lineNumber = (index + 1).toString().padStart(padWidth, '0'),

--- a/adapter-in-web/src/main/kotlin/de/chrgroth/spotify/control/adapter/in/web/SpotifyDebugResource.kt
+++ b/adapter-in-web/src/main/kotlin/de/chrgroth/spotify/control/adapter/in/web/SpotifyDebugResource.kt
@@ -15,7 +15,6 @@ import de.chrgroth.spotify.control.domain.model.playlist.PlaylistTracksPage
 import de.chrgroth.spotify.control.domain.model.playlist.SpotifyPlaylistItem
 import de.chrgroth.spotify.control.domain.model.user.AccessToken
 import de.chrgroth.spotify.control.domain.model.user.SpotifyProfile
-import de.chrgroth.spotify.control.domain.model.user.UserId
 import de.chrgroth.spotify.control.domain.port.`in`.catalog.CatalogBrowserPort
 import de.chrgroth.spotify.control.domain.port.`in`.playlist.PlaylistPort
 import de.chrgroth.spotify.control.domain.port.out.catalog.SpotifyCatalogPort
@@ -27,7 +26,6 @@ import io.quarkus.qute.Location
 import io.quarkus.qute.Template
 import io.quarkus.qute.TemplateInstance
 import io.quarkus.security.Authenticated
-import io.quarkus.security.identity.SecurityIdentity
 import jakarta.enterprise.context.ApplicationScoped
 import jakarta.ws.rs.GET
 import jakarta.ws.rs.POST
@@ -49,7 +47,6 @@ class SpotifyDebugResource(
   private val spotifyDebugTemplate: Template,
   private val catalogBrowser: CatalogBrowserPort,
   private val playlist: PlaylistPort,
-  private val securityIdentity: SecurityIdentity,
   private val spotifyAccessToken: SpotifyAccessTokenPort,
   private val spotifyAuth: SpotifyAuthPort,
   private val spotifyPlayback: SpotifyPlaybackPort,
@@ -86,9 +83,8 @@ class SpotifyDebugResource(
   @Produces(MediaType.APPLICATION_JSON)
   fun searchPlaylists(@QueryParam("filter") filter: String?): List<PickerOption> {
     if (filter.isNullOrBlank()) return emptyList()
-    val userId = UserId(securityIdentity.principal.name)
     val filterLower = filter.lowercase()
-    return playlist.getPlaylists(userId)
+    return playlist.getPlaylists()
       .filter { it.name.lowercase().contains(filterLower) }
       .map { PickerOption(it.spotifyPlaylistId, it.name) }
   }
@@ -100,7 +96,6 @@ class SpotifyDebugResource(
   fun execute(@PathParam("operation") operation: String, @Context uriInfo: UriInfo): Response {
     val params = uriInfo.queryParameters.entries
       .associate { (key, values) -> key to values.firstOrNull()?.takeIf { it.isNotBlank() } }
-    val userId = UserId(securityIdentity.principal.name)
 
     val accessToken = try {
       spotifyAccessToken.getValidAccessToken()
@@ -112,42 +107,42 @@ class SpotifyDebugResource(
       when (operation) {
         "current-user" -> spotifyAuth.getUserProfile(accessToken).toResponse(operation) { it.toJson() }
 
-        "currently-playing" -> spotifyPlayback.getCurrentlyPlaying(userId, accessToken).toResponse(operation) { it?.toJson() }
+        "currently-playing" -> spotifyPlayback.getCurrentlyPlaying(accessToken).toResponse(operation) { it?.toJson() }
 
         "recently-played" -> {
           val after = params["after"]?.toLongOrNull()?.let { Instant.fromEpochMilliseconds(it) }
-          spotifyPlayback.getRecentlyPlayed(userId, accessToken, after).toResponse(operation) { items -> items.map { it.toJson() } }
+          spotifyPlayback.getRecentlyPlayed(accessToken, after).toResponse(operation) { items -> items.map { it.toJson() } }
         }
 
-        "user-playlists" -> spotifyPlaylist.getPlaylists(userId, accessToken).toResponse(operation) { items -> items.map { it.toJson() } }
+        "user-playlists" -> spotifyPlaylist.getPlaylists(accessToken).toResponse(operation) { items -> items.map { it.toJson() } }
 
         "playlist-tracks" -> {
           val playlistId = params["playlistId"] ?: return errorResponse(operation, "playlistId is required")
           val pageUrl = params["pageUrl"]
-          spotifyPlaylist.getPlaylistTracksPage(userId, accessToken, playlistId, pageUrl).toResponse(operation) { it.toJson() }
+          spotifyPlaylist.getPlaylistTracksPage(accessToken, playlistId, pageUrl).toResponse(operation) { it.toJson() }
         }
 
         "artist" -> {
           val artistId = params["artistId"] ?: return errorResponse(operation, "artistId is required")
-          spotifyCatalog.getArtist(userId, accessToken, artistId).toResponse(operation) { it?.toJson() }
+          spotifyCatalog.getArtist(accessToken, artistId).toResponse(operation) { it?.toJson() }
         }
 
         "artist-albums" -> {
           val artistId = params["artistId"] ?: return errorResponse(operation, "artistId is required")
           val nextUrl = params["nextUrl"]
-          spotifyCatalog.getArtistAlbumsPage(userId, accessToken, artistId, nextUrl).toResponse(operation) { it.toJson() }
+          spotifyCatalog.getArtistAlbumsPage(accessToken, artistId, nextUrl).toResponse(operation) { it.toJson() }
         }
 
         "album" -> {
           val albumId = params["albumId"] ?: return errorResponse(operation, "albumId is required")
-          spotifyCatalog.getAlbum(userId, accessToken, albumId).toResponse(operation) { it.toJson() }
+          spotifyCatalog.getAlbum(accessToken, albumId).toResponse(operation) { it.toJson() }
         }
 
         "album-tracks" -> {
           val albumId = params["albumId"] ?: return errorResponse(operation, "albumId is required")
-          spotifyCatalog.getAlbum(userId, accessToken, albumId).fold(
+          spotifyCatalog.getAlbum(accessToken, albumId).fold(
             ifLeft = { errorResponse(operation, it.code) },
-            ifRight = { syncResult -> fetchAlbumTracks(operation, userId, accessToken, syncResult.album) },
+            ifRight = { syncResult -> fetchAlbumTracks(operation, accessToken, syncResult.album) },
           )
         }
 
@@ -158,8 +153,8 @@ class SpotifyDebugResource(
     }
   }
 
-  private fun fetchAlbumTracks(operation: String, userId: UserId, accessToken: AccessToken, album: AppAlbum): Response =
-    spotifyCatalog.getAlbumTracks(userId, accessToken, album).toResponse(operation) { tracks -> tracks.map { it.toJson() } }
+  private fun fetchAlbumTracks(operation: String, accessToken: AccessToken, album: AppAlbum): Response =
+    spotifyCatalog.getAlbumTracks(accessToken, album).toResponse(operation) { tracks -> tracks.map { it.toJson() } }
 
   private fun <T> Either<DomainError, T>.toResponse(operation: String, mapper: (T) -> Any?): Response =
     fold(

--- a/adapter-out-spotify/src/main/kotlin/de/chrgroth/spotify/control/adapter/out/spotify/SpotifyCatalogAdapter.kt
+++ b/adapter-out-spotify/src/main/kotlin/de/chrgroth/spotify/control/adapter/out/spotify/SpotifyCatalogAdapter.kt
@@ -23,7 +23,6 @@ import de.chrgroth.spotify.control.domain.model.catalog.ArtistAlbumsPage
 import de.chrgroth.spotify.control.domain.model.catalog.ArtistId
 import de.chrgroth.spotify.control.domain.model.catalog.TrackId
 import de.chrgroth.spotify.control.domain.model.user.AccessToken
-import de.chrgroth.spotify.control.domain.model.user.UserId
 import de.chrgroth.spotify.control.domain.outbox.DomainOutboxPartition
 import de.chrgroth.spotify.control.domain.port.out.catalog.SpotifyCatalogPort
 import jakarta.enterprise.context.ApplicationScoped
@@ -42,7 +41,6 @@ class SpotifyCatalogAdapter(
 ) : SpotifyCatalogPort {
 
   override fun getArtist(
-    userId: UserId,
     accessToken: AccessToken,
     artistId: String,
   ): Either<DomainError, AppArtist?> {
@@ -57,7 +55,7 @@ class SpotifyCatalogAdapter(
       logger.error { "Spotify artist fetch failed for $artistId: ${e.statusCode}" }
       SyncError.ARTIST_DETAILS_FETCH_FAILED.left()
     } catch (e: Exception) {
-      logger.error(e) { "Unexpected error fetching artist details for artist $artistId (user ${userId.value})" }
+      logger.error(e) { "Unexpected error fetching artist details for artist $artistId" }
       SyncError.ARTIST_DETAILS_FETCH_FAILED.left()
     } finally {
       SpotifyApiAuthContext.clear()
@@ -65,7 +63,6 @@ class SpotifyCatalogAdapter(
   }
 
   override fun getAlbum(
-    userId: UserId,
     accessToken: AccessToken,
     albumId: String,
   ): Either<DomainError, AlbumSyncResult> {
@@ -99,11 +96,11 @@ class SpotifyCatalogAdapter(
     } catch (e: SpotifyRateLimitException) {
       SpotifyRateLimitError(e.retryAfterSeconds.seconds).left()
     } catch (e: SpotifyApiException) {
-      logger.error { "Spotify album fetch failed for $albumId (user ${userId.value}): status=${e.statusCode}, body=${e.body.take(500)}" }
+      logger.error { "Spotify album fetch failed for $albumId: status=${e.statusCode}, body=${e.body.take(500)}" }
       SyncError.TRACK_DETAILS_FETCH_FAILED.left()
     } catch (e: Exception) {
       logger.error(e) {
-        "Unexpected error fetching album tracks for album $albumId (user ${userId.value}): ${e::class.simpleName}: ${e.message}"
+        "Unexpected error fetching album tracks for album $albumId: ${e::class.simpleName}: ${e.message}"
       }
       SyncError.TRACK_DETAILS_FETCH_FAILED.left()
     } finally {
@@ -112,7 +109,6 @@ class SpotifyCatalogAdapter(
   }
 
   override fun getAlbumTracks(
-    userId: UserId,
     accessToken: AccessToken,
     album: AppAlbum,
   ): Either<DomainError, List<AppTrack>> {
@@ -142,11 +138,11 @@ class SpotifyCatalogAdapter(
     } catch (e: SpotifyRateLimitException) {
       SpotifyRateLimitError(e.retryAfterSeconds.seconds).left()
     } catch (e: SpotifyApiException) {
-      logger.error { "Spotify album tracks fetch failed for $albumId (user ${userId.value}): status=${e.statusCode}, body=${e.body.take(500)}" }
+      logger.error { "Spotify album tracks fetch failed for $albumId: status=${e.statusCode}, body=${e.body.take(500)}" }
       SyncError.TRACK_DETAILS_FETCH_FAILED.left()
     } catch (e: Exception) {
       logger.error(e) {
-        "Unexpected error fetching album tracks for album $albumId (user ${userId.value}): ${e::class.simpleName}: ${e.message}"
+        "Unexpected error fetching album tracks for album $albumId: ${e::class.simpleName}: ${e.message}"
       }
       SyncError.TRACK_DETAILS_FETCH_FAILED.left()
     } finally {
@@ -155,7 +151,6 @@ class SpotifyCatalogAdapter(
   }
 
   override fun getArtistAlbumsPage(
-    userId: UserId,
     accessToken: AccessToken,
     artistId: String,
     nextUrl: String?,
@@ -174,7 +169,7 @@ class SpotifyCatalogAdapter(
       logger.error { "Spotify artist albums fetch failed for $artistId: ${e.statusCode}" }
       SyncError.ARTIST_DETAILS_FETCH_FAILED.left()
     } catch (e: Exception) {
-      logger.error(e) { "Unexpected error fetching album ids for artist $artistId (user ${userId.value})" }
+      logger.error(e) { "Unexpected error fetching album ids for artist $artistId" }
       SyncError.ARTIST_DETAILS_FETCH_FAILED.left()
     } finally {
       SpotifyApiAuthContext.clear()

--- a/adapter-out-spotify/src/main/kotlin/de/chrgroth/spotify/control/adapter/out/spotify/SpotifyPlaybackAdapter.kt
+++ b/adapter-out-spotify/src/main/kotlin/de/chrgroth/spotify/control/adapter/out/spotify/SpotifyPlaybackAdapter.kt
@@ -33,13 +33,13 @@ class SpotifyPlaybackAdapter(
   @param:RestClient private val apiClient: SpotifyApiRestClient,
 ) : SpotifyPlaybackPort {
 
-  override fun getCurrentlyPlaying(userId: UserId, accessToken: AccessToken): Either<DomainError, CurrentlyPlayingItem?> {
+  override fun getCurrentlyPlaying(accessToken: AccessToken): Either<DomainError, CurrentlyPlayingItem?> {
     return try {
       SpotifyApiAuthContext.set(accessToken)
       val currentlyPlaying = httpMetrics.timed("/v1/me/player/currently-playing") {
         apiClient.getCurrentlyPlaying()
       }
-      parseCurrentlyPlayingItem(userId, currentlyPlaying).right()
+      parseCurrentlyPlayingItem(currentlyPlaying).right()
     } catch (e: SpotifyNoContentException) {
       logger.debug(e) { "No currently playing item (204 No Content)" }
       null.right()
@@ -56,7 +56,7 @@ class SpotifyPlaybackAdapter(
     }
   }
 
-  private fun parseCurrentlyPlayingItem(userId: UserId, response: CurrentlyPlayingContextObject): CurrentlyPlayingItem? {
+  private fun parseCurrentlyPlayingItem(response: CurrentlyPlayingContextObject): CurrentlyPlayingItem? {
     val track = response.item?.let { decodeTrack(it) } ?: return null
     val trackId = track.id
     if (track.type != TrackObject.Type.TRACK || track.isLocal == true || trackId == null) {
@@ -65,7 +65,8 @@ class SpotifyPlaybackAdapter(
     val progressMs = response.progressMs ?: 0L
     val observedAt = Clock.System.now()
     return CurrentlyPlayingItem(
-      spotifyUserId = userId,
+      // stamped with the real user by PlaybackService, which resolves "the" current user
+      spotifyUserId = PLACEHOLDER_USER_ID,
       trackId = TrackId(trackId),
       trackName = track.name ?: "",
       artistIds = track.artists?.mapNotNull { it.id?.let { id -> ArtistId(id) } } ?: emptyList(),
@@ -79,7 +80,7 @@ class SpotifyPlaybackAdapter(
     )
   }
 
-  override fun getRecentlyPlayed(userId: UserId, accessToken: AccessToken, after: Instant?): Either<DomainError, List<RecentlyPlayedItem>> {
+  override fun getRecentlyPlayed(accessToken: AccessToken, after: Instant?): Either<DomainError, List<RecentlyPlayedItem>> {
     return try {
       SpotifyApiAuthContext.set(accessToken)
       val allItems = mutableListOf<RecentlyPlayedItem>()
@@ -91,7 +92,7 @@ class SpotifyPlaybackAdapter(
         }
         recentlyPlayed.items?.mapNotNullTo(allItems) { item ->
           val track = item.track ?: return@mapNotNullTo null
-          parseRecentlyPlayedItem(userId, track, item.playedAt ?: return@mapNotNullTo null)
+          parseRecentlyPlayedItem(track, item.playedAt ?: return@mapNotNullTo null)
         }
         val nextUrl = recentlyPlayed.next
         if (nextUrl == null) {
@@ -115,7 +116,7 @@ class SpotifyPlaybackAdapter(
     }
   }
 
-  private fun parseRecentlyPlayedItem(userId: UserId, track: TrackObject, playedAt: String): RecentlyPlayedItem? {
+  private fun parseRecentlyPlayedItem(track: TrackObject, playedAt: String): RecentlyPlayedItem? {
     if (track.type != TrackObject.Type.TRACK) {
       return null
     }
@@ -125,7 +126,8 @@ class SpotifyPlaybackAdapter(
     val durationSeconds = track.durationMs?.let { it.toLong() / MS_PER_SECOND }
     val playedAtInstant = Instant.parse(playedAt)
     return RecentlyPlayedItem(
-      spotifyUserId = userId,
+      // stamped with the real user by PlaybackService, which resolves "the" current user
+      spotifyUserId = PLACEHOLDER_USER_ID,
       trackId = TrackId(track.id),
       trackName = track.name ?: "",
       artistIds = track.artists?.mapNotNull { it.id?.let { id -> ArtistId(id) } } ?: emptyList(),
@@ -143,5 +145,6 @@ class SpotifyPlaybackAdapter(
   companion object : KLogging() {
     private const val MS_PER_SECOND = 1_000L
     private const val RECENTLY_PLAYED_LIMIT = 50
+    private val PLACEHOLDER_USER_ID = UserId("")
   }
 }

--- a/adapter-out-spotify/src/main/kotlin/de/chrgroth/spotify/control/adapter/out/spotify/SpotifyPlaylistAdapter.kt
+++ b/adapter-out-spotify/src/main/kotlin/de/chrgroth/spotify/control/adapter/out/spotify/SpotifyPlaylistAdapter.kt
@@ -24,7 +24,6 @@ import de.chrgroth.spotify.control.domain.model.playlist.PlaylistTrack
 import de.chrgroth.spotify.control.domain.model.playlist.PlaylistTracksPage
 import de.chrgroth.spotify.control.domain.model.playlist.SpotifyPlaylistItem
 import de.chrgroth.spotify.control.domain.model.user.AccessToken
-import de.chrgroth.spotify.control.domain.model.user.UserId
 import de.chrgroth.spotify.control.domain.outbox.DomainOutboxPartition
 import de.chrgroth.spotify.control.domain.port.out.playlist.SpotifyPlaylistPort
 import jakarta.enterprise.context.ApplicationScoped
@@ -41,7 +40,7 @@ class SpotifyPlaylistAdapter(
   @param:RestClient private val apiClient: SpotifyApiRestClient,
 ) : SpotifyPlaylistPort {
 
-  override fun getPlaylists(userId: UserId, accessToken: AccessToken): Either<DomainError, List<SpotifyPlaylistItem>> {
+  override fun getPlaylists(accessToken: AccessToken): Either<DomainError, List<SpotifyPlaylistItem>> {
     return try {
       SpotifyApiAuthContext.set(accessToken)
       val items = mutableListOf<SpotifyPlaylistItem>()
@@ -73,14 +72,14 @@ class SpotifyPlaylistAdapter(
       logger.error { "Spotify playlist fetch failed: ${e.statusCode}" }
       PlaylistSyncError.PLAYLIST_FETCH_FAILED.left()
     } catch (e: Exception) {
-      logger.error(e) { "Unexpected error during playlist fetch for user ${userId.value}" }
+      logger.error(e) { "Unexpected error during playlist fetch" }
       PlaylistSyncError.PLAYLIST_FETCH_FAILED.left()
     } finally {
       SpotifyApiAuthContext.clear()
     }
   }
 
-  override fun getPlaylistTracks(userId: UserId, accessToken: AccessToken, playlistId: String): Either<DomainError, Playlist> {
+  override fun getPlaylistTracks(accessToken: AccessToken, playlistId: String): Either<DomainError, Playlist> {
     return try {
       SpotifyApiAuthContext.set(accessToken)
       val tracks = mutableListOf<PlaylistTrack>()
@@ -110,14 +109,14 @@ class SpotifyPlaylistAdapter(
       logger.error { "Spotify playlist tracks fetch failed for $playlistId: ${e.statusCode}" }
       PlaylistSyncError.PLAYLIST_TRACKS_FETCH_FAILED.left()
     } catch (e: Exception) {
-      logger.error(e) { "Unexpected error during playlist tracks fetch for playlist $playlistId (user ${userId.value})" }
+      logger.error(e) { "Unexpected error during playlist tracks fetch for playlist $playlistId" }
       PlaylistSyncError.PLAYLIST_TRACKS_FETCH_FAILED.left()
     } finally {
       SpotifyApiAuthContext.clear()
     }
   }
 
-  override fun getPlaylistTracksPage(userId: UserId, accessToken: AccessToken, playlistId: String, pageUrl: String?): Either<DomainError, PlaylistTracksPage> {
+  override fun getPlaylistTracksPage(accessToken: AccessToken, playlistId: String, pageUrl: String?): Either<DomainError, PlaylistTracksPage> {
     return try {
       SpotifyApiAuthContext.set(accessToken)
       val offset = pageUrl?.queryParamInt("offset")
@@ -136,7 +135,7 @@ class SpotifyPlaylistAdapter(
       logger.error { "Spotify playlist tracks page fetch failed for $playlistId: ${e.statusCode}" }
       PlaylistSyncError.PLAYLIST_TRACKS_FETCH_FAILED.left()
     } catch (e: Exception) {
-      logger.error(e) { "Unexpected error during playlist tracks page fetch for playlist $playlistId (user ${userId.value})" }
+      logger.error(e) { "Unexpected error during playlist tracks page fetch for playlist $playlistId" }
       PlaylistSyncError.PLAYLIST_TRACKS_FETCH_FAILED.left()
     } finally {
       SpotifyApiAuthContext.clear()
@@ -174,7 +173,6 @@ class SpotifyPlaylistAdapter(
     }
 
   override fun removePlaylistTracks(
-    userId: UserId,
     accessToken: AccessToken,
     playlistId: String,
     trackIds: List<String>,
@@ -194,7 +192,7 @@ class SpotifyPlaylistAdapter(
       logger.error { "Spotify track removal failed for playlist $playlistId: ${e.statusCode}" }
       PlaylistFixError.FIX_FAILED.left()
     } catch (e: Exception) {
-      logger.error(e) { "Unexpected error during track removal from playlist $playlistId (user ${userId.value})" }
+      logger.error(e) { "Unexpected error during track removal from playlist $playlistId" }
       PlaylistFixError.FIX_FAILED.left()
     } finally {
       SpotifyApiAuthContext.clear()
@@ -202,7 +200,6 @@ class SpotifyPlaylistAdapter(
   }
 
   override fun addPlaylistTracks(
-    userId: UserId,
     accessToken: AccessToken,
     playlistId: String,
     trackIds: List<String>,
@@ -222,7 +219,7 @@ class SpotifyPlaylistAdapter(
       logger.error { "Spotify track addition failed for playlist $playlistId: ${e.statusCode}" }
       PlaylistFixError.FIX_FAILED.left()
     } catch (e: Exception) {
-      logger.error(e) { "Unexpected error during track addition to playlist $playlistId (user ${userId.value})" }
+      logger.error(e) { "Unexpected error during track addition to playlist $playlistId" }
       PlaylistFixError.FIX_FAILED.left()
     } finally {
       SpotifyApiAuthContext.clear()
@@ -230,7 +227,6 @@ class SpotifyPlaylistAdapter(
   }
 
   override fun replacePlaylistTrack(
-    userId: UserId,
     accessToken: AccessToken,
     playlistId: String,
     oldTrackId: String,
@@ -258,7 +254,7 @@ class SpotifyPlaylistAdapter(
       logger.error { "Spotify track replacement failed for playlist $playlistId: ${e.statusCode}" }
       PlaylistFixError.FIX_FAILED.left()
     } catch (e: Exception) {
-      logger.error(e) { "Unexpected error during track replacement in playlist $playlistId (user ${userId.value})" }
+      logger.error(e) { "Unexpected error during track replacement in playlist $playlistId" }
       PlaylistFixError.FIX_FAILED.left()
     } finally {
       SpotifyApiAuthContext.clear()

--- a/application-quarkus/src/test/kotlin/de/chrgroth/spotify/control/adapter/out/mongodb/OutboxAdminPortAdapterTests.kt
+++ b/application-quarkus/src/test/kotlin/de/chrgroth/spotify/control/adapter/out/mongodb/OutboxAdminPortAdapterTests.kt
@@ -1,6 +1,5 @@
 package de.chrgroth.spotify.control.adapter.out.mongodb
 
-import de.chrgroth.spotify.control.domain.model.user.UserId
 import de.chrgroth.spotify.control.domain.outbox.DomainOutboxEvent
 import de.chrgroth.spotify.control.domain.outbox.DomainOutboxPartition
 import de.chrgroth.spotify.control.domain.port.out.infra.OutboxAdminPort
@@ -9,7 +8,6 @@ import io.quarkus.test.junit.QuarkusTest
 import jakarta.inject.Inject
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import java.util.UUID
 
 @QuarkusTest
 class OutboxAdminPortAdapterTests {
@@ -22,8 +20,7 @@ class OutboxAdminPortAdapterTests {
 
   @Test
   fun `wipeAll removes all enqueued outbox tasks and partition documents`() {
-    val userId = UserId("user-${UUID.randomUUID()}")
-    outbox.enqueue(DomainOutboxEvent.FetchPlaybackData(userId))
+    outbox.enqueue(DomainOutboxEvent.FetchPlaybackData())
 
     outboxAdmin.wipeAll()
 

--- a/application-quarkus/src/test/kotlin/de/chrgroth/spotify/control/adapter/out/spotify/SpotifyCurrentlyPlayingAdapterTests.kt
+++ b/application-quarkus/src/test/kotlin/de/chrgroth/spotify/control/adapter/out/spotify/SpotifyCurrentlyPlayingAdapterTests.kt
@@ -4,7 +4,6 @@ import arrow.core.Either
 import de.chrgroth.spotify.control.domain.model.user.AccessToken
 import de.chrgroth.spotify.control.domain.model.catalog.ArtistId
 import de.chrgroth.spotify.control.domain.model.catalog.TrackId
-import de.chrgroth.spotify.control.domain.model.user.UserId
 import de.chrgroth.spotify.control.domain.port.out.playback.SpotifyPlaybackPort
 import io.quarkus.test.junit.QuarkusTest
 import jakarta.inject.Inject
@@ -19,7 +18,7 @@ class SpotifyCurrentlyPlayingAdapterTests {
 
   @Test
   fun `getCurrentlyPlaying returns item from mock`() {
-    val result = spotifyPlayback.getCurrentlyPlaying(UserId("test-user-a"), AccessToken("mock-access-token"))
+    val result = spotifyPlayback.getCurrentlyPlaying(AccessToken("mock-access-token"))
 
     assertThat(result).isInstanceOf(Either.Right::class.java)
     val item = (result as Either.Right).value
@@ -31,12 +30,11 @@ class SpotifyCurrentlyPlayingAdapterTests {
     assertThat(item.progressMs).isEqualTo(45000L)
     assertThat(item.durationMs).isEqualTo(200000L)
     assertThat(item.isPlaying).isTrue()
-    assertThat(item.spotifyUserId).isEqualTo(UserId("test-user-a"))
   }
 
   @Test
   fun `getCurrentlyPlaying records spotify request metrics`() {
-    spotifyPlayback.getCurrentlyPlaying(UserId("test-user-a"), AccessToken("mock-access-token"))
+    spotifyPlayback.getCurrentlyPlaying(AccessToken("mock-access-token"))
 
     // Metrics are recorded via shared SpotifyHttpMetrics
     assertThat(true).isTrue()

--- a/application-quarkus/src/test/kotlin/de/chrgroth/spotify/control/adapter/out/spotify/SpotifyPlaylistTracksAdapterTests.kt
+++ b/application-quarkus/src/test/kotlin/de/chrgroth/spotify/control/adapter/out/spotify/SpotifyPlaylistTracksAdapterTests.kt
@@ -5,7 +5,6 @@ import de.chrgroth.spotify.control.domain.model.user.AccessToken
 import de.chrgroth.spotify.control.domain.model.catalog.AlbumId
 import de.chrgroth.spotify.control.domain.model.catalog.ArtistId
 import de.chrgroth.spotify.control.domain.model.catalog.TrackId
-import de.chrgroth.spotify.control.domain.model.user.UserId
 import de.chrgroth.spotify.control.domain.port.out.infra.OutgoingRequestStatsPort
 import de.chrgroth.spotify.control.domain.port.out.playlist.SpotifyPlaylistPort
 import io.micrometer.core.instrument.MeterRegistry
@@ -28,7 +27,7 @@ class SpotifyPlaylistTracksAdapterTests {
 
   @Test
   fun `getPlaylistTracks returns tracks from mock`() {
-    val result = spotifyPlaylist.getPlaylistTracks(UserId("test-user-a"), AccessToken("mock-access-token"), "mock-playlist-1")
+    val result = spotifyPlaylist.getPlaylistTracks(AccessToken("mock-access-token"), "mock-playlist-1")
 
     assertThat(result).isInstanceOf(Either.Right::class.java)
     val playlist = (result as Either.Right).value
@@ -41,7 +40,7 @@ class SpotifyPlaylistTracksAdapterTests {
 
   @Test
   fun `getPlaylistTracks filters out non-track items`() {
-    val result = spotifyPlaylist.getPlaylistTracks(UserId("test-user-a"), AccessToken("mock-access-token"), "mock-playlist-1")
+    val result = spotifyPlaylist.getPlaylistTracks(AccessToken("mock-access-token"), "mock-playlist-1")
 
     assertThat(result).isInstanceOf(Either.Right::class.java)
     val playlist = (result as Either.Right).value
@@ -50,7 +49,7 @@ class SpotifyPlaylistTracksAdapterTests {
 
   @Test
   fun `getPlaylistTracks filters out null track items`() {
-    val result = spotifyPlaylist.getPlaylistTracks(UserId("test-user-a"), AccessToken("mock-access-token"), "mock-playlist-1")
+    val result = spotifyPlaylist.getPlaylistTracks(AccessToken("mock-access-token"), "mock-playlist-1")
 
     assertThat(result).isInstanceOf(Either.Right::class.java)
     val playlist = (result as Either.Right).value
@@ -59,7 +58,7 @@ class SpotifyPlaylistTracksAdapterTests {
 
   @Test
   fun `getPlaylistTracks handles null items in the items list`() {
-    val result = spotifyPlaylist.getPlaylistTracks(UserId("test-user-a"), AccessToken("mock-access-token"), "mock-playlist-1")
+    val result = spotifyPlaylist.getPlaylistTracks(AccessToken("mock-access-token"), "mock-playlist-1")
 
     assertThat(result).isInstanceOf(Either.Right::class.java)
     val playlist = (result as Either.Right).value
@@ -68,7 +67,7 @@ class SpotifyPlaylistTracksAdapterTests {
 
   @Test
   fun `getPlaylistTracks includes track with null album id`() {
-    val result = spotifyPlaylist.getPlaylistTracks(UserId("test-user-a"), AccessToken("mock-access-token"), "mock-playlist-2")
+    val result = spotifyPlaylist.getPlaylistTracks(AccessToken("mock-access-token"), "mock-playlist-2")
 
     assertThat(result).isInstanceOf(Either.Right::class.java)
     val playlist = (result as Either.Right).value
@@ -80,7 +79,7 @@ class SpotifyPlaylistTracksAdapterTests {
 
   @Test
   fun `getPlaylistTracks includes track with album id when present`() {
-    val result = spotifyPlaylist.getPlaylistTracks(UserId("test-user-a"), AccessToken("mock-access-token"), "mock-playlist-2")
+    val result = spotifyPlaylist.getPlaylistTracks(AccessToken("mock-access-token"), "mock-playlist-2")
 
     assertThat(result).isInstanceOf(Either.Right::class.java)
     val playlist = (result as Either.Right).value
@@ -91,7 +90,7 @@ class SpotifyPlaylistTracksAdapterTests {
 
   @Test
   fun `getPlaylistTracks includes track with null artist id skipping that artist`() {
-    val result = spotifyPlaylist.getPlaylistTracks(UserId("test-user-a"), AccessToken("mock-access-token"), "mock-playlist-3")
+    val result = spotifyPlaylist.getPlaylistTracks(AccessToken("mock-access-token"), "mock-playlist-3")
 
     assertThat(result).isInstanceOf(Either.Right::class.java)
     val playlist = (result as Either.Right).value
@@ -102,7 +101,7 @@ class SpotifyPlaylistTracksAdapterTests {
 
   @Test
   fun `getPlaylistTracks includes track when only non-null artists are returned`() {
-    val result = spotifyPlaylist.getPlaylistTracks(UserId("test-user-a"), AccessToken("mock-access-token"), "mock-playlist-3")
+    val result = spotifyPlaylist.getPlaylistTracks(AccessToken("mock-access-token"), "mock-playlist-3")
 
     assertThat(result).isInstanceOf(Either.Right::class.java)
     val playlist = (result as Either.Right).value
@@ -111,7 +110,7 @@ class SpotifyPlaylistTracksAdapterTests {
 
   @Test
   fun `getPlaylistTracks records spotify request metrics`() {
-    spotifyPlaylist.getPlaylistTracks(UserId("test-user-a"), AccessToken("mock-access-token"), "mock-playlist-1")
+    spotifyPlaylist.getPlaylistTracks(AccessToken("mock-access-token"), "mock-playlist-1")
 
     val timer = meterRegistry.find("spotify.request").timer()
     assertThat(timer).isNotNull
@@ -120,7 +119,7 @@ class SpotifyPlaylistTracksAdapterTests {
 
   @Test
   fun `getPlaylistTracks increments in-memory request counter`() {
-    spotifyPlaylist.getPlaylistTracks(UserId("test-user-a"), AccessToken("mock-access-token"), "mock-playlist-1")
+    spotifyPlaylist.getPlaylistTracks(AccessToken("mock-access-token"), "mock-playlist-1")
 
     val stats = outgoingRequestStats.getRequestStats()
     assertThat(stats).isNotEmpty

--- a/application-quarkus/src/test/kotlin/de/chrgroth/spotify/control/adapter/out/spotify/SpotifyRecentlyPlayedAdapterTests.kt
+++ b/application-quarkus/src/test/kotlin/de/chrgroth/spotify/control/adapter/out/spotify/SpotifyRecentlyPlayedAdapterTests.kt
@@ -4,7 +4,6 @@ import arrow.core.Either
 import de.chrgroth.spotify.control.domain.model.user.AccessToken
 import de.chrgroth.spotify.control.domain.model.catalog.ArtistId
 import de.chrgroth.spotify.control.domain.model.catalog.TrackId
-import de.chrgroth.spotify.control.domain.model.user.UserId
 import de.chrgroth.spotify.control.domain.port.out.playback.SpotifyPlaybackPort
 import de.chrgroth.spotify.control.domain.port.out.infra.OutgoingRequestStatsPort
 import io.micrometer.core.instrument.MeterRegistry
@@ -28,7 +27,7 @@ class SpotifyRecentlyPlayedAdapterTests {
 
   @Test
   fun `getRecentlyPlayed returns items from mock`() {
-    val result = spotifyPlayback.getRecentlyPlayed(UserId("test-user-a"), AccessToken("mock-access-token"))
+    val result = spotifyPlayback.getRecentlyPlayed(AccessToken("mock-access-token"))
 
     assertThat(result).isInstanceOf(Either.Right::class.java)
     val items = (result as Either.Right).value
@@ -37,14 +36,13 @@ class SpotifyRecentlyPlayedAdapterTests {
     assertThat(items[0].trackName).isEqualTo("Track One")
     assertThat(items[0].artistIds).containsExactly(ArtistId("artist-1"))
     assertThat(items[0].artistNames).containsExactly("Artist One")
-    assertThat(items[0].spotifyUserId).isEqualTo(UserId("test-user-a"))
     assertThat(items[0].durationSeconds).isEqualTo(210L)
   }
 
   @Test
   fun `getRecentlyPlayed with after parameter returns items from mock`() {
     val after = Instant.parse("2024-01-01T00:00:00Z")
-    val result = spotifyPlayback.getRecentlyPlayed(UserId("test-user-a"), AccessToken("mock-access-token"), after)
+    val result = spotifyPlayback.getRecentlyPlayed(AccessToken("mock-access-token"), after)
 
     assertThat(result).isInstanceOf(Either.Right::class.java)
     val items = (result as Either.Right).value
@@ -54,7 +52,7 @@ class SpotifyRecentlyPlayedAdapterTests {
 
   @Test
   fun `getRecentlyPlayed filters out podcast episodes`() {
-    val result = spotifyPlayback.getRecentlyPlayed(UserId("test-user-a"), AccessToken("mock-access-token"))
+    val result = spotifyPlayback.getRecentlyPlayed(AccessToken("mock-access-token"))
 
     assertThat(result).isInstanceOf(Either.Right::class.java)
     val items = (result as Either.Right).value
@@ -63,7 +61,7 @@ class SpotifyRecentlyPlayedAdapterTests {
 
   @Test
   fun `getRecentlyPlayed filters out local tracks`() {
-    val result = spotifyPlayback.getRecentlyPlayed(UserId("test-user-a"), AccessToken("mock-access-token"))
+    val result = spotifyPlayback.getRecentlyPlayed(AccessToken("mock-access-token"))
 
     assertThat(result).isInstanceOf(Either.Right::class.java)
     val items = (result as Either.Right).value
@@ -72,7 +70,7 @@ class SpotifyRecentlyPlayedAdapterTests {
 
   @Test
   fun `getRecentlyPlayed records spotify request metrics`() {
-    spotifyPlayback.getRecentlyPlayed(UserId("test-user-a"), AccessToken("mock-access-token"))
+    spotifyPlayback.getRecentlyPlayed(AccessToken("mock-access-token"))
 
     val timer = meterRegistry.find("spotify.request").timer()
     assertThat(timer).isNotNull
@@ -81,7 +79,7 @@ class SpotifyRecentlyPlayedAdapterTests {
 
   @Test
   fun `getRecentlyPlayed increments in-memory request counter`() {
-    spotifyPlayback.getRecentlyPlayed(UserId("test-user-a"), AccessToken("mock-access-token"))
+    spotifyPlayback.getRecentlyPlayed(AccessToken("mock-access-token"))
 
     val stats = outgoingRequestStats.getRequestStats()
     assertThat(stats).isNotEmpty

--- a/docs/arc42/arc42.md
+++ b/docs/arc42/arc42.md
@@ -514,7 +514,7 @@ SLACK_WEBHOOK_URL
 | Enrichment completeness | `app_artist`, `app_track`, and `app_album` entries that existed before enrichment was introduced may lack imageLink or albumTitle until re-enriched. |
 | Partial-play detection accuracy | Partial play detection relies on polling frequency; very short plays near the end of a track may be missed or misclassified. |
 | Test coverage for domain adapters | Domain adapter integration (e.g. `PlaybackDataAdapter`, `PlaylistSyncAdapter`) is not yet covered by `@QuarkusTest` boundary tests. |
-| Multi-user plumbing | `UserId` is still threaded through ports, services, outbox events, and MongoDB document keys even though the application only ever supports a single user. Tracked by [ADR-0008](../adr/0008-single-user-architecture.md) and the [single-user simplification plan](../plans/single-user-simplification.md). |
+| Multi-user plumbing | `UserId` is no longer part of any port's public signature (Phase 3 of the [single-user simplification plan](../plans/single-user-simplification.md) is complete), but repository out-ports and MongoDB document keys still carry `spotifyUserId` internally until Phase 4 migrates the schema. Tracked by [ADR-0008](../adr/0008-single-user-architecture.md). |
 
 # Glossary
 

--- a/docs/plans/single-user-simplification.md
+++ b/docs/plans/single-user-simplification.md
@@ -64,7 +64,7 @@ afterward, since it becomes structurally impossible.
 
 ---
 
-## Phase 3: Thread removal of `UserId` through ports and services — in progress
+## Phase 3: Thread removal of `UserId` through ports and services — done
 
 **Goal:** Drop `UserId` parameters from ports, services, and outbox events where they only ever
 existed to distinguish between users, once Phase 2 has established that there is exactly one user.
@@ -91,36 +91,33 @@ a `UserId`; `DashboardService` resolves the one stored user internally via `Curr
 there is only ever one possible subscriber. `DashboardResource`, `PlaybackResource`, and
 `DashboardSseResource` updated their call sites accordingly.
 
-Remaining slices (playback, playlist, catalog) are still open. These are substantially larger:
-unlike the slices above, the `UserId` in `PlaybackPort`, `PlaylistPort`, `PlaylistCheckPort`,
-`PlaybackEventViewerPort`, `CatalogPort`, `SpotifyPlaybackPort`, `SpotifyCatalogPort`, and
-`SpotifyPlaylistPort` also flows into repository out-ports (`AppPlaybackRepositoryPort`,
-`PlaylistRepositoryPort`, `CurrentlyPlayingRepositoryPort`, etc.) that still key their MongoDB
-queries by `spotifyUserId` until Phase 4 migrates the schema, and into every `adapter-in-web`
-resource. Per the risk note below, do these as separate, bounded-context PRs rather than one large
-change.
+**Playback, playlist, and catalog slices — done:** `PlaybackPort` (`fetchPlaybackData`,
+`enqueueRebuildPlaybackData`, `rebuildPlaybackData`, `appendPlaybackData`), `PlaybackEventViewerPort
+.getEvents()`, `PlaylistPort` (`getPlaylists`, `getTrackCounts`, `syncPlaylists`,
+`syncPlaylistData`, `updateSyncStatus`, `updatePlaylistType`, `enqueueSyncPlaylistData`),
+`PlaylistCheckPort` (`getCheckDashboard`, `runFix`), and `CatalogPort.syncArtistDetails` no longer
+take a `UserId`; each service resolves the one stored user internally via `CurrentUserResolver`
+(with the pre-existing guard-clause pattern for the "no user yet" case). `SpotifyPlaybackPort`,
+`SpotifyPlaylistPort`, and `SpotifyCatalogPort` also dropped `UserId` — `SpotifyPlaylistPort` and
+`SpotifyCatalogPort` only ever used it for log messages, but `SpotifyPlaybackPort` actually stamped
+it into the returned `CurrentlyPlayingItem`/`RecentlyPlayedItem` domain objects, so `PlaybackService`
+now stamps the real user onto those items itself right after the adapter call, since the adapter no
+longer has a `UserId` to use.
 
-* `domain-api/.../port/out/*` – ports whose only use of `UserId` is to select "which user" (not
-  domain data itself) can drop the parameter: `PlaybackPort`, `PlaybackAggregationPort`,
-  `PlaylistPort`, `SpotifyPlaybackPort`, `SpotifyCatalogPort`, `SpotifyPlaylistPort`.
-  Note that `CatalogPort` needs care — some of the `UserId` usages there are about *which token to
-  use for a Spotify call*, which still needs to resolve to "the one user," not "no user."
-* `domain-api/.../domain/outbox/DomainOutboxEvent.kt` – outbox event payloads that carry `userId`
-  purely to route to "the current user" (`FetchPlaybackData`, `RebuildPlaybackData`,
-  `AppendPlaybackData`, `SyncArtistAlbums`, etc.) can drop the field. Existing in-flight outbox
-  tasks in MongoDB will already contain the old payload shape — deserialization must tolerate
-  (ignore) a stray `userId` field during the transition, or old tasks must be drained before
-  deploying this phase.
-* `adapter-in-web/.../*Resource.kt` – all resources currently resolve "current user" via
-  `UserId(securityIdentity.principal.name)` (`PlaybackResource`, `StatsResource`,
-  `PlaylistsResource`, `PlaylistSettingsResource`, `PlaybackSettingsResource`,
-  `PlaylistChecksResource`, `PlaybackEventViewerResource`, `HealthSseResource`). This resolution
-  can stay as-is (it still identifies the logged-in session), but downstream calls no longer need
-  to pass it further than the point where a Spotify token must be selected.
+The outbox events that only carried `userId` to route to "the current user"
+(`FetchPlaybackData`, `RebuildPlaybackData`, `AppendPlaybackData`, `SyncPlaylistInfo`,
+`SyncPlaylistData`, `SyncArtistDetails`, `SyncArtistAlbums`, `RunPlaylistChecks`,
+`AggregatePlaybackData`) dropped the field, following the same placeholder-payload pattern already
+established by `UpdateUserProfile`/`ResyncCatalog`. Backward compatibility with in-flight outbox
+tasks queued under the old payload format is handled directly in `fromKey`/`fromPayload`: no-arg
+events ignore their payload entirely, and events with real remaining fields (e.g.
+`SyncArtistDetails.artistId`) parse them with `substringBefore/-After(':')`, which transparently
+strips a leading `userId:` prefix if present without needing a separate legacy code path.
 
-**Risk:** High — this phase touches the largest surface area (most of `domain-api` and
-`domain-impl`, and all of `adapter-in-web`). Recommend splitting further into one PR per bounded
-context (playback, playlist, catalog, user profile) rather than one large PR.
+Repository out-ports (`AppPlaybackRepositoryPort`, `PlaylistRepositoryPort`,
+`CurrentlyPlayingRepositoryPort`, etc.) were intentionally left untouched — they still key their
+MongoDB queries by `spotifyUserId` until Phase 4 migrates the schema, and internal service code
+still resolves and threads `UserId` down to those calls, just no longer as a public port parameter.
 
 ---
 
@@ -176,7 +173,7 @@ downtime, and must run after Phase 3 so no code still reads/writes the dropped f
 |---|---|---|
 | 1 – Login/allow-list removal | Low | Permissive change; single real operator already unaffected. |
 | 2 – Scheduler fan-out & catalog-sync shortcut | Medium | Done — "zero users" and "one user" cases covered by tests. |
-| 3 – `UserId` threading removal | High | Split per bounded context; handle in-flight outbox payloads carrying stale `userId` fields during rollout. User-profile, `SpotifyAccessTokenPort`, and SSE/dashboard slices done. |
+| 3 – `UserId` threading removal | High | Done — split per bounded context (user-profile, `SpotifyAccessTokenPort`, SSE/dashboard, then playback/playlist/catalog); in-flight outbox payloads with stale `userId` fields are tolerated by `fromKey`/`fromPayload`. |
 | 4 – MongoDB schema/index cleanup | Medium | Use a one-time `Starter`; sequence after Phase 3; rebuild indexes without downtime. |
 | 5 – Config/tests/deploy cleanup | Low | Cleanup only. |
 

--- a/docs/releasenotes/snippets/issue-737-20260709-1723-bugfix.md
+++ b/docs/releasenotes/snippets/issue-737-20260709-1723-bugfix.md
@@ -1,0 +1,1 @@
+* Continued the single-user simplification: playback, playlist, and catalog no longer require selecting a user internally, since the app only ever supports one.

--- a/domain-api/src/main/kotlin/de/chrgroth/spotify/control/domain/outbox/DomainOutboxEvent.kt
+++ b/domain-api/src/main/kotlin/de/chrgroth/spotify/control/domain/outbox/DomainOutboxEvent.kt
@@ -3,7 +3,6 @@ package de.chrgroth.spotify.control.domain.outbox
 import de.chrgroth.quarkus.outbox.domain.ApplicationOutboxEvent
 import de.chrgroth.quarkus.outbox.domain.OutboxEventPriority
 import de.chrgroth.spotify.control.domain.model.playback.aggregation.AggregationPeriodType
-import de.chrgroth.spotify.control.domain.model.user.UserId
 import kotlinx.datetime.LocalDate
 
 sealed interface DomainOutboxEvent : ApplicationOutboxEvent {
@@ -11,12 +10,12 @@ sealed interface DomainOutboxEvent : ApplicationOutboxEvent {
   override val priority: OutboxEventPriority get() = OutboxEventPriority.MEDIUM
   override val serializePayload: String
 
-  data class FetchPlaybackData(val userId: UserId) : DomainOutboxEvent {
+  data class FetchPlaybackData(val placeholder: String = "") : DomainOutboxEvent {
     override val key = KEY
-    override val deduplicationKey = "$KEY:${userId.value}"
+    override val deduplicationKey = KEY
     override val partition = DomainOutboxPartition.ToSpotifyPlayback
     override val priority = OutboxEventPriority.HIGH
-    override val serializePayload = userId.value
+    override val serializePayload = ""
 
     companion object {
       const val KEY = "FetchPlaybackData"
@@ -34,11 +33,11 @@ sealed interface DomainOutboxEvent : ApplicationOutboxEvent {
     }
   }
 
-  data class SyncPlaylistInfo(val userId: UserId) : DomainOutboxEvent {
+  data class SyncPlaylistInfo(val placeholder: String = "") : DomainOutboxEvent {
     override val key = KEY
-    override val deduplicationKey = "$KEY:${userId.value}"
+    override val deduplicationKey = KEY
     override val partition = DomainOutboxPartition.ToSpotifyPlaylist
-    override val serializePayload = userId.value
+    override val serializePayload = ""
 
     companion object {
       const val KEY = "SyncPlaylistInfo"
@@ -52,64 +51,59 @@ sealed interface DomainOutboxEvent : ApplicationOutboxEvent {
    * If the fetched page's snapshot ID differs from [snapshotId], the sync restarts from the first page.
    * The deduplication key includes both [snapshotId] and [nextUrl] so that each page+snapshot combination
    * can be queued independently while retries of the same page are still correctly deduplicated.
-   * payload: "${userId.value}:$playlistId" for the first page;
-   *          "${userId.value}:$playlistId\n$snapshotId\n$nextUrl" for subsequent pages.
-   * Legacy payload (no snapshotId): "${userId.value}:$playlistId\n$nextUrl" — parsed with snapshotId=null.
+   * payload: "$playlistId" for the first page;
+   *          "$playlistId\n$snapshotId\n$nextUrl" for subsequent pages.
+   * Legacy payload (no snapshotId): "$playlistId\n$nextUrl" — parsed with snapshotId=null.
    */
-  data class SyncPlaylistData(val userId: UserId, val playlistId: String, val nextUrl: String? = null, val snapshotId: String? = null) : DomainOutboxEvent {
+  data class SyncPlaylistData(val playlistId: String, val nextUrl: String? = null, val snapshotId: String? = null) : DomainOutboxEvent {
     override val key = KEY
-    override val deduplicationKey = "$KEY:${userId.value}:$playlistId:${snapshotId ?: ""}:${nextUrl ?: ""}"
+    override val deduplicationKey = "$KEY:$playlistId:${snapshotId ?: ""}:${nextUrl ?: ""}"
     override val partition = DomainOutboxPartition.ToSpotifyPlaylist
     override val serializePayload = when {
-      nextUrl == null -> "${userId.value}:$playlistId"
-      snapshotId != null -> "${userId.value}:$playlistId\n$snapshotId\n$nextUrl"
-      else -> "${userId.value}:$playlistId\n$nextUrl"
+      nextUrl == null -> playlistId
+      snapshotId != null -> "$playlistId\n$snapshotId\n$nextUrl"
+      else -> "$playlistId\n$nextUrl"
     }
 
     companion object {
       const val KEY = "SyncPlaylistData"
       fun fromPayload(payload: String): SyncPlaylistData {
-        val colonIndex = payload.indexOf(':')
-        require(colonIndex > 0 && colonIndex < payload.length - 1) { "Invalid SyncPlaylistData payload: $payload" }
-        val userId = UserId(payload.substring(0, colonIndex))
-        val rest = payload.substring(colonIndex + 1)
-        val firstNewline = rest.indexOf('\n')
-        return if (firstNewline < 0) {
-          SyncPlaylistData(userId, rest)
+        val firstNewline = payload.indexOf('\n')
+        if (firstNewline < 0) {
+          return SyncPlaylistData(playlistId = payload.substringAfter(':'))
+        }
+        val playlistId = payload.substring(0, firstNewline).substringAfter(':')
+        val afterFirst = payload.substring(firstNewline + 1)
+        val secondNewline = afterFirst.indexOf('\n')
+        return if (secondNewline < 0) {
+          // Legacy format: no snapshotId
+          SyncPlaylistData(playlistId, afterFirst)
         } else {
-          val playlistId = rest.substring(0, firstNewline)
-          val afterFirst = rest.substring(firstNewline + 1)
-          val secondNewline = afterFirst.indexOf('\n')
-          if (secondNewline < 0) {
-            // Legacy format: no snapshotId
-            SyncPlaylistData(userId, playlistId, afterFirst)
-          } else {
-            // New format: snapshotId\nnextUrl
-            val snapshotId = afterFirst.substring(0, secondNewline).takeIf { it.isNotEmpty() }
-            val nextUrl = afterFirst.substring(secondNewline + 1)
-            SyncPlaylistData(userId, playlistId, nextUrl, snapshotId)
-          }
+          // New format: snapshotId\nnextUrl
+          val snapshotId = afterFirst.substring(0, secondNewline).takeIf { it.isNotEmpty() }
+          val nextUrl = afterFirst.substring(secondNewline + 1)
+          SyncPlaylistData(playlistId, nextUrl, snapshotId)
         }
       }
     }
   }
 
-  data class RebuildPlaybackData(val userId: UserId) : DomainOutboxEvent {
+  data class RebuildPlaybackData(val placeholder: String = "") : DomainOutboxEvent {
     override val key = KEY
-    override val deduplicationKey = "$KEY:${userId.value}"
+    override val deduplicationKey = KEY
     override val partition = DomainOutboxPartition.Domain
-    override val serializePayload = userId.value
+    override val serializePayload = ""
 
     companion object {
       const val KEY = "RebuildPlaybackData"
     }
   }
 
-  data class AppendPlaybackData(val userId: UserId) : DomainOutboxEvent {
+  data class AppendPlaybackData(val placeholder: String = "") : DomainOutboxEvent {
     override val key = KEY
-    override val deduplicationKey = "$KEY:${userId.value}"
+    override val deduplicationKey = KEY
     override val partition = DomainOutboxPartition.Domain
-    override val serializePayload = userId.value
+    override val serializePayload = ""
 
     companion object {
       const val KEY = "AppendPlaybackData"
@@ -119,25 +113,18 @@ sealed interface DomainOutboxEvent : ApplicationOutboxEvent {
   /**
    * Syncs genres and images for a single artist from the Spotify API and updates app_artist.
    * Deduplication is by artistId only (artist data is shared across users).
-   * payload = "$artistId:${userId.value}"
+   * payload = artistId
    */
-  data class SyncArtistDetails(val artistId: String, val userId: UserId) : DomainOutboxEvent {
+  data class SyncArtistDetails(val artistId: String) : DomainOutboxEvent {
     override val key = KEY
     override val deduplicationKey = "$KEY:$artistId"
     override val partition = DomainOutboxPartition.ToSpotifyCatalog
-    override val serializePayload = "$artistId:${userId.value}"
+    override val serializePayload = artistId
 
     companion object {
       const val KEY = "SyncArtistDetails"
       const val LEGACY_KEY = "EnrichArtistDetails"
-      fun fromPayload(payload: String): SyncArtistDetails {
-        val colonIndex = payload.indexOf(':')
-        require(colonIndex > 0 && colonIndex < payload.length - 1) { "Invalid SyncArtistDetails payload: $payload" }
-        return SyncArtistDetails(
-          artistId = payload.substring(0, colonIndex),
-          userId = UserId(payload.substring(colonIndex + 1)),
-        )
-      }
+      fun fromPayload(payload: String): SyncArtistDetails = SyncArtistDetails(artistId = payload.substringBefore(':'))
     }
   }
 
@@ -164,33 +151,28 @@ sealed interface DomainOutboxEvent : ApplicationOutboxEvent {
    * SyncAlbumDetails for any albums not yet in the catalog.
    * Each page is fetched in a separate outbox task to avoid rate limit bursts.
    * Deduplication is by artistId and nextUrl so that each page can be queued independently.
-   * payload: "$artistId:${userId.value}" for the first page;
-   *          "$artistId:${userId.value}\n$nextUrl" for subsequent pages.
+   * payload: "$artistId" for the first page;
+   *          "$artistId\n$nextUrl" for subsequent pages.
    */
-  data class SyncArtistAlbums(val artistId: String, val userId: UserId, val nextUrl: String? = null) : DomainOutboxEvent {
+  data class SyncArtistAlbums(val artistId: String, val nextUrl: String? = null) : DomainOutboxEvent {
     override val key = KEY
     override val deduplicationKey = "$KEY:$artistId:${nextUrl ?: ""}"
     override val partition = DomainOutboxPartition.ToSpotifyCatalog
     override val serializePayload = when {
-      nextUrl == null -> "$artistId:${userId.value}"
-      else -> "$artistId:${userId.value}\n$nextUrl"
+      nextUrl == null -> artistId
+      else -> "$artistId\n$nextUrl"
     }
 
     companion object {
       const val KEY = "SyncArtistAlbums"
       fun fromPayload(payload: String): SyncArtistAlbums {
-        val colonIndex = payload.indexOf(':')
-        require(colonIndex > 0 && colonIndex < payload.length - 1) { "Invalid SyncArtistAlbums payload: $payload" }
-        val artistId = payload.substring(0, colonIndex)
-        val rest = payload.substring(colonIndex + 1)
-        val newlineIndex = rest.indexOf('\n')
+        val newlineIndex = payload.indexOf('\n')
         return if (newlineIndex < 0) {
-          SyncArtistAlbums(artistId = artistId, userId = UserId(rest))
+          SyncArtistAlbums(artistId = payload.substringBefore(':'))
         } else {
           SyncArtistAlbums(
-            artistId = artistId,
-            userId = UserId(rest.substring(0, newlineIndex)),
-            nextUrl = rest.substring(newlineIndex + 1),
+            artistId = payload.substring(0, newlineIndex).substringBefore(':'),
+            nextUrl = payload.substring(newlineIndex + 1),
           )
         }
       }
@@ -214,34 +196,30 @@ sealed interface DomainOutboxEvent : ApplicationOutboxEvent {
   }
 
   /**
-   * Runs all playlist checks for a given user's playlist.
-   * payload = "${userId.value}:$playlistId"
+   * Runs all playlist checks for the user's playlist.
+   * payload = playlistId
    */
-  data class RunPlaylistChecks(val userId: UserId, val playlistId: String) : DomainOutboxEvent {
+  data class RunPlaylistChecks(val playlistId: String) : DomainOutboxEvent {
     override val key = KEY
-    override val deduplicationKey = "$KEY:${userId.value}:$playlistId"
+    override val deduplicationKey = "$KEY:$playlistId"
     override val partition = DomainOutboxPartition.Domain
-    override val serializePayload = "${userId.value}:$playlistId"
+    override val serializePayload = playlistId
 
     companion object {
       const val KEY = "RunPlaylistChecks"
-      fun fromPayload(payload: String): RunPlaylistChecks {
-        val colonIndex = payload.indexOf(':')
-        require(colonIndex > 0 && colonIndex < payload.length - 1) { "Invalid RunPlaylistChecks payload: $payload" }
-        return RunPlaylistChecks(UserId(payload.substring(0, colonIndex)), payload.substring(colonIndex + 1))
-      }
+      fun fromPayload(payload: String): RunPlaylistChecks = RunPlaylistChecks(payload.substringAfter(':'))
     }
   }
 
   /**
-   * Triggers aggregation of playback data for a specific period and user.
-   * payload = "${userId.value}:${type.name}:${periodStart}"
+   * Triggers aggregation of playback data for a specific period.
+   * payload = "${type.name}:${periodStart}"
    */
-  data class AggregatePlaybackData(val userId: UserId, val type: AggregationPeriodType, val periodStart: LocalDate) : DomainOutboxEvent {
+  data class AggregatePlaybackData(val type: AggregationPeriodType, val periodStart: LocalDate) : DomainOutboxEvent {
     override val key = KEY
-    override val deduplicationKey = "$KEY:${userId.value}:${type.name}:$periodStart"
+    override val deduplicationKey = "$KEY:${type.name}:$periodStart"
     override val partition = DomainOutboxPartition.Domain
-    override val serializePayload = "${userId.value}:${type.name}:$periodStart"
+    override val serializePayload = "${type.name}:$periodStart"
 
     companion object {
       const val KEY = "AggregatePlaybackData"
@@ -249,12 +227,18 @@ sealed interface DomainOutboxEvent : ApplicationOutboxEvent {
         val firstColon = payload.indexOf(':')
         require(firstColon > 0) { "Invalid AggregatePlaybackData payload: $payload" }
         val secondColon = payload.indexOf(':', firstColon + 1)
-        require(secondColon > firstColon) { "Invalid AggregatePlaybackData payload: $payload" }
-        return AggregatePlaybackData(
-          userId = UserId(payload.substring(0, firstColon)),
-          type = AggregationPeriodType.valueOf(payload.substring(firstColon + 1, secondColon)),
-          periodStart = LocalDate.parse(payload.substring(secondColon + 1)),
-        )
+        return if (secondColon < 0) {
+          AggregatePlaybackData(
+            type = AggregationPeriodType.valueOf(payload.substring(0, firstColon)),
+            periodStart = LocalDate.parse(payload.substring(firstColon + 1)),
+          )
+        } else {
+          // Legacy format: "${userId}:${type}:${periodStart}"
+          AggregatePlaybackData(
+            type = AggregationPeriodType.valueOf(payload.substring(firstColon + 1, secondColon)),
+            periodStart = LocalDate.parse(payload.substring(secondColon + 1)),
+          )
+        }
       }
     }
   }
@@ -277,12 +261,12 @@ sealed interface DomainOutboxEvent : ApplicationOutboxEvent {
 
     @Suppress("CyclomaticComplexMethod")
     fun fromKey(key: String, payload: String): DomainOutboxEvent = when (key) {
-      FetchPlaybackData.KEY -> FetchPlaybackData(UserId(payload))
+      FetchPlaybackData.KEY -> FetchPlaybackData()
       UpdateUserProfile.KEY -> UpdateUserProfile()
-      SyncPlaylistInfo.KEY -> SyncPlaylistInfo(UserId(payload))
+      SyncPlaylistInfo.KEY -> SyncPlaylistInfo()
       SyncPlaylistData.KEY -> SyncPlaylistData.fromPayload(payload)
-      RebuildPlaybackData.KEY -> RebuildPlaybackData(UserId(payload))
-      AppendPlaybackData.KEY -> AppendPlaybackData(UserId(payload))
+      RebuildPlaybackData.KEY -> RebuildPlaybackData()
+      AppendPlaybackData.KEY -> AppendPlaybackData()
       SyncArtistDetails.KEY, SyncArtistDetails.LEGACY_KEY -> SyncArtistDetails.fromPayload(payload)
       SyncArtistAlbums.KEY -> SyncArtistAlbums.fromPayload(payload)
       SyncAlbumDetails.KEY -> SyncAlbumDetails.fromPayload(payload)

--- a/domain-api/src/main/kotlin/de/chrgroth/spotify/control/domain/port/in/catalog/CatalogPort.kt
+++ b/domain-api/src/main/kotlin/de/chrgroth/spotify/control/domain/port/in/catalog/CatalogPort.kt
@@ -3,14 +3,13 @@ package de.chrgroth.spotify.control.domain.port.`in`.catalog
 import arrow.core.Either
 import de.chrgroth.spotify.control.domain.error.DomainError
 import de.chrgroth.spotify.control.domain.model.catalog.AppArtist
-import de.chrgroth.spotify.control.domain.model.user.UserId
 import de.chrgroth.spotify.control.domain.outbox.DomainOutboxEvent
 
 interface CatalogPort {
   fun findAllArtists(): List<AppArtist>
   fun blockArtistFromAggregation(artistId: String): Either<DomainError, Unit>
   fun unblockArtistFromAggregation(artistId: String): Either<DomainError, Unit>
-  fun syncArtistDetails(artistId: String, userId: UserId): Either<DomainError, Unit>
+  fun syncArtistDetails(artistId: String): Either<DomainError, Unit>
   fun resyncCatalog(): Either<DomainError, Unit>
   fun resyncArtist(artistId: String): Either<DomainError, Unit>
   fun wipeCatalog(): Either<DomainError, Unit>

--- a/domain-api/src/main/kotlin/de/chrgroth/spotify/control/domain/port/in/playback/PlaybackEventViewerPort.kt
+++ b/domain-api/src/main/kotlin/de/chrgroth/spotify/control/domain/port/in/playback/PlaybackEventViewerPort.kt
@@ -1,9 +1,8 @@
 package de.chrgroth.spotify.control.domain.port.`in`.playback
 
 import de.chrgroth.spotify.control.domain.model.playback.PlaybackEventViewerResult
-import de.chrgroth.spotify.control.domain.model.user.UserId
 import kotlinx.datetime.LocalDate
 
 interface PlaybackEventViewerPort {
-  fun getEvents(userId: UserId, date: LocalDate): PlaybackEventViewerResult
+  fun getEvents(date: LocalDate): PlaybackEventViewerResult
 }

--- a/domain-api/src/main/kotlin/de/chrgroth/spotify/control/domain/port/in/playback/PlaybackPort.kt
+++ b/domain-api/src/main/kotlin/de/chrgroth/spotify/control/domain/port/in/playback/PlaybackPort.kt
@@ -2,15 +2,14 @@ package de.chrgroth.spotify.control.domain.port.`in`.playback
 
 import arrow.core.Either
 import de.chrgroth.spotify.control.domain.error.DomainError
-import de.chrgroth.spotify.control.domain.model.user.UserId
 import de.chrgroth.spotify.control.domain.outbox.DomainOutboxEvent
 
 interface PlaybackPort {
   fun enqueueFetchPlaybackData()
-  fun fetchPlaybackData(userId: UserId): Either<DomainError, Unit>
-  fun enqueueRebuildPlaybackData(userId: UserId)
-  fun rebuildPlaybackData(userId: UserId)
-  fun appendPlaybackData(userId: UserId)
+  fun fetchPlaybackData(): Either<DomainError, Unit>
+  fun enqueueRebuildPlaybackData()
+  fun rebuildPlaybackData()
+  fun appendPlaybackData()
   fun handle(event: DomainOutboxEvent.FetchPlaybackData): Either<DomainError, Unit>
   fun handle(event: DomainOutboxEvent.RebuildPlaybackData): Either<DomainError, Unit>
   fun handle(event: DomainOutboxEvent.AppendPlaybackData): Either<DomainError, Unit>

--- a/domain-api/src/main/kotlin/de/chrgroth/spotify/control/domain/port/in/playlist/PlaylistCheckPort.kt
+++ b/domain-api/src/main/kotlin/de/chrgroth/spotify/control/domain/port/in/playlist/PlaylistCheckPort.kt
@@ -3,13 +3,12 @@ package de.chrgroth.spotify.control.domain.port.`in`.playlist
 import arrow.core.Either
 import de.chrgroth.spotify.control.domain.error.DomainError
 import de.chrgroth.spotify.control.domain.model.playlist.PlaylistCheckDashboard
-import de.chrgroth.spotify.control.domain.model.user.UserId
 import de.chrgroth.spotify.control.domain.outbox.DomainOutboxEvent
 
 interface PlaylistCheckPort {
   fun handle(event: DomainOutboxEvent.RunPlaylistChecks): Either<DomainError, Unit>
-  fun getCheckDashboard(userId: UserId): PlaylistCheckDashboard
+  fun getCheckDashboard(): PlaylistCheckDashboard
   fun getDisplayNames(): Map<String, String>
   fun getFixableCheckIds(): Set<String>
-  fun runFix(userId: UserId, playlistId: String, checkType: String): Either<DomainError, Unit>
+  fun runFix(playlistId: String, checkType: String): Either<DomainError, Unit>
 }

--- a/domain-api/src/main/kotlin/de/chrgroth/spotify/control/domain/port/in/playlist/PlaylistPort.kt
+++ b/domain-api/src/main/kotlin/de/chrgroth/spotify/control/domain/port/in/playlist/PlaylistPort.kt
@@ -5,18 +5,17 @@ import de.chrgroth.spotify.control.domain.error.DomainError
 import de.chrgroth.spotify.control.domain.model.playlist.PlaylistInfo
 import de.chrgroth.spotify.control.domain.model.playlist.PlaylistSyncStatus
 import de.chrgroth.spotify.control.domain.model.playlist.PlaylistType
-import de.chrgroth.spotify.control.domain.model.user.UserId
 import de.chrgroth.spotify.control.domain.outbox.DomainOutboxEvent
 
 interface PlaylistPort {
-  fun getPlaylists(userId: UserId): List<PlaylistInfo>
-  fun getTrackCounts(userId: UserId): Map<String, Int>
+  fun getPlaylists(): List<PlaylistInfo>
+  fun getTrackCounts(): Map<String, Int>
   fun enqueueUpdates()
-  fun syncPlaylists(userId: UserId): Either<DomainError, Unit>
-  fun syncPlaylistData(userId: UserId, playlistId: String, nextUrl: String? = null, snapshotId: String? = null): Either<DomainError, Unit>
-  fun updateSyncStatus(userId: UserId, playlistId: String, syncStatus: PlaylistSyncStatus): Either<DomainError, Unit>
-  fun updatePlaylistType(userId: UserId, playlistId: String, type: PlaylistType): Either<DomainError, Unit>
-  fun enqueueSyncPlaylistData(userId: UserId, playlistId: String): Either<DomainError, Unit>
+  fun syncPlaylists(): Either<DomainError, Unit>
+  fun syncPlaylistData(playlistId: String, nextUrl: String? = null, snapshotId: String? = null): Either<DomainError, Unit>
+  fun updateSyncStatus(playlistId: String, syncStatus: PlaylistSyncStatus): Either<DomainError, Unit>
+  fun updatePlaylistType(playlistId: String, type: PlaylistType): Either<DomainError, Unit>
+  fun enqueueSyncPlaylistData(playlistId: String): Either<DomainError, Unit>
   fun handle(event: DomainOutboxEvent.SyncPlaylistInfo): Either<DomainError, Unit>
   fun handle(event: DomainOutboxEvent.SyncPlaylistData): Either<DomainError, Unit>
 }

--- a/domain-api/src/main/kotlin/de/chrgroth/spotify/control/domain/port/out/catalog/SpotifyCatalogPort.kt
+++ b/domain-api/src/main/kotlin/de/chrgroth/spotify/control/domain/port/out/catalog/SpotifyCatalogPort.kt
@@ -8,21 +8,20 @@ import de.chrgroth.spotify.control.domain.model.catalog.AppAlbum
 import de.chrgroth.spotify.control.domain.model.catalog.AppArtist
 import de.chrgroth.spotify.control.domain.model.catalog.AppTrack
 import de.chrgroth.spotify.control.domain.model.catalog.ArtistAlbumsPage
-import de.chrgroth.spotify.control.domain.model.user.UserId
 
 interface SpotifyCatalogPort {
-  fun getArtist(userId: UserId, accessToken: AccessToken, artistId: String): Either<DomainError, AppArtist?>
+  fun getArtist(accessToken: AccessToken, artistId: String): Either<DomainError, AppArtist?>
 
   /**
    * Fetches an album's full metadata and all tracks via GET /v1/albums/{id}.
    * Used as a fallback for albums whose metadata is not yet known locally.
    */
-  fun getAlbum(userId: UserId, accessToken: AccessToken, albumId: String): Either<DomainError, AlbumSyncResult>
+  fun getAlbum(accessToken: AccessToken, albumId: String): Either<DomainError, AlbumSyncResult>
 
   /**
    * Fetches all tracks for an album whose metadata is already known, via GET /v1/albums/{id}/tracks.
    * Avoids re-fetching album metadata that was already captured from the artist discography response.
    */
-  fun getAlbumTracks(userId: UserId, accessToken: AccessToken, album: AppAlbum): Either<DomainError, List<AppTrack>>
-  fun getArtistAlbumsPage(userId: UserId, accessToken: AccessToken, artistId: String, nextUrl: String?): Either<DomainError, ArtistAlbumsPage>
+  fun getAlbumTracks(accessToken: AccessToken, album: AppAlbum): Either<DomainError, List<AppTrack>>
+  fun getArtistAlbumsPage(accessToken: AccessToken, artistId: String, nextUrl: String?): Either<DomainError, ArtistAlbumsPage>
 }

--- a/domain-api/src/main/kotlin/de/chrgroth/spotify/control/domain/port/out/playback/SpotifyPlaybackPort.kt
+++ b/domain-api/src/main/kotlin/de/chrgroth/spotify/control/domain/port/out/playback/SpotifyPlaybackPort.kt
@@ -5,10 +5,9 @@ import de.chrgroth.spotify.control.domain.error.DomainError
 import de.chrgroth.spotify.control.domain.model.user.AccessToken
 import de.chrgroth.spotify.control.domain.model.playback.CurrentlyPlayingItem
 import de.chrgroth.spotify.control.domain.model.playback.RecentlyPlayedItem
-import de.chrgroth.spotify.control.domain.model.user.UserId
 import kotlin.time.Instant
 
 interface SpotifyPlaybackPort {
-  fun getCurrentlyPlaying(userId: UserId, accessToken: AccessToken): Either<DomainError, CurrentlyPlayingItem?>
-  fun getRecentlyPlayed(userId: UserId, accessToken: AccessToken, after: Instant? = null): Either<DomainError, List<RecentlyPlayedItem>>
+  fun getCurrentlyPlaying(accessToken: AccessToken): Either<DomainError, CurrentlyPlayingItem?>
+  fun getRecentlyPlayed(accessToken: AccessToken, after: Instant? = null): Either<DomainError, List<RecentlyPlayedItem>>
 }

--- a/domain-api/src/main/kotlin/de/chrgroth/spotify/control/domain/port/out/playlist/SpotifyPlaylistPort.kt
+++ b/domain-api/src/main/kotlin/de/chrgroth/spotify/control/domain/port/out/playlist/SpotifyPlaylistPort.kt
@@ -6,13 +6,12 @@ import de.chrgroth.spotify.control.domain.model.user.AccessToken
 import de.chrgroth.spotify.control.domain.model.playlist.Playlist
 import de.chrgroth.spotify.control.domain.model.playlist.PlaylistTracksPage
 import de.chrgroth.spotify.control.domain.model.playlist.SpotifyPlaylistItem
-import de.chrgroth.spotify.control.domain.model.user.UserId
 
 interface SpotifyPlaylistPort {
-  fun getPlaylists(userId: UserId, accessToken: AccessToken): Either<DomainError, List<SpotifyPlaylistItem>>
-  fun getPlaylistTracks(userId: UserId, accessToken: AccessToken, playlistId: String): Either<DomainError, Playlist>
-  fun getPlaylistTracksPage(userId: UserId, accessToken: AccessToken, playlistId: String, pageUrl: String?): Either<DomainError, PlaylistTracksPage>
-  fun removePlaylistTracks(userId: UserId, accessToken: AccessToken, playlistId: String, trackIds: List<String>): Either<DomainError, Unit>
-  fun addPlaylistTracks(userId: UserId, accessToken: AccessToken, playlistId: String, trackIds: List<String>): Either<DomainError, Unit>
-  fun replacePlaylistTrack(userId: UserId, accessToken: AccessToken, playlistId: String, oldTrackId: String, newTrackId: String, position: Int): Either<DomainError, Unit>
+  fun getPlaylists(accessToken: AccessToken): Either<DomainError, List<SpotifyPlaylistItem>>
+  fun getPlaylistTracks(accessToken: AccessToken, playlistId: String): Either<DomainError, Playlist>
+  fun getPlaylistTracksPage(accessToken: AccessToken, playlistId: String, pageUrl: String?): Either<DomainError, PlaylistTracksPage>
+  fun removePlaylistTracks(accessToken: AccessToken, playlistId: String, trackIds: List<String>): Either<DomainError, Unit>
+  fun addPlaylistTracks(accessToken: AccessToken, playlistId: String, trackIds: List<String>): Either<DomainError, Unit>
+  fun replacePlaylistTrack(accessToken: AccessToken, playlistId: String, oldTrackId: String, newTrackId: String, position: Int): Either<DomainError, Unit>
 }

--- a/domain-api/src/test/kotlin/de/chrgroth/spotify/control/domain/outbox/DomainOutboxContractTests.kt
+++ b/domain-api/src/test/kotlin/de/chrgroth/spotify/control/domain/outbox/DomainOutboxContractTests.kt
@@ -1,7 +1,6 @@
 package de.chrgroth.spotify.control.domain.outbox
 
 import de.chrgroth.spotify.control.domain.model.playback.aggregation.AggregationPeriodType
-import de.chrgroth.spotify.control.domain.model.user.UserId
 import de.chrgroth.spotify.control.domain.port.`in`.catalog.CatalogPort
 import de.chrgroth.spotify.control.domain.port.`in`.playback.PlaybackAggregationPort
 import de.chrgroth.spotify.control.domain.port.`in`.playback.PlaybackPort
@@ -14,22 +13,22 @@ import org.junit.jupiter.api.Test
 class DomainOutboxContractTests {
 
   private val allEvents: List<DomainOutboxEvent> = listOf(
-    DomainOutboxEvent.FetchPlaybackData(UserId("user-1")),
+    DomainOutboxEvent.FetchPlaybackData(),
     DomainOutboxEvent.UpdateUserProfile(),
-    DomainOutboxEvent.SyncPlaylistInfo(UserId("user-1")),
-    DomainOutboxEvent.SyncPlaylistData(UserId("user-1"), "playlist-1"),
-    DomainOutboxEvent.SyncPlaylistData(UserId("user-1"), "playlist-1", "https://api.spotify.com/v1/playlists/playlist-1/tracks?offset=50&limit=50", "snapshot-abc"),
-    DomainOutboxEvent.RebuildPlaybackData(UserId("user-1")),
-    DomainOutboxEvent.AppendPlaybackData(UserId("user-1")),
-    DomainOutboxEvent.SyncArtistDetails("artist-1", UserId("user-1")),
-    DomainOutboxEvent.SyncArtistAlbums("artist-1", UserId("user-1")),
-    DomainOutboxEvent.SyncArtistAlbums("artist-1", UserId("user-1"), "https://api.spotify.com/v1/artists/artist-1/albums?offset=50&limit=50"),
+    DomainOutboxEvent.SyncPlaylistInfo(),
+    DomainOutboxEvent.SyncPlaylistData("playlist-1"),
+    DomainOutboxEvent.SyncPlaylistData("playlist-1", "https://api.spotify.com/v1/playlists/playlist-1/tracks?offset=50&limit=50", "snapshot-abc"),
+    DomainOutboxEvent.RebuildPlaybackData(),
+    DomainOutboxEvent.AppendPlaybackData(),
+    DomainOutboxEvent.SyncArtistDetails("artist-1"),
+    DomainOutboxEvent.SyncArtistAlbums("artist-1"),
+    DomainOutboxEvent.SyncArtistAlbums("artist-1", "https://api.spotify.com/v1/artists/artist-1/albums?offset=50&limit=50"),
     DomainOutboxEvent.SyncAlbumDetails("album-1"),
-    DomainOutboxEvent.AggregatePlaybackData(UserId("user-1"), AggregationPeriodType.DAY, LocalDate(2024, 1, 15)),
-    DomainOutboxEvent.AggregatePlaybackData(UserId("user-1"), AggregationPeriodType.WEEK, LocalDate(2024, 1, 8)),
-    DomainOutboxEvent.AggregatePlaybackData(UserId("user-1"), AggregationPeriodType.MONTH, LocalDate(2024, 1, 1)),
-    DomainOutboxEvent.AggregatePlaybackData(UserId("user-1"), AggregationPeriodType.QUARTER, LocalDate(2024, 1, 1)),
-    DomainOutboxEvent.AggregatePlaybackData(UserId("user-1"), AggregationPeriodType.YEAR, LocalDate(2024, 1, 1)),
+    DomainOutboxEvent.AggregatePlaybackData(AggregationPeriodType.DAY, LocalDate(2024, 1, 15)),
+    DomainOutboxEvent.AggregatePlaybackData(AggregationPeriodType.WEEK, LocalDate(2024, 1, 8)),
+    DomainOutboxEvent.AggregatePlaybackData(AggregationPeriodType.MONTH, LocalDate(2024, 1, 1)),
+    DomainOutboxEvent.AggregatePlaybackData(AggregationPeriodType.QUARTER, LocalDate(2024, 1, 1)),
+    DomainOutboxEvent.AggregatePlaybackData(AggregationPeriodType.YEAR, LocalDate(2024, 1, 1)),
   )
 
   @Test
@@ -38,23 +37,6 @@ class DomainOutboxContractTests {
       assertThat(event.deduplicationKey)
         .describedAs("deduplicationKey for ${event::class.simpleName}")
         .isNotBlank()
-    }
-  }
-
-  @Test
-  fun `deduplication key includes userId to allow per-user deduplication`() {
-    val userId = "user-abc"
-    listOf(
-      DomainOutboxEvent.FetchPlaybackData(UserId(userId)),
-      DomainOutboxEvent.SyncPlaylistInfo(UserId(userId)),
-      DomainOutboxEvent.SyncPlaylistData(UserId(userId), "playlist-abc"),
-      DomainOutboxEvent.RebuildPlaybackData(UserId(userId)),
-      DomainOutboxEvent.AppendPlaybackData(UserId(userId)),
-      DomainOutboxEvent.AggregatePlaybackData(UserId(userId), AggregationPeriodType.DAY, LocalDate(2024, 1, 15)),
-    ).forEach { event ->
-      assertThat(event.deduplicationKey)
-        .describedAs("deduplicationKey for ${event::class.simpleName} should contain userId")
-        .contains(userId)
     }
   }
 

--- a/domain-impl/src/main/kotlin/de/chrgroth/spotify/control/domain/catalog/CatalogService.kt
+++ b/domain-impl/src/main/kotlin/de/chrgroth/spotify/control/domain/catalog/CatalogService.kt
@@ -78,18 +78,22 @@ class CatalogService(
 
   // --- Catalog Sync ---
 
-  override fun syncArtistDetails(artistId: String, userId: UserId): Either<DomainError, Unit> {
+  override fun syncArtistDetails(artistId: String): Either<DomainError, Unit> {
     val existing = appArtistRepository.findByArtistIds(setOf(ArtistId(artistId))).firstOrNull()
     if (existing != null) {
       logger.debug { "Artist $artistId already synced, skipping" }
       return Unit.right()
     }
+    currentUserResolver.userId() ?: run {
+      logger.warn { "No users available for artist details sync, skipping $artistId" }
+      return Unit.right()
+    }
     val accessToken = spotifyAccessToken.getValidAccessToken()
-    return spotifyCatalog.getArtist(userId, accessToken, artistId)
+    return spotifyCatalog.getArtist(accessToken, artistId)
       .flatMap { detail ->
         if (detail != null) {
           appArtistRepository.upsertAll(listOf(detail))
-          outboxPort.enqueue(DomainOutboxEvent.SyncArtistAlbums(artistId, userId))
+          outboxPort.enqueue(DomainOutboxEvent.SyncArtistAlbums(artistId))
           dashboardRefresh.notifyCatalogData()
         } else {
           logger.warn { "No data returned from Spotify for artist $artistId" }
@@ -103,19 +107,19 @@ class CatalogService(
     val userId = currentUserResolver.userId() ?: return Unit.right()
     val playbackCatalogRequests = buildPlaybackCatalogRequests(userId)
     logger.info { "Re-syncing catalog: ${allArtistIds.size} catalog artist(s), ${playbackCatalogRequests.size} playback track(s)" }
-    allArtistIds.forEach { outboxPort.enqueue(DomainOutboxEvent.SyncArtistAlbums(it, userId)) }
-    syncController.syncForTracks(playbackCatalogRequests, userId)
+    allArtistIds.forEach { outboxPort.enqueue(DomainOutboxEvent.SyncArtistAlbums(it)) }
+    syncController.syncForTracks(playbackCatalogRequests)
     return Unit.right()
   }
 
   override fun resyncArtist(artistId: String): Either<DomainError, Unit> {
     appArtistRepository.findByArtistIds(setOf(ArtistId(artistId))).firstOrNull()
       ?: return ArtistSettingsError.ARTIST_NOT_FOUND.left()
-    val userId = currentUserResolver.userId() ?: run {
+    currentUserResolver.userId() ?: run {
       logger.warn { "No users available for artist resync, skipping $artistId" }
       return Unit.right()
     }
-    outboxPort.enqueue(DomainOutboxEvent.SyncArtistAlbums(artistId, userId))
+    outboxPort.enqueue(DomainOutboxEvent.SyncArtistAlbums(artistId))
     return Unit.right()
   }
 
@@ -131,8 +135,7 @@ class CatalogService(
   }
 
   private fun syncAlbumDetails(albumId: String): Either<DomainError, Int> {
-    val userId = currentUserResolver.userId()
-    if (userId == null) {
+    currentUserResolver.userId() ?: run {
       logger.debug { "No users available, skipping syncAlbumDetails" }
       return 0.right()
     }
@@ -140,10 +143,10 @@ class CatalogService(
     val knownAlbum = appAlbumRepository.findByAlbumIds(setOf(AlbumId(albumId))).firstOrNull()
     val result = if (knownAlbum != null) {
       // metadata already captured from the artist discography response, only tracks are missing
-      spotifyCatalog.getAlbumTracks(userId, accessToken, knownAlbum).map { tracks -> AlbumSyncResult(knownAlbum, tracks) }
+      spotifyCatalog.getAlbumTracks(accessToken, knownAlbum).map { tracks -> AlbumSyncResult(knownAlbum, tracks) }
     } else {
       // fallback for albums without known metadata, e.g. events enqueued before this album was upserted
-      spotifyCatalog.getAlbum(userId, accessToken, albumId)
+      spotifyCatalog.getAlbum(accessToken, albumId)
     }
     return when (result) {
       is Either.Left -> result.value.left()
@@ -169,10 +172,10 @@ class CatalogService(
   // --- Outbox Handlers ---
 
   override fun handle(event: DomainOutboxEvent.SyncArtistDetails): Either<DomainError, Unit> =
-    syncArtistDetails(event.artistId, event.userId)
+    syncArtistDetails(event.artistId)
 
   override fun handle(event: DomainOutboxEvent.SyncArtistAlbums): Either<DomainError, Unit> =
-    syncArtistAlbums(event.artistId, event.userId, event.nextUrl)
+    syncArtistAlbums(event.artistId, event.nextUrl)
 
   override fun handle(event: DomainOutboxEvent.SyncAlbumDetails): Either<DomainError, Unit> =
     syncAlbumDetails(event.albumId).map { Unit }
@@ -182,14 +185,13 @@ class CatalogService(
 
   override fun enqueueArtistAlbumsSync(partition: Int, totalPartitions: Int) {
     val allArtists = appArtistRepository.findAll()
-    val userId = currentUserResolver.userId()
-    if (userId == null) {
+    currentUserResolver.userId() ?: run {
       logger.warn { "No users available for artist albums sync, skipping partition $partition/$totalPartitions" }
       return
     }
     val partitioned = allArtists.filterIndexed { idx, _ -> idx % totalPartitions == partition }
     partitioned.forEach { artist ->
-      outboxPort.enqueue(DomainOutboxEvent.SyncArtistAlbums(artist.id.value, userId))
+      outboxPort.enqueue(DomainOutboxEvent.SyncArtistAlbums(artist.id.value))
     }
   }
 
@@ -202,7 +204,7 @@ class CatalogService(
     val playbackCatalogRequests = buildPlaybackCatalogRequests(userId)
     val artistCount = playbackCatalogRequests.flatMap { it.artistIds }.filter { it.isNotBlank() }.distinct().size
     logger.info { "Enqueuing artist sync for $artistCount artist(s) found in playback data" }
-    syncController.syncForTracks(playbackCatalogRequests, userId)
+    syncController.syncForTracks(playbackCatalogRequests)
   }
 
   private fun buildPlaybackCatalogRequests(userId: UserId): List<CatalogSyncRequest> {
@@ -220,9 +222,9 @@ class CatalogService(
     cause = SyncCause.ManualResync,
   )
 
-  private fun syncArtistAlbums(artistId: String, userId: UserId, nextUrl: String?): Either<DomainError, Unit> {
+  private fun syncArtistAlbums(artistId: String, nextUrl: String?): Either<DomainError, Unit> {
     val accessToken = spotifyAccessToken.getValidAccessToken()
-    return spotifyCatalog.getArtistAlbumsPage(userId, accessToken, artistId, nextUrl)
+    return spotifyCatalog.getArtistAlbumsPage(accessToken, artistId, nextUrl)
       .flatMap { page ->
         val existingAlbumIds = appAlbumRepository.findByAlbumIds(page.albums.map { it.id }.toSet()).map { it.id.value }.toSet()
         val newAlbums = page.albums.filter { it.id.value !in existingAlbumIds }
@@ -238,7 +240,7 @@ class CatalogService(
         }
         if (page.nextUrl != null) {
           if (newAlbums.isNotEmpty()) {
-            outboxPort.enqueue(DomainOutboxEvent.SyncArtistAlbums(artistId, userId, page.nextUrl))
+            outboxPort.enqueue(DomainOutboxEvent.SyncArtistAlbums(artistId, page.nextUrl))
           }
         }
         Unit.right()

--- a/domain-impl/src/main/kotlin/de/chrgroth/spotify/control/domain/catalog/SyncController.kt
+++ b/domain-impl/src/main/kotlin/de/chrgroth/spotify/control/domain/catalog/SyncController.kt
@@ -5,7 +5,6 @@ import de.chrgroth.spotify.control.domain.model.catalog.SyncCause
 import de.chrgroth.spotify.control.domain.model.catalog.SyncTrace
 import de.chrgroth.spotify.control.domain.model.catalog.SyncTraceEntityType
 import de.chrgroth.spotify.control.domain.model.catalog.TrackId
-import de.chrgroth.spotify.control.domain.model.user.UserId
 import de.chrgroth.spotify.control.domain.outbox.DomainOutboxEvent
 import de.chrgroth.spotify.control.domain.port.out.catalog.AppArtistRepositoryPort
 import de.chrgroth.spotify.control.domain.port.out.catalog.AppTrackRepositoryPort
@@ -26,25 +25,25 @@ class SyncController(
    * - Checks which tracks are missing from app_track.
    * - For missing tracks: enqueues SyncArtistDetails for any artists not yet in the catalog.
    */
-  fun syncForTracks(tracks: List<CatalogSyncRequest>, userId: UserId) {
+  fun syncForTracks(tracks: List<CatalogSyncRequest>) {
     if (tracks.isEmpty()) return
     val trackIds = tracks.map { TrackId(it.trackId) }.toSet()
     val existingTrackIds = appTrackRepository.findByTrackIds(trackIds).map { it.id }.toSet()
     val missingTracks = tracks.filter { TrackId(it.trackId) !in existingTrackIds }
     if (missingTracks.isEmpty()) return
     val artistCauses = missingTracks.flatMap { request -> request.artistIds.map { it to request.cause } }.toMap()
-    syncArtists(artistCauses, userId)
+    syncArtists(artistCauses)
   }
 
   /**
    * Checks which artists are missing from app_artist and enqueues SyncArtistDetails.
    */
-  fun syncArtists(artistIds: List<String>, userId: UserId, cause: SyncCause) {
+  fun syncArtists(artistIds: List<String>, cause: SyncCause) {
     if (artistIds.isEmpty()) return
-    syncArtists(artistIds.associateWith { cause }, userId)
+    syncArtists(artistIds.associateWith { cause })
   }
 
-  private fun syncArtists(artistCauses: Map<String, SyncCause>, userId: UserId) {
+  private fun syncArtists(artistCauses: Map<String, SyncCause>) {
     if (artistCauses.isEmpty()) return
     val existingArtistIds = appArtistRepository.findByArtistIds(artistCauses.keys.map { ArtistId(it) }.toSet()).map { it.id.value }.toSet()
     val newArtistIds = artistCauses.keys.filter { it !in existingArtistIds }
@@ -52,7 +51,7 @@ class SyncController(
     val now = Clock.System.now()
     newArtistIds.forEach { artistId ->
       syncTraceRepository.upsert(SyncTrace(SyncTraceEntityType.ARTIST, artistId, artistCauses.getValue(artistId), now))
-      outboxPort.enqueue(DomainOutboxEvent.SyncArtistDetails(artistId, userId))
+      outboxPort.enqueue(DomainOutboxEvent.SyncArtistDetails(artistId))
     }
   }
 }

--- a/domain-impl/src/main/kotlin/de/chrgroth/spotify/control/domain/playback/PlaybackAggregationService.kt
+++ b/domain-impl/src/main/kotlin/de/chrgroth/spotify/control/domain/playback/PlaybackAggregationService.kt
@@ -52,28 +52,28 @@ class PlaybackAggregationService(
   // --- Enqueue helpers ---
 
   override fun enqueueAggregateDay(date: LocalDate) {
-    val userId = currentUserResolver.userId() ?: return
-    outboxPort.enqueue(DomainOutboxEvent.AggregatePlaybackData(userId, AggregationPeriodType.DAY, date))
+    currentUserResolver.userId() ?: return
+    outboxPort.enqueue(DomainOutboxEvent.AggregatePlaybackData(AggregationPeriodType.DAY, date))
   }
 
   override fun enqueueAggregateWeek(weekStart: LocalDate) {
-    val userId = currentUserResolver.userId() ?: return
-    outboxPort.enqueue(DomainOutboxEvent.AggregatePlaybackData(userId, AggregationPeriodType.WEEK, weekStart))
+    currentUserResolver.userId() ?: return
+    outboxPort.enqueue(DomainOutboxEvent.AggregatePlaybackData(AggregationPeriodType.WEEK, weekStart))
   }
 
   override fun enqueueAggregateMonth(monthStart: LocalDate) {
-    val userId = currentUserResolver.userId() ?: return
-    outboxPort.enqueue(DomainOutboxEvent.AggregatePlaybackData(userId, AggregationPeriodType.MONTH, monthStart))
+    currentUserResolver.userId() ?: return
+    outboxPort.enqueue(DomainOutboxEvent.AggregatePlaybackData(AggregationPeriodType.MONTH, monthStart))
   }
 
   override fun enqueueAggregateQuarter(quarterStart: LocalDate) {
-    val userId = currentUserResolver.userId() ?: return
-    outboxPort.enqueue(DomainOutboxEvent.AggregatePlaybackData(userId, AggregationPeriodType.QUARTER, quarterStart))
+    currentUserResolver.userId() ?: return
+    outboxPort.enqueue(DomainOutboxEvent.AggregatePlaybackData(AggregationPeriodType.QUARTER, quarterStart))
   }
 
   override fun enqueueAggregateYear(yearStart: LocalDate) {
-    val userId = currentUserResolver.userId() ?: return
-    outboxPort.enqueue(DomainOutboxEvent.AggregatePlaybackData(userId, AggregationPeriodType.YEAR, yearStart))
+    currentUserResolver.userId() ?: return
+    outboxPort.enqueue(DomainOutboxEvent.AggregatePlaybackData(AggregationPeriodType.YEAR, yearStart))
   }
 
   // --- Rebuild ---
@@ -167,19 +167,20 @@ class PlaybackAggregationService(
   // --- Outbox handler ---
 
   override fun handle(event: DomainOutboxEvent.AggregatePlaybackData): Either<DomainError, Unit> {
+    val userId = currentUserResolver.userId() ?: return Unit.right()
     when (event.type) {
-      AggregationPeriodType.DAY -> aggregateDay(event.userId, event.periodStart)
+      AggregationPeriodType.DAY -> aggregateDay(userId, event.periodStart)
       AggregationPeriodType.WEEK -> aggregateFromDailyAggregations(
-        event.userId, AggregationPeriodType.WEEK, event.periodStart, event.periodStart.plusKDays(DAYS_IN_WEEK),
+        userId, AggregationPeriodType.WEEK, event.periodStart, event.periodStart.plusKDays(DAYS_IN_WEEK),
       )
       AggregationPeriodType.MONTH -> aggregateFromDailyAggregations(
-        event.userId, AggregationPeriodType.MONTH, event.periodStart, event.periodStart.endOfMonth(),
+        userId, AggregationPeriodType.MONTH, event.periodStart, event.periodStart.endOfMonth(),
       )
       AggregationPeriodType.QUARTER -> aggregateFromDailyAggregations(
-        event.userId, AggregationPeriodType.QUARTER, event.periodStart, event.periodStart.plusKMonths(MONTHS_PER_QUARTER).minusKDays(1),
+        userId, AggregationPeriodType.QUARTER, event.periodStart, event.periodStart.plusKMonths(MONTHS_PER_QUARTER).minusKDays(1),
       )
       AggregationPeriodType.YEAR -> aggregateFromDailyAggregations(
-        event.userId, AggregationPeriodType.YEAR, event.periodStart, event.periodStart.plusKMonths(MONTHS_PER_YEAR).minusKDays(1),
+        userId, AggregationPeriodType.YEAR, event.periodStart, event.periodStart.plusKMonths(MONTHS_PER_YEAR).minusKDays(1),
       )
     }
     recordAggregationSuccess(event.type)

--- a/domain-impl/src/main/kotlin/de/chrgroth/spotify/control/domain/playback/PlaybackEventViewerService.kt
+++ b/domain-impl/src/main/kotlin/de/chrgroth/spotify/control/domain/playback/PlaybackEventViewerService.kt
@@ -5,10 +5,10 @@ import de.chrgroth.spotify.control.domain.model.playback.PlaybackEventEntry
 import de.chrgroth.spotify.control.domain.model.playback.PlaybackEventType
 import de.chrgroth.spotify.control.domain.model.playback.PlaybackEventViewerResult
 import de.chrgroth.spotify.control.domain.model.playback.RawPlaybackEvent
-import de.chrgroth.spotify.control.domain.model.user.UserId
 import de.chrgroth.spotify.control.domain.port.`in`.playback.PlaybackEventViewerPort
 import de.chrgroth.spotify.control.domain.port.out.catalog.AppAlbumRepositoryPort
 import de.chrgroth.spotify.control.domain.port.out.playback.PlaybackEventViewerRepositoryPort
+import de.chrgroth.spotify.control.domain.user.CurrentUserResolver
 import jakarta.enterprise.context.ApplicationScoped
 import kotlin.time.Clock
 import kotlinx.datetime.DatePeriod
@@ -23,14 +23,15 @@ import kotlinx.datetime.toLocalDateTime
 class PlaybackEventViewerService(
   private val repository: PlaybackEventViewerRepositoryPort,
   private val appAlbumRepository: AppAlbumRepositoryPort,
+  private val currentUserResolver: CurrentUserResolver,
 ) : PlaybackEventViewerPort {
 
-  override fun getEvents(userId: UserId, date: LocalDate): PlaybackEventViewerResult {
+  override fun getEvents(date: LocalDate): PlaybackEventViewerResult {
     val tz = TimeZone.currentSystemDefault()
+    val isToday = date == Clock.System.now().toLocalDateTime(tz).date
+    val userId = currentUserResolver.userId() ?: return PlaybackEventViewerResult(date = date, isToday = isToday, events = emptyList())
     val from = date.atStartOfDayIn(tz)
     val to = date.plus(DatePeriod(days = 1)).atStartOfDayIn(tz)
-    val today = Clock.System.now().toLocalDateTime(tz).date
-    val isToday = date == today
 
     val rawCurrentlyPlaying = repository.findCurrentlyPlaying(userId, from, to)
     val latestCurrentlyPlayingTimestamp = if (isToday) rawCurrentlyPlaying.maxByOrNull { it.timestamp }?.timestamp else null

--- a/domain-impl/src/main/kotlin/de/chrgroth/spotify/control/domain/playback/PlaybackService.kt
+++ b/domain-impl/src/main/kotlin/de/chrgroth/spotify/control/domain/playback/PlaybackService.kt
@@ -68,11 +68,12 @@ class PlaybackService(
   // --- Combined Playback Detection ---
 
   override fun enqueueFetchPlaybackData() {
-    val userId = currentUserResolver.userId() ?: return
-    outboxPort.enqueue(DomainOutboxEvent.FetchPlaybackData(userId))
+    currentUserResolver.userId() ?: return
+    outboxPort.enqueue(DomainOutboxEvent.FetchPlaybackData())
   }
 
-  override fun fetchPlaybackData(userId: UserId): Either<DomainError, Unit> {
+  override fun fetchPlaybackData(): Either<DomainError, Unit> {
+    val userId = currentUserResolver.userId() ?: return Unit.right()
     val currentlyPlayingResult = fetchCurrentlyPlaying(userId)
     val recentlyPlayedResult = fetchRecentlyPlayed(userId)
     return currentlyPlayingResult.flatMap { recentlyPlayedResult }
@@ -82,7 +83,8 @@ class PlaybackService(
 
   internal fun fetchCurrentlyPlaying(userId: UserId): Either<DomainError, Unit> {
     val accessToken = spotifyAccessToken.getValidAccessToken()
-    return spotifyPlayback.getCurrentlyPlaying(userId, accessToken).flatMap { item ->
+    return spotifyPlayback.getCurrentlyPlaying(accessToken).flatMap { rawItem ->
+      val item = rawItem?.copy(spotifyUserId = userId)
       if (item != null && item.isPlaying) {
         playbackState.onPlaybackDetected()
       }
@@ -153,7 +155,8 @@ class PlaybackService(
   internal fun fetchRecentlyPlayed(userId: UserId): Either<DomainError, Unit> {
     val accessToken = spotifyAccessToken.getValidAccessToken()
     val after = recentlyPlayedRepository.findMostRecentPlayedAt(userId)
-    return spotifyPlayback.getRecentlyPlayed(userId, accessToken, after).flatMap { tracks ->
+    return spotifyPlayback.getRecentlyPlayed(accessToken, after).flatMap { rawTracks ->
+      val tracks = rawTracks.map { it.copy(spotifyUserId = userId) }
       val playedAts = tracks.map { it.playedAt }.toSet()
       val existingPlayedAts = recentlyPlayedRepository.findExistingPlayedAts(userId, playedAts)
       val newItems = tracks.filter { it.playedAt !in existingPlayedAts }
@@ -165,7 +168,7 @@ class PlaybackService(
       val computedCount = convertPartialPlays(userId, tracks.map { it.trackId }.toSet())
       if (newItems.isNotEmpty() || computedCount > 0) {
         dashboardRefresh.notifyUserPlaybackData()
-        outboxPort.enqueue(DomainOutboxEvent.AppendPlaybackData(userId))
+        outboxPort.enqueue(DomainOutboxEvent.AppendPlaybackData())
       }
       recordFetchSuccess(userId, "recently_played")
       Unit.right()
@@ -216,7 +219,7 @@ class PlaybackService(
         .map { instant -> JLocalDate.ofInstant(instant.toJavaInstant(), ZoneOffset.UTC).toKotlinLocalDate() }
         .toSet()
         .forEach { day ->
-          outboxPort.enqueue(DomainOutboxEvent.AggregatePlaybackData(userId, AggregationPeriodType.DAY, day))
+          outboxPort.enqueue(DomainOutboxEvent.AggregatePlaybackData(AggregationPeriodType.DAY, day))
         }
     }
   }
@@ -267,18 +270,25 @@ class PlaybackService(
 
   // --- Playback Data ---
 
-  override fun enqueueRebuildPlaybackData(userId: UserId) {
+  override fun enqueueRebuildPlaybackData() {
+    val userId = currentUserResolver.userId() ?: return
     logger.info { "Enqueuing playback data rebuild for user: ${userDisplayName(userId)}" }
-    outboxPort.enqueue(DomainOutboxEvent.RebuildPlaybackData(userId))
+    outboxPort.enqueue(DomainOutboxEvent.RebuildPlaybackData())
   }
 
-  override fun rebuildPlaybackData(userId: UserId) {
+  override fun rebuildPlaybackData() {
+    val userId = currentUserResolver.userId() ?: return
     logger.info { "Rebuilding playback data for user: ${userDisplayName(userId)}" }
     appPlaybackRepository.deleteAllByUserId(userId)
-    appendPlaybackData(userId)
+    appendPlaybackDataForUser(userId)
   }
 
-  override fun appendPlaybackData(userId: UserId) {
+  override fun appendPlaybackData() {
+    val userId = currentUserResolver.userId() ?: return
+    appendPlaybackDataForUser(userId)
+  }
+
+  private fun appendPlaybackDataForUser(userId: UserId) {
     val since = appPlaybackRepository.findMostRecentPlayedAt(userId)
     val recentlyPlayed = recentlyPlayedRepository.findSince(userId, since)
     val partialPlayed = recentlyPartialPlayedRepository.findSince(userId, since)
@@ -299,14 +309,14 @@ class PlaybackService(
       .map { item -> JLocalDate.ofInstant(item.playedAt.toJavaInstant(), ZoneOffset.UTC).toKotlinLocalDate() }
       .toSet()
       .forEach { day ->
-        outboxPort.enqueue(DomainOutboxEvent.AggregatePlaybackData(userId, AggregationPeriodType.DAY, day))
+        outboxPort.enqueue(DomainOutboxEvent.AggregatePlaybackData(AggregationPeriodType.DAY, day))
       }
 
     val catalogRequests = (
       recentlyPlayed.map { CatalogSyncRequest(it.trackId.value, listOfNotNull(it.artistIds.firstOrNull()?.value), SyncCause.Playback(it.trackId.value)) } +
         partialPlayed.map { CatalogSyncRequest(it.trackId.value, listOfNotNull(it.artistIds.firstOrNull()?.value), SyncCause.Playback(it.trackId.value)) }
     ).distinctBy { it.trackId }
-    syncController.syncForTracks(catalogRequests, userId)
+    syncController.syncForTracks(catalogRequests)
   }
 
   private fun buildPlaybackItems(
@@ -331,15 +341,15 @@ class PlaybackService(
   // --- Outbox Handlers ---
 
   override fun handle(event: DomainOutboxEvent.FetchPlaybackData): Either<DomainError, Unit> =
-    fetchPlaybackData(event.userId)
+    fetchPlaybackData()
 
   override fun handle(event: DomainOutboxEvent.RebuildPlaybackData): Either<DomainError, Unit> {
-    rebuildPlaybackData(event.userId)
+    rebuildPlaybackData()
     return Unit.right()
   }
 
   override fun handle(event: DomainOutboxEvent.AppendPlaybackData): Either<DomainError, Unit> {
-    appendPlaybackData(event.userId)
+    appendPlaybackData()
     return Unit.right()
   }
 

--- a/domain-impl/src/main/kotlin/de/chrgroth/spotify/control/domain/playlist/PlaylistCheckService.kt
+++ b/domain-impl/src/main/kotlin/de/chrgroth/spotify/control/domain/playlist/PlaylistCheckService.kt
@@ -8,7 +8,6 @@ import de.chrgroth.spotify.control.domain.error.PlaylistFixError
 import de.chrgroth.spotify.control.domain.playlist.check.PlaylistCheckRunner
 import de.chrgroth.spotify.control.domain.model.playlist.AppPlaylistCheck
 import de.chrgroth.spotify.control.domain.model.playlist.PlaylistCheckDashboard
-import de.chrgroth.spotify.control.domain.model.user.UserId
 import de.chrgroth.spotify.control.domain.outbox.DomainOutboxEvent
 import de.chrgroth.spotify.control.domain.port.`in`.playlist.PlaylistCheckPort
 import de.chrgroth.spotify.control.domain.port.out.playlist.AppPlaylistCheckRepositoryPort
@@ -18,6 +17,7 @@ import de.chrgroth.spotify.control.domain.port.out.playlist.PlaylistCheckNotific
 import de.chrgroth.spotify.control.domain.port.out.playlist.PlaylistRepositoryPort
 import de.chrgroth.spotify.control.domain.port.out.user.SpotifyAccessTokenPort
 import de.chrgroth.spotify.control.domain.port.out.user.UserRepositoryPort
+import de.chrgroth.spotify.control.domain.user.CurrentUserResolver
 import io.micrometer.core.instrument.MeterRegistry
 import io.micrometer.core.instrument.Timer
 import jakarta.enterprise.context.ApplicationScoped
@@ -33,6 +33,7 @@ class PlaylistCheckService(
   private val playlistRepository: PlaylistRepositoryPort,
   private val playlistCheckRepository: AppPlaylistCheckRepositoryPort,
   private val userRepository: UserRepositoryPort,
+  private val currentUserResolver: CurrentUserResolver,
   private val dashboardRefresh: DashboardRefreshPort,
   private val notification: PlaylistCheckNotificationPort,
   private val spotifyAccessToken: SpotifyAccessTokenPort,
@@ -42,13 +43,14 @@ class PlaylistCheckService(
 ) : PlaylistCheckPort {
 
   override fun handle(event: DomainOutboxEvent.RunPlaylistChecks): Either<DomainError, Unit> {
-    val playlist = playlistRepository.findByUserIdAndPlaylistId(event.userId, event.playlistId)
+    val userId = currentUserResolver.userId() ?: return Unit.right()
+    val playlist = playlistRepository.findByUserIdAndPlaylistId(userId, event.playlistId)
     if (playlist == null) {
-      logger.warn { "Playlist ${event.playlistId} not found for user ${event.userId.value}, skipping checks" }
+      logger.warn { "Playlist ${event.playlistId} not found for user ${userId.value}, skipping checks" }
       return Unit.right()
     }
 
-    val allPlaylistInfos = playlistRepository.findByUserId(event.userId)
+    val allPlaylistInfos = playlistRepository.findByUserId(userId)
     val currentPlaylistInfo = allPlaylistInfos.find { it.spotifyPlaylistId == event.playlistId }
 
     val applicableRunners = checkRunners.filter { it.isApplicable(currentPlaylistInfo) }
@@ -56,7 +58,7 @@ class PlaylistCheckService(
       .map { runner ->
         managedExecutor.supplyAsync {
           timedCheck(runner.checkId, event.playlistId) {
-            runner.run(event.userId, event.playlistId, playlist, currentPlaylistInfo, allPlaylistInfos)
+            runner.run(userId, event.playlistId, playlist, currentPlaylistInfo, allPlaylistInfos)
           }
         }
       }
@@ -70,12 +72,19 @@ class PlaylistCheckService(
 
     val totalViolations = results.sumOf { it.violations.size }
     val status = if (totalViolations == 0) "all passed" else "$totalViolations violation(s)"
-    logger.info { "Ran playlist checks for playlist ${event.playlistId} (user ${event.userId.value}): $status" }
+    logger.info { "Ran playlist checks for playlist ${event.playlistId} (user ${userId.value}): $status" }
     dashboardRefresh.notifyUserPlaylistChecks()
     return Unit.right()
   }
 
-  override fun getCheckDashboard(userId: UserId): PlaylistCheckDashboard {
+  override fun getCheckDashboard(): PlaylistCheckDashboard {
+    val userId = currentUserResolver.userId() ?: return PlaylistCheckDashboard(
+      displayName = "",
+      checks = emptyList(),
+      playlistNameById = emptyMap(),
+      displayNames = getDisplayNames(),
+      fixableCheckIds = getFixableCheckIds(),
+    )
     val displayNameFuture = managedExecutor.supplyAsync { userRepository.findById(userId)?.displayName ?: userId.value }
     val playlistNamesFuture = managedExecutor.supplyAsync {
       playlistRepository.findByUserId(userId).associateBy({ it.spotifyPlaylistId }, { it.name })
@@ -99,7 +108,8 @@ class PlaylistCheckService(
   override fun getFixableCheckIds(): Set<String> =
     checkRunners.filter { it.canFix() }.map { it.checkId }.toSet()
 
-  override fun runFix(userId: UserId, playlistId: String, checkType: String): Either<DomainError, Unit> {
+  override fun runFix(playlistId: String, checkType: String): Either<DomainError, Unit> {
+    val userId = currentUserResolver.userId() ?: return PlaylistFixError.PLAYLIST_NOT_FOUND.left()
     val runner = checkRunners.find { it.checkId == checkType && it.canFix() } ?: run {
       logger.warn { "No fix runner found for checkType $checkType" }
       return PlaylistFixError.FIX_NOT_FOUND.left()
@@ -115,7 +125,7 @@ class PlaylistCheckService(
     return runner.fix(userId, accessToken, playlistId, playlist, currentPlaylistInfo, allPlaylistInfos).also { result ->
       if (result.isRight()) {
         logger.info { "Fix '$checkType' for playlist $playlistId completed, enqueueing re-check" }
-        outboxPort.enqueue(DomainOutboxEvent.SyncPlaylistData(userId, playlistId))
+        outboxPort.enqueue(DomainOutboxEvent.SyncPlaylistData(playlistId))
       }
     }
   }

--- a/domain-impl/src/main/kotlin/de/chrgroth/spotify/control/domain/playlist/PlaylistService.kt
+++ b/domain-impl/src/main/kotlin/de/chrgroth/spotify/control/domain/playlist/PlaylistService.kt
@@ -57,20 +57,26 @@ class PlaylistService(
       .register(meterRegistry)
   }
 
-  override fun getPlaylists(userId: UserId): List<PlaylistInfo> = playlistRepository.findByUserId(userId)
+  override fun getPlaylists(): List<PlaylistInfo> {
+    val userId = currentUserResolver.userId() ?: return emptyList()
+    return playlistRepository.findByUserId(userId)
+  }
 
-  override fun getTrackCounts(userId: UserId): Map<String, Int> = playlistRepository.findTrackCountsByUserId(userId)
+  override fun getTrackCounts(): Map<String, Int> {
+    val userId = currentUserResolver.userId() ?: return emptyMap()
+    return playlistRepository.findTrackCountsByUserId(userId)
+  }
 
   override fun enqueueUpdates() {
-    val userId = currentUserResolver.userId() ?: return
-    outboxPort.enqueue(DomainOutboxEvent.SyncPlaylistInfo(userId))
+    currentUserResolver.userId() ?: return
+    outboxPort.enqueue(DomainOutboxEvent.SyncPlaylistInfo())
     lastSyncJobSuccessTimestamp.set(Clock.System.now().toEpochMilliseconds() / MILLIS_PER_SECOND)
   }
 
-  override fun syncPlaylists(userId: UserId): Either<DomainError, Unit> {
-    userRepository.findById(userId) ?: return Unit.right()
+  override fun syncPlaylists(): Either<DomainError, Unit> {
+    val userId = currentUserResolver.userId() ?: return Unit.right()
     val accessToken = spotifyAccessToken.getValidAccessToken()
-    return spotifyPlaylist.getPlaylists(userId, accessToken).map { spotifyPlaylists ->
+    return spotifyPlaylist.getPlaylists(accessToken).map { spotifyPlaylists ->
       val now = Clock.System.now()
       val existingById = playlistRepository.findByUserId(userId).associateBy { it.spotifyPlaylistId }
       val updatedPlaylists = spotifyPlaylists.filter { it.ownerId == userId.value }.map { item ->
@@ -97,19 +103,19 @@ class PlaylistService(
             playlistRepository.findByUserIdAndPlaylistId(userId, playlist.spotifyPlaylistId) == null
         }
         .forEach { playlist ->
-          outboxPort.enqueue(DomainOutboxEvent.SyncPlaylistData(userId, playlist.spotifyPlaylistId))
+          outboxPort.enqueue(DomainOutboxEvent.SyncPlaylistData(playlist.spotifyPlaylistId))
         }
     }
   }
 
-  override fun syncPlaylistData(userId: UserId, playlistId: String, nextUrl: String?, snapshotId: String?): Either<DomainError, Unit> {
-    userRepository.findById(userId) ?: return Unit.right()
+  override fun syncPlaylistData(playlistId: String, nextUrl: String?, snapshotId: String?): Either<DomainError, Unit> {
+    val userId = currentUserResolver.userId() ?: return Unit.right()
     val accessToken = spotifyAccessToken.getValidAccessToken()
     val isFirstPage = nextUrl == null
-    return spotifyPlaylist.getPlaylistTracksPage(userId, accessToken, playlistId, nextUrl).map { page ->
+    return spotifyPlaylist.getPlaylistTracksPage(accessToken, playlistId, nextUrl).map { page ->
       if (snapshotId != null && page.snapshotId != snapshotId) {
         logger.warn { "Snapshot changed for playlist $playlistId (expected $snapshotId, got ${page.snapshotId}), restarting sync from first page" }
-        outboxPort.enqueue(DomainOutboxEvent.SyncPlaylistData(userId, playlistId))
+        outboxPort.enqueue(DomainOutboxEvent.SyncPlaylistData(playlistId))
         return@map
       }
       if (isFirstPage) {
@@ -121,20 +127,20 @@ class PlaylistService(
       val catalogRequests = page.tracks.map {
         CatalogSyncRequest(it.trackId.value, listOfNotNull(it.artistIds.firstOrNull()?.value), SyncCause.Playlist(playlistId, it.trackId.value))
       }
-      syncController.syncForTracks(catalogRequests, userId)
+      syncController.syncForTracks(catalogRequests)
 
       if (page.nextUrl != null) {
-        outboxPort.enqueue(DomainOutboxEvent.SyncPlaylistData(userId, playlistId, page.nextUrl, page.snapshotId))
+        outboxPort.enqueue(DomainOutboxEvent.SyncPlaylistData(playlistId, page.nextUrl, page.snapshotId))
       } else {
         logger.info { "Completed all pages for playlist $playlistId (user ${userDisplayName(userId)})" }
         playlistRepository.updateLastSyncTime(userId, playlistId, Clock.System.now())
-        outboxPort.enqueue(DomainOutboxEvent.RunPlaylistChecks(userId, playlistId))
+        outboxPort.enqueue(DomainOutboxEvent.RunPlaylistChecks(playlistId))
       }
     }
   }
 
-  override fun updateSyncStatus(userId: UserId, playlistId: String, syncStatus: PlaylistSyncStatus): Either<DomainError, Unit> {
-    userRepository.findById(userId) ?: return PlaylistSyncError.PLAYLIST_NOT_FOUND.left()
+  override fun updateSyncStatus(playlistId: String, syncStatus: PlaylistSyncStatus): Either<DomainError, Unit> {
+    val userId = currentUserResolver.userId() ?: return PlaylistSyncError.PLAYLIST_NOT_FOUND.left()
     val playlists = playlistRepository.findByUserId(userId)
     val playlist = playlists.find { it.spotifyPlaylistId == playlistId }
       ?: return PlaylistSyncError.PLAYLIST_NOT_FOUND.left()
@@ -161,12 +167,13 @@ class PlaylistService(
       playlistCheckRepository.deleteByPlaylistId(playlistId)
     } else if (syncStatus == PlaylistSyncStatus.ACTIVE) {
       logger.info { "Enqueueing SyncPlaylistData for activated playlist '${playlist.name}' ($playlistId, user ${userDisplayName(userId)})" }
-      outboxPort.enqueue(DomainOutboxEvent.SyncPlaylistData(userId, playlistId))
+      outboxPort.enqueue(DomainOutboxEvent.SyncPlaylistData(playlistId))
     }
     return Unit.right()
   }
 
-  override fun updatePlaylistType(userId: UserId, playlistId: String, type: PlaylistType): Either<DomainError, Unit> {
+  override fun updatePlaylistType(playlistId: String, type: PlaylistType): Either<DomainError, Unit> {
+    val userId = currentUserResolver.userId() ?: return PlaylistSyncError.PLAYLIST_NOT_FOUND.left()
     val validationError = validatePlaylistTypeUpdate(userId, playlistId, type)
     if (validationError != null) return validationError.left()
     val playlists = playlistRepository.findByUserId(userId)
@@ -181,7 +188,6 @@ class PlaylistService(
   }
 
   private fun validatePlaylistTypeUpdate(userId: UserId, playlistId: String, type: PlaylistType): PlaylistSyncError? {
-    userRepository.findById(userId) ?: return PlaylistSyncError.PLAYLIST_NOT_FOUND
     val playlists = playlistRepository.findByUserId(userId)
     val playlist = playlists.find { it.spotifyPlaylistId == playlistId }
     return when {
@@ -195,8 +201,8 @@ class PlaylistService(
     }
   }
 
-  override fun enqueueSyncPlaylistData(userId: UserId, playlistId: String): Either<DomainError, Unit> {
-    userRepository.findById(userId) ?: return PlaylistSyncError.PLAYLIST_NOT_FOUND.left()
+  override fun enqueueSyncPlaylistData(playlistId: String): Either<DomainError, Unit> {
+    val userId = currentUserResolver.userId() ?: return PlaylistSyncError.PLAYLIST_NOT_FOUND.left()
     val playlists = playlistRepository.findByUserId(userId)
     val playlist = playlists.find { it.spotifyPlaylistId == playlistId }
       ?: return PlaylistSyncError.PLAYLIST_NOT_FOUND.left()
@@ -204,16 +210,16 @@ class PlaylistService(
       PlaylistSyncError.PLAYLIST_SYNC_INACTIVE.left()
     } else {
       logger.info { "Enqueueing SyncPlaylistData for playlist '${playlist.name}' ($playlistId, user ${userDisplayName(userId)})" }
-      outboxPort.enqueue(DomainOutboxEvent.SyncPlaylistData(userId, playlistId))
+      outboxPort.enqueue(DomainOutboxEvent.SyncPlaylistData(playlistId))
       Unit.right()
     }
   }
 
   override fun handle(event: DomainOutboxEvent.SyncPlaylistInfo): Either<DomainError, Unit> =
-    syncPlaylists(event.userId)
+    syncPlaylists()
 
   override fun handle(event: DomainOutboxEvent.SyncPlaylistData): Either<DomainError, Unit> =
-    syncPlaylistData(event.userId, event.playlistId, event.nextUrl, event.snapshotId)
+    syncPlaylistData(event.playlistId, event.nextUrl, event.snapshotId)
 
   private fun userDisplayName(userId: UserId) = userRepository.findById(userId)?.displayName ?: userId.value
 

--- a/domain-impl/src/main/kotlin/de/chrgroth/spotify/control/domain/playlist/check/DuplicateTrackIdsCheckRunner.kt
+++ b/domain-impl/src/main/kotlin/de/chrgroth/spotify/control/domain/playlist/check/DuplicateTrackIdsCheckRunner.kt
@@ -69,8 +69,8 @@ class DuplicateTrackIdsCheckRunner(
       return Unit.right()
     }
     logger.info { "Removing all occurrences of ${duplicateTrackIds.size} duplicate track(s) from playlist $playlistId (user ${userId.value}), then re-adding once each" }
-    return spotifyPlaylist.removePlaylistTracks(userId, accessToken, playlistId, duplicateTrackIds)
-      .flatMap { spotifyPlaylist.addPlaylistTracks(userId, accessToken, playlistId, duplicateTrackIds) }
+    return spotifyPlaylist.removePlaylistTracks(accessToken, playlistId, duplicateTrackIds)
+      .flatMap { spotifyPlaylist.addPlaylistTracks(accessToken, playlistId, duplicateTrackIds) }
       .onRight { meterRegistry.counter("app.playlist.duplicates_removed", "playlistId", playlistId).increment(duplicateTrackIds.size.toDouble()) }
   }
 

--- a/domain-impl/src/main/kotlin/de/chrgroth/spotify/control/domain/playlist/check/TrackFromLatestReleaseCheckRunner.kt
+++ b/domain-impl/src/main/kotlin/de/chrgroth/spotify/control/domain/playlist/check/TrackFromLatestReleaseCheckRunner.kt
@@ -69,7 +69,7 @@ class TrackFromLatestReleaseCheckRunner(
     // Process in reverse position order so earlier positions are unaffected by later replacements
     violations.sortedByDescending { it.position }.forEach { violation ->
       val result = spotifyPlaylist.replacePlaylistTrack(
-        userId, accessToken, playlistId,
+        accessToken, playlistId,
         violation.oldTrackId, violation.newTrackId, violation.position,
       )
       result.onLeft { error ->

--- a/domain-impl/src/main/kotlin/de/chrgroth/spotify/control/domain/playlist/check/YearSongsInAllCheckRunner.kt
+++ b/domain-impl/src/main/kotlin/de/chrgroth/spotify/control/domain/playlist/check/YearSongsInAllCheckRunner.kt
@@ -85,7 +85,7 @@ class YearSongsInAllCheckRunner(
         Unit.right()
       } else {
         logger.info { "Adding ${missingTrackIds.size} track(s) to all playlist ${allPlaylistInfo.spotifyPlaylistId} (user ${userId.value})" }
-        spotifyPlaylist.addPlaylistTracks(userId, accessToken, allPlaylistInfo.spotifyPlaylistId, missingTrackIds)
+        spotifyPlaylist.addPlaylistTracks(accessToken, allPlaylistInfo.spotifyPlaylistId, missingTrackIds)
       }
     }
 

--- a/domain-impl/src/test/kotlin/de/chrgroth/spotify/control/domain/catalog/CatalogServiceTests.kt
+++ b/domain-impl/src/test/kotlin/de/chrgroth/spotify/control/domain/catalog/CatalogServiceTests.kt
@@ -140,7 +140,7 @@ class CatalogServiceTests {
     val result = adapter.resyncArtist("artist-1")
 
     assertThat(result.isRight()).isTrue()
-    verify { outboxPort.enqueue(DomainOutboxEvent.SyncArtistAlbums("artist-1", userId)) }
+    verify { outboxPort.enqueue(DomainOutboxEvent.SyncArtistAlbums("artist-1")) }
     verify(exactly = 0) { outboxPort.enqueue(match { it is DomainOutboxEvent.SyncAlbumDetails }) }
   }
 
@@ -175,7 +175,6 @@ class CatalogServiceTests {
             requests.any { it == CatalogSyncRequest("track-1", listOf("artist-1"), SyncCause.ManualResync) } &&
             requests.any { it == CatalogSyncRequest("track-2", listOf("artist-2"), SyncCause.ManualResync) }
         },
-        userId,
       )
     }
   }
@@ -191,8 +190,8 @@ class CatalogServiceTests {
     val result = adapter.resyncCatalog()
 
     assertThat(result.isRight()).isTrue()
-    verify { outboxPort.enqueue(DomainOutboxEvent.SyncArtistAlbums("artist-1", userId)) }
-    verify { outboxPort.enqueue(DomainOutboxEvent.SyncArtistAlbums("artist-2", userId)) }
+    verify { outboxPort.enqueue(DomainOutboxEvent.SyncArtistAlbums("artist-1")) }
+    verify { outboxPort.enqueue(DomainOutboxEvent.SyncArtistAlbums("artist-2")) }
   }
 
   @Test
@@ -240,7 +239,7 @@ class CatalogServiceTests {
     val result = adapter.handle(DomainOutboxEvent.SyncAlbumDetails("album-1"))
 
     assertThat(result.isRight()).isTrue()
-    verify(exactly = 0) { spotifyCatalog.getAlbum(any(), any(), any()) }
+    verify(exactly = 0) { spotifyCatalog.getAlbum(any(), any()) }
   }
 
   @Test
@@ -248,15 +247,15 @@ class CatalogServiceTests {
     every { currentUserResolver.userId() } returns userId
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
     every { appAlbumRepository.findByAlbumIds(setOf(AlbumId("album-1"))) } returns listOf(album1)
-    every { spotifyCatalog.getAlbumTracks(userId, accessToken, album1) } returns listOf(trackWithAlbum1, trackWithAlbum2).right()
+    every { spotifyCatalog.getAlbumTracks(accessToken, album1) } returns listOf(trackWithAlbum1, trackWithAlbum2).right()
     every { appTrackRepository.upsertAll(any()) } just runs
     every { outboxPort.enqueue(any()) } just runs
 
     val result = adapter.handle(DomainOutboxEvent.SyncAlbumDetails("album-1"))
 
     assertThat(result.isRight()).isTrue()
-    verify { spotifyCatalog.getAlbumTracks(userId, accessToken, album1) }
-    verify(exactly = 0) { spotifyCatalog.getAlbum(any(), any(), any()) }
+    verify { spotifyCatalog.getAlbumTracks(accessToken, album1) }
+    verify(exactly = 0) { spotifyCatalog.getAlbum(any(), any()) }
     verify { appTrackRepository.upsertAll(listOf(trackWithAlbum1, trackWithAlbum2)) }
     verify(exactly = 0) { appAlbumRepository.upsertAll(any()) }
   }
@@ -266,7 +265,7 @@ class CatalogServiceTests {
     every { currentUserResolver.userId() } returns userId
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
     every { appAlbumRepository.findByAlbumIds(setOf(AlbumId("album-1"))) } returns emptyList()
-    every { spotifyCatalog.getAlbum(userId, accessToken, "album-1") } returns albumSyncResult.right()
+    every { spotifyCatalog.getAlbum(accessToken, "album-1") } returns albumSyncResult.right()
     every { appTrackRepository.upsertAll(any()) } just runs
     every { appAlbumRepository.upsertAll(any()) } just runs
     every { outboxPort.enqueue(any()) } just runs
@@ -274,8 +273,8 @@ class CatalogServiceTests {
     val result = adapter.handle(DomainOutboxEvent.SyncAlbumDetails("album-1"))
 
     assertThat(result.isRight()).isTrue()
-    verify { spotifyCatalog.getAlbum(userId, accessToken, "album-1") }
-    verify(exactly = 0) { spotifyCatalog.getAlbumTracks(any(), any(), any()) }
+    verify { spotifyCatalog.getAlbum(accessToken, "album-1") }
+    verify(exactly = 0) { spotifyCatalog.getAlbumTracks(any(), any()) }
     verify { appTrackRepository.upsertAll(listOf(trackWithAlbum1, trackWithAlbum2)) }
     verify { appAlbumRepository.upsertAll(listOf(album1)) }
   }
@@ -285,13 +284,13 @@ class CatalogServiceTests {
     every { currentUserResolver.userId() } returns userId
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
     every { appAlbumRepository.findByAlbumIds(setOf(AlbumId("album-1"))) } returns emptyList()
-    every { spotifyCatalog.getAlbum(userId, accessToken, "album-1") } returns albumSyncResult.right()
+    every { spotifyCatalog.getAlbum(accessToken, "album-1") } returns albumSyncResult.right()
     every { appTrackRepository.upsertAll(any()) } just runs
     every { appAlbumRepository.upsertAll(any()) } just runs
 
     adapter.handle(DomainOutboxEvent.SyncAlbumDetails("album-1"))
 
-    verify(exactly = 0) { syncController.syncArtists(any(), any(), any()) }
+    verify(exactly = 0) { syncController.syncArtists(any(), any()) }
   }
 
   @Test
@@ -299,7 +298,7 @@ class CatalogServiceTests {
     every { currentUserResolver.userId() } returns userId
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
     every { appAlbumRepository.findByAlbumIds(setOf(AlbumId("album-1"))) } returns emptyList()
-    every { spotifyCatalog.getAlbum(userId, accessToken, "album-1") } returns SyncError.TRACK_DETAILS_FETCH_FAILED.left()
+    every { spotifyCatalog.getAlbum(accessToken, "album-1") } returns SyncError.TRACK_DETAILS_FETCH_FAILED.left()
 
     val result = adapter.handle(DomainOutboxEvent.SyncAlbumDetails("album-1"))
 
@@ -313,7 +312,7 @@ class CatalogServiceTests {
     every { currentUserResolver.userId() } returns userId
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
     every { appAlbumRepository.findByAlbumIds(setOf(AlbumId("album-1"))) } returns emptyList()
-    every { spotifyCatalog.getAlbum(userId, accessToken, "album-1") } returns rateLimitError.left()
+    every { spotifyCatalog.getAlbum(accessToken, "album-1") } returns rateLimitError.left()
 
     val result = adapter.handle(DomainOutboxEvent.SyncAlbumDetails("album-1"))
 
@@ -326,12 +325,12 @@ class CatalogServiceTests {
   fun `handle SyncArtistAlbums enqueues SyncAlbumDetails for new albums and completes when no next page`() {
     val page = ArtistAlbumsPage(albums = listOf(album1, album2), nextUrl = null)
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
-    every { spotifyCatalog.getArtistAlbumsPage(userId, accessToken, "artist-1", null) } returns page.right()
+    every { spotifyCatalog.getArtistAlbumsPage(accessToken, "artist-1", null) } returns page.right()
     every { appAlbumRepository.findByAlbumIds(setOf(AlbumId("album-1"), AlbumId("album-2"))) } returns emptyList()
     every { appAlbumRepository.upsertAll(any()) } just runs
     every { outboxPort.enqueue(any()) } just runs
 
-    val result = adapter.handle(DomainOutboxEvent.SyncArtistAlbums("artist-1", userId))
+    val result = adapter.handle(DomainOutboxEvent.SyncArtistAlbums("artist-1"))
 
     assertThat(result.isRight()).isTrue()
     verify { appAlbumRepository.upsertAll(listOf(album1, album2)) }
@@ -345,16 +344,16 @@ class CatalogServiceTests {
     val nextPageUrl = "https://api.spotify.com/v1/artists/artist-1/albums?offset=50&limit=50"
     val page = ArtistAlbumsPage(albums = listOf(album1), nextUrl = nextPageUrl)
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
-    every { spotifyCatalog.getArtistAlbumsPage(userId, accessToken, "artist-1", null) } returns page.right()
+    every { spotifyCatalog.getArtistAlbumsPage(accessToken, "artist-1", null) } returns page.right()
     every { appAlbumRepository.findByAlbumIds(setOf(AlbumId("album-1"))) } returns emptyList()
     every { appAlbumRepository.upsertAll(any()) } just runs
     every { outboxPort.enqueue(any()) } just runs
 
-    val result = adapter.handle(DomainOutboxEvent.SyncArtistAlbums("artist-1", userId))
+    val result = adapter.handle(DomainOutboxEvent.SyncArtistAlbums("artist-1"))
 
     assertThat(result.isRight()).isTrue()
     verify { outboxPort.enqueue(DomainOutboxEvent.SyncAlbumDetails("album-1")) }
-    verify { outboxPort.enqueue(DomainOutboxEvent.SyncArtistAlbums("artist-1", userId, nextPageUrl)) }
+    verify { outboxPort.enqueue(DomainOutboxEvent.SyncArtistAlbums("artist-1", nextPageUrl)) }
   }
 
   @Test
@@ -362,12 +361,12 @@ class CatalogServiceTests {
     val nextPageUrl = "https://api.spotify.com/v1/artists/artist-1/albums?offset=50&limit=50"
     val page = ArtistAlbumsPage(albums = listOf(album2), nextUrl = null)
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
-    every { spotifyCatalog.getArtistAlbumsPage(userId, accessToken, "artist-1", nextPageUrl) } returns page.right()
+    every { spotifyCatalog.getArtistAlbumsPage(accessToken, "artist-1", nextPageUrl) } returns page.right()
     every { appAlbumRepository.findByAlbumIds(setOf(AlbumId("album-2"))) } returns emptyList()
     every { appAlbumRepository.upsertAll(any()) } just runs
     every { outboxPort.enqueue(any()) } just runs
 
-    val result = adapter.handle(DomainOutboxEvent.SyncArtistAlbums("artist-1", userId, nextPageUrl))
+    val result = adapter.handle(DomainOutboxEvent.SyncArtistAlbums("artist-1", nextPageUrl))
 
     assertThat(result.isRight()).isTrue()
     verify { outboxPort.enqueue(DomainOutboxEvent.SyncAlbumDetails("album-2")) }
@@ -378,12 +377,12 @@ class CatalogServiceTests {
   fun `handle SyncArtistAlbums enqueues only new albums and skips existing ones`() {
     val page = ArtistAlbumsPage(albums = listOf(album1, album2), nextUrl = null)
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
-    every { spotifyCatalog.getArtistAlbumsPage(userId, accessToken, "artist-1", null) } returns page.right()
+    every { spotifyCatalog.getArtistAlbumsPage(accessToken, "artist-1", null) } returns page.right()
     every { appAlbumRepository.findByAlbumIds(setOf(AlbumId("album-1"), AlbumId("album-2"))) } returns listOf(album1)
     every { appAlbumRepository.upsertAll(any()) } just runs
     every { outboxPort.enqueue(any()) } just runs
 
-    val result = adapter.handle(DomainOutboxEvent.SyncArtistAlbums("artist-1", userId))
+    val result = adapter.handle(DomainOutboxEvent.SyncArtistAlbums("artist-1"))
 
     assertThat(result.isRight()).isTrue()
     verify { appAlbumRepository.upsertAll(listOf(album2)) }
@@ -396,11 +395,11 @@ class CatalogServiceTests {
     val nextPageUrl = "https://api.spotify.com/v1/artists/artist-1/albums?offset=50&limit=50"
     val page = ArtistAlbumsPage(albums = listOf(album1, album2), nextUrl = nextPageUrl)
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
-    every { spotifyCatalog.getArtistAlbumsPage(userId, accessToken, "artist-1", null) } returns page.right()
+    every { spotifyCatalog.getArtistAlbumsPage(accessToken, "artist-1", null) } returns page.right()
     every { appAlbumRepository.findByAlbumIds(setOf(AlbumId("album-1"), AlbumId("album-2"))) } returns listOf(album1, album2)
     every { outboxPort.enqueue(any()) } just runs
 
-    val result = adapter.handle(DomainOutboxEvent.SyncArtistAlbums("artist-1", userId))
+    val result = adapter.handle(DomainOutboxEvent.SyncArtistAlbums("artist-1"))
 
     assertThat(result.isRight()).isTrue()
     verify(exactly = 0) { outboxPort.enqueue(any()) }
@@ -412,25 +411,25 @@ class CatalogServiceTests {
     val nextPageUrl = "https://api.spotify.com/v1/artists/artist-1/albums?offset=50&limit=50"
     val page = ArtistAlbumsPage(albums = listOf(album1, album2), nextUrl = nextPageUrl)
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
-    every { spotifyCatalog.getArtistAlbumsPage(userId, accessToken, "artist-1", null) } returns page.right()
+    every { spotifyCatalog.getArtistAlbumsPage(accessToken, "artist-1", null) } returns page.right()
     every { appAlbumRepository.findByAlbumIds(setOf(AlbumId("album-1"), AlbumId("album-2"))) } returns listOf(album1)
     every { appAlbumRepository.upsertAll(any()) } just runs
     every { outboxPort.enqueue(any()) } just runs
 
-    val result = adapter.handle(DomainOutboxEvent.SyncArtistAlbums("artist-1", userId))
+    val result = adapter.handle(DomainOutboxEvent.SyncArtistAlbums("artist-1"))
 
     assertThat(result.isRight()).isTrue()
     verify { appAlbumRepository.upsertAll(listOf(album2)) }
     verify { outboxPort.enqueue(DomainOutboxEvent.SyncAlbumDetails("album-2")) }
-    verify { outboxPort.enqueue(DomainOutboxEvent.SyncArtistAlbums("artist-1", userId, nextPageUrl)) }
+    verify { outboxPort.enqueue(DomainOutboxEvent.SyncArtistAlbums("artist-1", nextPageUrl)) }
   }
 
   @Test
   fun `handle SyncArtistAlbums returns error when artist albums page fetch fails`() {
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
-    every { spotifyCatalog.getArtistAlbumsPage(userId, accessToken, "artist-1", null) } returns SyncError.ARTIST_DETAILS_FETCH_FAILED.left()
+    every { spotifyCatalog.getArtistAlbumsPage(accessToken, "artist-1", null) } returns SyncError.ARTIST_DETAILS_FETCH_FAILED.left()
 
-    val result = adapter.handle(DomainOutboxEvent.SyncArtistAlbums("artist-1", userId))
+    val result = adapter.handle(DomainOutboxEvent.SyncArtistAlbums("artist-1"))
 
     assertThat(result.isLeft()).isTrue()
     verify(exactly = 0) { outboxPort.enqueue(any()) }
@@ -471,7 +470,6 @@ class CatalogServiceTests {
             requests.any { it == CatalogSyncRequest("track-1", listOf("artist-1"), SyncCause.ManualResync) } &&
             requests.any { it == CatalogSyncRequest("track-2", listOf("artist-2"), SyncCause.ManualResync) }
         },
-        userId,
       )
     }
   }

--- a/domain-impl/src/test/kotlin/de/chrgroth/spotify/control/domain/catalog/PlaybackEnrichmentServiceTests.kt
+++ b/domain-impl/src/test/kotlin/de/chrgroth/spotify/control/domain/catalog/PlaybackEnrichmentServiceTests.kt
@@ -75,15 +75,16 @@ class PlaybackEnrichmentServiceTests {
       lastSync = kotlin.time.Instant.fromEpochSeconds(1),
     )
     every { appArtistRepository.findByArtistIds(setOf(ArtistId(artistId))) } returns emptyList()
+    every { currentUserResolver.userId() } returns userId
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
-    every { spotifyCatalog.getArtist(userId, accessToken, artistId) } returns spotifyArtist.right()
+    every { spotifyCatalog.getArtist(accessToken, artistId) } returns spotifyArtist.right()
     every { appArtistRepository.upsertAll(listOf(spotifyArtist)) } just runs
     every { outboxPort.enqueue(any()) } just runs
 
-    adapter.syncArtistDetails(artistId, userId)
+    adapter.syncArtistDetails(artistId)
 
     verify { appArtistRepository.upsertAll(listOf(spotifyArtist)) }
-    verify { outboxPort.enqueue(de.chrgroth.spotify.control.domain.outbox.DomainOutboxEvent.SyncArtistAlbums(artistId, userId)) }
+    verify { outboxPort.enqueue(de.chrgroth.spotify.control.domain.outbox.DomainOutboxEvent.SyncArtistAlbums(artistId)) }
   }
 
   @Test
@@ -96,9 +97,9 @@ class PlaybackEnrichmentServiceTests {
     )
     every { appArtistRepository.findByArtistIds(setOf(ArtistId(artistId))) } returns listOf(syncedArtist)
 
-    adapter.syncArtistDetails(artistId, userId)
+    adapter.syncArtistDetails(artistId)
 
-    verify(exactly = 0) { spotifyCatalog.getArtist(any(), any(), any()) }
+    verify(exactly = 0) { spotifyCatalog.getArtist(any(), any()) }
     verify(exactly = 0) { appArtistRepository.upsertAll(any()) }
   }
 }

--- a/domain-impl/src/test/kotlin/de/chrgroth/spotify/control/domain/catalog/SyncControllerTests.kt
+++ b/domain-impl/src/test/kotlin/de/chrgroth/spotify/control/domain/catalog/SyncControllerTests.kt
@@ -5,7 +5,6 @@ import de.chrgroth.spotify.control.domain.model.catalog.AppTrack
 import de.chrgroth.spotify.control.domain.model.catalog.ArtistId
 import de.chrgroth.spotify.control.domain.model.catalog.SyncCause
 import de.chrgroth.spotify.control.domain.model.catalog.TrackId
-import de.chrgroth.spotify.control.domain.model.user.UserId
 import de.chrgroth.spotify.control.domain.outbox.DomainOutboxEvent
 import de.chrgroth.spotify.control.domain.port.out.catalog.AppArtistRepositoryPort
 import de.chrgroth.spotify.control.domain.port.out.catalog.AppTrackRepositoryPort
@@ -31,7 +30,6 @@ class SyncControllerTests {
     outboxPort,
   )
 
-  private val userId = UserId("user-1")
   private val syncTime = Instant.fromEpochSeconds(1)
 
   private fun track(id: String) = AppTrack(
@@ -51,7 +49,7 @@ class SyncControllerTests {
 
   @Test
   fun `syncForTracks with empty list does nothing`() {
-    controller.syncForTracks(emptyList(), userId)
+    controller.syncForTracks(emptyList())
 
     verify(exactly = 0) { appTrackRepository.findByTrackIds(any()) }
     verify(exactly = 0) { outboxPort.enqueue(any()) }
@@ -63,7 +61,6 @@ class SyncControllerTests {
 
     controller.syncForTracks(
       listOf(CatalogSyncRequest("t1", listOf("artist-1"), SyncCause.ManualResync)),
-      userId,
     )
 
     verify(exactly = 0) { outboxPort.enqueue(any()) }
@@ -76,10 +73,9 @@ class SyncControllerTests {
 
     controller.syncForTracks(
       listOf(CatalogSyncRequest("t1", listOf("artist-1"), SyncCause.ManualResync)),
-      userId,
     )
 
-    verify { outboxPort.enqueue(DomainOutboxEvent.SyncArtistDetails("artist-1", userId)) }
+    verify { outboxPort.enqueue(DomainOutboxEvent.SyncArtistDetails("artist-1")) }
   }
 
   @Test
@@ -89,7 +85,6 @@ class SyncControllerTests {
 
     controller.syncForTracks(
       listOf(CatalogSyncRequest("t1", listOf("artist-1"), SyncCause.ManualResync)),
-      userId,
     )
 
     verify(exactly = 0) { outboxPort.enqueue(match { it is DomainOutboxEvent.SyncArtistDetails }) }
@@ -104,7 +99,6 @@ class SyncControllerTests {
         CatalogSyncRequest("t1", listOf("artist-1"), SyncCause.ManualResync),
         CatalogSyncRequest("t2", listOf("artist-2"), SyncCause.ManualResync),
       ),
-      userId,
     )
 
     verify(exactly = 0) { outboxPort.enqueue(any()) }
@@ -120,10 +114,9 @@ class SyncControllerTests {
         CatalogSyncRequest("t1", listOf("artist-shared"), SyncCause.ManualResync),
         CatalogSyncRequest("t2", listOf("artist-shared"), SyncCause.ManualResync),
       ),
-      userId,
     )
 
-    verify(exactly = 1) { outboxPort.enqueue(DomainOutboxEvent.SyncArtistDetails("artist-shared", userId)) }
+    verify(exactly = 1) { outboxPort.enqueue(DomainOutboxEvent.SyncArtistDetails("artist-shared")) }
   }
 
   // --- syncArtists ---
@@ -132,24 +125,24 @@ class SyncControllerTests {
   fun `syncArtists enqueues SyncArtistDetails for missing artists`() {
     every { appArtistRepository.findByArtistIds(any()) } returns emptyList()
 
-    controller.syncArtists(listOf("artist-1", "artist-2"), userId, SyncCause.ManualResync)
+    controller.syncArtists(listOf("artist-1", "artist-2"), SyncCause.ManualResync)
 
-    verify { outboxPort.enqueue(DomainOutboxEvent.SyncArtistDetails("artist-1", userId)) }
-    verify { outboxPort.enqueue(DomainOutboxEvent.SyncArtistDetails("artist-2", userId)) }
+    verify { outboxPort.enqueue(DomainOutboxEvent.SyncArtistDetails("artist-1")) }
+    verify { outboxPort.enqueue(DomainOutboxEvent.SyncArtistDetails("artist-2")) }
   }
 
   @Test
   fun `syncArtists skips artists already in catalog`() {
     every { appArtistRepository.findByArtistIds(any()) } returns listOf(artist("artist-1"))
 
-    controller.syncArtists(listOf("artist-1"), userId, SyncCause.ManualResync)
+    controller.syncArtists(listOf("artist-1"), SyncCause.ManualResync)
 
     verify(exactly = 0) { outboxPort.enqueue(any()) }
   }
 
   @Test
   fun `syncArtists with empty list does nothing`() {
-    controller.syncArtists(emptyList(), userId, SyncCause.ManualResync)
+    controller.syncArtists(emptyList(), SyncCause.ManualResync)
 
     verify(exactly = 0) { appArtistRepository.findByArtistIds(any()) }
     verify(exactly = 0) { outboxPort.enqueue(any()) }

--- a/domain-impl/src/test/kotlin/de/chrgroth/spotify/control/domain/playback/FetchCurrentlyPlayingServiceTests.kt
+++ b/domain-impl/src/test/kotlin/de/chrgroth/spotify/control/domain/playback/FetchCurrentlyPlayingServiceTests.kt
@@ -95,7 +95,7 @@ class FetchCurrentlyPlayingServiceTests {
   @Test
   fun `fetchCurrentlyPlaying returns Left on error`() {
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
-    every { spotifyPlayback.getCurrentlyPlaying(userId, accessToken) } returns PlaybackError.CURRENTLY_PLAYING_FETCH_FAILED.left()
+    every { spotifyPlayback.getCurrentlyPlaying(accessToken) } returns PlaybackError.CURRENTLY_PLAYING_FETCH_FAILED.left()
 
     val result = service.fetchCurrentlyPlaying(userId)
 
@@ -106,7 +106,7 @@ class FetchCurrentlyPlayingServiceTests {
   @Test
   fun `fetchCurrentlyPlaying does nothing when nothing is playing`() {
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
-    every { spotifyPlayback.getCurrentlyPlaying(userId, accessToken) } returns null.right()
+    every { spotifyPlayback.getCurrentlyPlaying(accessToken) } returns null.right()
 
     service.fetchCurrentlyPlaying(userId)
 
@@ -119,7 +119,7 @@ class FetchCurrentlyPlayingServiceTests {
   fun `fetchCurrentlyPlaying saves new entry when no existing entry for track`() {
     val item = currentlyPlayingItem("track-1", progressMs = 30_000L)
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
-    every { spotifyPlayback.getCurrentlyPlaying(userId, accessToken) } returns item.right()
+    every { spotifyPlayback.getCurrentlyPlaying(accessToken) } returns item.right()
     every { currentlyPlayingRepository.findMostRecentByUserAndTrack(userId, item.trackId) } returns null
 
     service.fetchCurrentlyPlaying(userId)
@@ -136,7 +136,7 @@ class FetchCurrentlyPlayingServiceTests {
     val newItem = currentlyPlayingItem("track-1", progressMs = 80_000L)
 
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
-    every { spotifyPlayback.getCurrentlyPlaying(userId, accessToken) } returns newItem.right()
+    every { spotifyPlayback.getCurrentlyPlaying(accessToken) } returns newItem.right()
     every { currentlyPlayingRepository.findMostRecentByUserAndTrack(userId, newItem.trackId) } returns existingItem
 
     service.fetchCurrentlyPlaying(userId)
@@ -153,7 +153,7 @@ class FetchCurrentlyPlayingServiceTests {
     val newItem = currentlyPlayingItem("track-1", progressMs = 210_000L)
 
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
-    every { spotifyPlayback.getCurrentlyPlaying(userId, accessToken) } returns newItem.right()
+    every { spotifyPlayback.getCurrentlyPlaying(accessToken) } returns newItem.right()
     every { currentlyPlayingRepository.findMostRecentByUserAndTrack(userId, newItem.trackId) } returns existingItem
 
     service.fetchCurrentlyPlaying(userId)
@@ -172,7 +172,7 @@ class FetchCurrentlyPlayingServiceTests {
     val afterResumeItem = currentlyPlayingItem("track-1", progressMs = 120_500L)
 
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
-    every { spotifyPlayback.getCurrentlyPlaying(userId, accessToken) } returns afterResumeItem.right()
+    every { spotifyPlayback.getCurrentlyPlaying(accessToken) } returns afterResumeItem.right()
     every { currentlyPlayingRepository.findMostRecentByUserAndTrack(userId, afterResumeItem.trackId) } returns existingItem
 
     service.fetchCurrentlyPlaying(userId)
@@ -190,7 +190,7 @@ class FetchCurrentlyPlayingServiceTests {
     val restartedItem = currentlyPlayingItem("track-1", progressMs = 3_000L)
 
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
-    every { spotifyPlayback.getCurrentlyPlaying(userId, accessToken) } returns restartedItem.right()
+    every { spotifyPlayback.getCurrentlyPlaying(accessToken) } returns restartedItem.right()
     every { currentlyPlayingRepository.findMostRecentByUserAndTrack(userId, restartedItem.trackId) } returns existingItem
 
     service.fetchCurrentlyPlaying(userId)
@@ -205,7 +205,7 @@ class FetchCurrentlyPlayingServiceTests {
     val newItem = currentlyPlayingItem("track-1", progressMs = 3_000L)
 
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
-    every { spotifyPlayback.getCurrentlyPlaying(userId, accessToken) } returns newItem.right()
+    every { spotifyPlayback.getCurrentlyPlaying(accessToken) } returns newItem.right()
     every { currentlyPlayingRepository.findMostRecentByUserAndTrack(userId, newItem.trackId) } returns null
 
     service.fetchCurrentlyPlaying(userId)
@@ -222,7 +222,7 @@ class FetchCurrentlyPlayingServiceTests {
     val trackB = currentlyPlayingItem("track-b", progressMs = 60_000L)
     val orphanedTrackA = currentlyPlayingItem("track-a", progressMs = 50_000L, observedAt = now - 5.minutes)
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
-    every { spotifyPlayback.getCurrentlyPlaying(userId, accessToken) } returns trackB.right()
+    every { spotifyPlayback.getCurrentlyPlaying(accessToken) } returns trackB.right()
     every { currentlyPlayingRepository.findMostRecentByUserAndTrack(userId, trackB.trackId) } returns null
     every { currentlyPlayingRepository.findByUserId(userId) } returns listOf(orphanedTrackA)
     every { recentlyPartialPlayedRepository.findExistingPlayedAts(userId, any()) } returns emptySet()
@@ -244,7 +244,7 @@ class FetchCurrentlyPlayingServiceTests {
     val trackB = currentlyPlayingItem("track-b", progressMs = 60_000L)
     val orphanedTrackA = currentlyPlayingItem("track-a", progressMs = 5_000L, observedAt = now - 5.minutes)
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
-    every { spotifyPlayback.getCurrentlyPlaying(userId, accessToken) } returns trackB.right()
+    every { spotifyPlayback.getCurrentlyPlaying(accessToken) } returns trackB.right()
     every { currentlyPlayingRepository.findMostRecentByUserAndTrack(userId, trackB.trackId) } returns null
     every { currentlyPlayingRepository.findByUserId(userId) } returns listOf(orphanedTrackA)
 
@@ -262,7 +262,7 @@ class FetchCurrentlyPlayingServiceTests {
     val trackA = currentlyPlayingItem("track-a", progressMs = 150_000L, observedAt = now - 10.minutes)
     val trackB = currentlyPlayingItem("track-b", progressMs = 60_000L)
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
-    every { spotifyPlayback.getCurrentlyPlaying(userId, accessToken) } returns trackB.right()
+    every { spotifyPlayback.getCurrentlyPlaying(accessToken) } returns trackB.right()
     every { currentlyPlayingRepository.findMostRecentByUserAndTrack(userId, trackB.trackId) } returns null
     every { currentlyPlayingRepository.findByUserId(userId) } returns listOf(trackA)
     every { recentlyPartialPlayedRepository.findExistingPlayedAts(userId, any()) } returns emptySet()
@@ -282,7 +282,7 @@ class FetchCurrentlyPlayingServiceTests {
   @Test
   fun `fetchCurrentlyPlaying cleans up orphaned entries when nothing is playing`() {
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
-    every { spotifyPlayback.getCurrentlyPlaying(userId, accessToken) } returns null.right()
+    every { spotifyPlayback.getCurrentlyPlaying(accessToken) } returns null.right()
     every { currentlyPlayingRepository.findByUserId(userId) } returns emptyList()
 
     service.fetchCurrentlyPlaying(userId)
@@ -296,7 +296,7 @@ class FetchCurrentlyPlayingServiceTests {
   fun `fetchCurrentlyPlaying converts and deletes orphaned entries when nothing is playing`() {
     val lingeringTrack = currentlyPlayingItem("track-a", progressMs = 50_000L, observedAt = now - 5.minutes)
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
-    every { spotifyPlayback.getCurrentlyPlaying(userId, accessToken) } returns null.right()
+    every { spotifyPlayback.getCurrentlyPlaying(accessToken) } returns null.right()
     every { currentlyPlayingRepository.findByUserId(userId) } returns listOf(lingeringTrack)
     every { recentlyPartialPlayedRepository.findExistingPlayedAts(userId, any()) } returns emptySet()
     every { recentlyPartialPlayedRepository.saveAll(any()) } just runs
@@ -316,7 +316,7 @@ class FetchCurrentlyPlayingServiceTests {
   fun `fetchCurrentlyPlaying deletes orphaned entry below progress threshold without creating partial play when nothing is playing`() {
     val lingeringTrack = currentlyPlayingItem("track-a", progressMs = 5_000L, observedAt = now - 5.minutes)
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
-    every { spotifyPlayback.getCurrentlyPlaying(userId, accessToken) } returns null.right()
+    every { spotifyPlayback.getCurrentlyPlaying(accessToken) } returns null.right()
     every { currentlyPlayingRepository.findByUserId(userId) } returns listOf(lingeringTrack)
 
     service.fetchCurrentlyPlaying(userId)
@@ -332,7 +332,7 @@ class FetchCurrentlyPlayingServiceTests {
   fun `fetchCurrentlyPlaying notifies playback state when track is playing`() {
     val item = currentlyPlayingItem("track-1", progressMs = 30_000L)
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
-    every { spotifyPlayback.getCurrentlyPlaying(userId, accessToken) } returns item.right()
+    every { spotifyPlayback.getCurrentlyPlaying(accessToken) } returns item.right()
     every { currentlyPlayingRepository.findMostRecentByUserAndTrack(userId, item.trackId) } returns null
 
     service.fetchCurrentlyPlaying(userId)
@@ -344,7 +344,7 @@ class FetchCurrentlyPlayingServiceTests {
   fun `fetchCurrentlyPlaying does not notify playback state when item is paused`() {
     val item = currentlyPlayingItem("track-1", progressMs = 30_000L).copy(isPlaying = false)
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
-    every { spotifyPlayback.getCurrentlyPlaying(userId, accessToken) } returns item.right()
+    every { spotifyPlayback.getCurrentlyPlaying(accessToken) } returns item.right()
     every { currentlyPlayingRepository.findMostRecentByUserAndTrack(userId, item.trackId) } returns null
 
     service.fetchCurrentlyPlaying(userId)
@@ -356,7 +356,7 @@ class FetchCurrentlyPlayingServiceTests {
   fun `fetchCurrentlyPlaying does not notify dashboard when track is merely still playing`() {
     val item = currentlyPlayingItem("track-1", progressMs = 30_000L)
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
-    every { spotifyPlayback.getCurrentlyPlaying(userId, accessToken) } returns item.right()
+    every { spotifyPlayback.getCurrentlyPlaying(accessToken) } returns item.right()
     every { currentlyPlayingRepository.findMostRecentByUserAndTrack(userId, item.trackId) } returns null
 
     service.fetchCurrentlyPlaying(userId)
@@ -367,7 +367,7 @@ class FetchCurrentlyPlayingServiceTests {
   @Test
   fun `fetchCurrentlyPlaying does not notify dashboard when nothing is playing`() {
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
-    every { spotifyPlayback.getCurrentlyPlaying(userId, accessToken) } returns null.right()
+    every { spotifyPlayback.getCurrentlyPlaying(accessToken) } returns null.right()
 
     service.fetchCurrentlyPlaying(userId)
 

--- a/domain-impl/src/test/kotlin/de/chrgroth/spotify/control/domain/playback/PlaybackAggregationServiceTests.kt
+++ b/domain-impl/src/test/kotlin/de/chrgroth/spotify/control/domain/playback/PlaybackAggregationServiceTests.kt
@@ -53,6 +53,7 @@ class PlaybackAggregationServiceTests {
 
   @Test
   fun `aggregate day persists album entries and distinct album count`() {
+    every { currentUserResolver.userId() } returns userId
     val savedAggregation = slot<PlaybackAggregation>()
     every { aggregationRepository.save(capture(savedAggregation)) } returns Unit
     every { appPlaybackRepository.findAllBetween(userId, any(), any()) } returns listOf(
@@ -90,7 +91,7 @@ class PlaybackAggregationServiceTests {
       AppArtist(id = ArtistId("artist-2"), artistName = "Artist Two", lastSync = syncTimestamp),
     )
 
-    val result = service.handle(DomainOutboxEvent.AggregatePlaybackData(userId, AggregationPeriodType.DAY, date))
+    val result = service.handle(DomainOutboxEvent.AggregatePlaybackData(AggregationPeriodType.DAY, date))
 
     assertThat(result.isRight()).isTrue()
     assertThat(savedAggregation.captured.distinctAlbumCount).isEqualTo(2)
@@ -102,6 +103,7 @@ class PlaybackAggregationServiceTests {
 
   @Test
   fun `aggregate week merges album entries from day aggregations`() {
+    every { currentUserResolver.userId() } returns userId
     val weekStart = LocalDate(2024, 1, 15)
     val day1 = LocalDate(2024, 1, 15)
     val day2 = LocalDate(2024, 1, 16)
@@ -125,7 +127,7 @@ class PlaybackAggregationServiceTests {
       ),
     )
 
-    val result = service.handle(DomainOutboxEvent.AggregatePlaybackData(userId, AggregationPeriodType.WEEK, weekStart))
+    val result = service.handle(DomainOutboxEvent.AggregatePlaybackData(AggregationPeriodType.WEEK, weekStart))
 
     assertThat(result.isRight()).isTrue()
     assertThat(savedAggregation.captured.distinctAlbumCount).isEqualTo(2)
@@ -138,6 +140,7 @@ class PlaybackAggregationServiceTests {
 
   @Test
   fun `aggregate week persists only top entries but keeps full distinct counts`() {
+    every { currentUserResolver.userId() } returns userId
     val weekStart = LocalDate(2024, 1, 15)
     val savedAggregation = slot<PlaybackAggregation>()
     every { aggregationRepository.save(capture(savedAggregation)) } returns Unit
@@ -146,7 +149,7 @@ class PlaybackAggregationServiceTests {
       aggregationRepository.findByUserTypeAndPeriodRange(userId, AggregationPeriodType.DAY, weekStart, LocalDate(2024, 1, 21))
     } returns listOf(dayAggregation(weekStart, trackEntries = manyTrackEntries))
 
-    val result = service.handle(DomainOutboxEvent.AggregatePlaybackData(userId, AggregationPeriodType.WEEK, weekStart))
+    val result = service.handle(DomainOutboxEvent.AggregatePlaybackData(AggregationPeriodType.WEEK, weekStart))
 
     assertThat(result.isRight()).isTrue()
     assertThat(savedAggregation.captured.distinctTrackCount).isEqualTo(STORED_ENTRIES_LIMIT_PLUS_MARGIN)

--- a/domain-impl/src/test/kotlin/de/chrgroth/spotify/control/domain/playback/RecentlyPlayedServiceTests.kt
+++ b/domain-impl/src/test/kotlin/de/chrgroth/spotify/control/domain/playback/RecentlyPlayedServiceTests.kt
@@ -130,7 +130,7 @@ class RecentlyPlayedServiceTests {
 
     adapter.enqueueFetchPlaybackData()
 
-    verify(exactly = 1) { outboxPort.enqueue(DomainOutboxEvent.FetchPlaybackData(UserId("user-1"))) }
+    verify(exactly = 1) { outboxPort.enqueue(DomainOutboxEvent.FetchPlaybackData()) }
   }
 
   // --- update tests ---
@@ -140,7 +140,7 @@ class RecentlyPlayedServiceTests {
     val items = listOf(item(1), item(2))
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
     every { recentlyPlayedRepository.findMostRecentPlayedAt(userId) } returns null
-    every { spotifyPlayback.getRecentlyPlayed(userId, accessToken, null) } returns items.right()
+    every { spotifyPlayback.getRecentlyPlayed(accessToken, null) } returns items.right()
     every { recentlyPlayedRepository.findExistingPlayedAts(userId, any()) } returns emptySet()
     every { recentlyPlayedRepository.saveAll(any()) } just runs
     setupNoConsolidation()
@@ -158,7 +158,7 @@ class RecentlyPlayedServiceTests {
     val items = listOf(item(1))
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
     every { recentlyPlayedRepository.findMostRecentPlayedAt(userId) } returns null
-    every { spotifyPlayback.getRecentlyPlayed(userId, accessToken, null) } returns items.right()
+    every { spotifyPlayback.getRecentlyPlayed(accessToken, null) } returns items.right()
     every { recentlyPlayedRepository.findExistingPlayedAts(userId, any()) } returns emptySet()
     every { recentlyPlayedRepository.saveAll(any()) } just runs
     setupNoConsolidation()
@@ -173,7 +173,7 @@ class RecentlyPlayedServiceTests {
     val items = listOf(item(1))
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
     every { recentlyPlayedRepository.findMostRecentPlayedAt(userId) } returns null
-    every { spotifyPlayback.getRecentlyPlayed(userId, accessToken, null) } returns items.right()
+    every { spotifyPlayback.getRecentlyPlayed(accessToken, null) } returns items.right()
     every { recentlyPlayedRepository.findExistingPlayedAts(userId, any()) } returns setOf(items[0].playedAt)
     setupNoConsolidation()
 
@@ -188,14 +188,14 @@ class RecentlyPlayedServiceTests {
     val items = listOf(item(1))
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
     every { recentlyPlayedRepository.findMostRecentPlayedAt(userId) } returns after
-    every { spotifyPlayback.getRecentlyPlayed(userId, accessToken, after) } returns items.right()
+    every { spotifyPlayback.getRecentlyPlayed(accessToken, after) } returns items.right()
     every { recentlyPlayedRepository.findExistingPlayedAts(userId, any()) } returns emptySet()
     every { recentlyPlayedRepository.saveAll(any()) } just runs
     setupNoConsolidation()
 
     adapter.fetchRecentlyPlayed(userId)
 
-    verify { spotifyPlayback.getRecentlyPlayed(userId, accessToken, after) }
+    verify { spotifyPlayback.getRecentlyPlayed(accessToken, after) }
   }
 
   @Test
@@ -203,7 +203,7 @@ class RecentlyPlayedServiceTests {
     val items = listOf(item(1), item(2))
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
     every { recentlyPlayedRepository.findMostRecentPlayedAt(userId) } returns null
-    every { spotifyPlayback.getRecentlyPlayed(userId, accessToken, null) } returns items.right()
+    every { spotifyPlayback.getRecentlyPlayed(accessToken, null) } returns items.right()
     every { recentlyPlayedRepository.findExistingPlayedAts(userId, any()) } returns setOf(items[0].playedAt)
     every { recentlyPlayedRepository.saveAll(any()) } just runs
     setupNoConsolidation()
@@ -221,7 +221,7 @@ class RecentlyPlayedServiceTests {
     val items = listOf(item(1))
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
     every { recentlyPlayedRepository.findMostRecentPlayedAt(userId) } returns null
-    every { spotifyPlayback.getRecentlyPlayed(userId, accessToken, null) } returns items.right()
+    every { spotifyPlayback.getRecentlyPlayed(accessToken, null) } returns items.right()
     every { recentlyPlayedRepository.findExistingPlayedAts(userId, any()) } returns setOf(items[0].playedAt)
     setupNoConsolidation()
 
@@ -234,7 +234,7 @@ class RecentlyPlayedServiceTests {
   fun `update does not call saveAll when no tracks returned`() {
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
     every { recentlyPlayedRepository.findMostRecentPlayedAt(userId) } returns null
-    every { spotifyPlayback.getRecentlyPlayed(userId, accessToken, null) } returns emptyList<RecentlyPlayedItem>().right()
+    every { spotifyPlayback.getRecentlyPlayed(accessToken, null) } returns emptyList<RecentlyPlayedItem>().right()
     every { recentlyPlayedRepository.findExistingPlayedAts(userId, any()) } returns emptySet()
     setupNoConsolidation()
 
@@ -247,7 +247,7 @@ class RecentlyPlayedServiceTests {
   fun `update returns Left on domain error`() {
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
     every { recentlyPlayedRepository.findMostRecentPlayedAt(userId) } returns null
-    every { spotifyPlayback.getRecentlyPlayed(userId, accessToken, null) } returns PlaybackError.RECENTLY_PLAYED_FETCH_FAILED.left()
+    every { spotifyPlayback.getRecentlyPlayed(accessToken, null) } returns PlaybackError.RECENTLY_PLAYED_FETCH_FAILED.left()
 
     val result = adapter.fetchRecentlyPlayed(userId)
 
@@ -262,7 +262,7 @@ class RecentlyPlayedServiceTests {
     val items = listOf(item(1))
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
     every { recentlyPlayedRepository.findMostRecentPlayedAt(userId) } returns null
-    every { spotifyPlayback.getRecentlyPlayed(userId, accessToken, null) } returns items.right()
+    every { spotifyPlayback.getRecentlyPlayed(accessToken, null) } returns items.right()
     every { recentlyPlayedRepository.findExistingPlayedAts(userId, any()) } returns emptySet()
     every { recentlyPlayedRepository.saveAll(any()) } just runs
     setupNoConsolidation()
@@ -276,7 +276,7 @@ class RecentlyPlayedServiceTests {
   fun `update converts partial plays exceeding 25s to recently partial played`() {
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
     every { recentlyPlayedRepository.findMostRecentPlayedAt(userId) } returns null
-    every { spotifyPlayback.getRecentlyPlayed(userId, accessToken, null) } returns emptyList<RecentlyPlayedItem>().right()
+    every { spotifyPlayback.getRecentlyPlayed(accessToken, null) } returns emptyList<RecentlyPlayedItem>().right()
     every { recentlyPlayedRepository.findExistingPlayedAts(userId, any()) } returns emptySet()
     every { recentlyPartialPlayedRepository.findExistingPlayedAts(userId, any()) } returns emptySet()
     every { recentlyPartialPlayedRepository.saveAll(any()) } just runs
@@ -297,7 +297,7 @@ class RecentlyPlayedServiceTests {
   fun `update computes playedSeconds using progressMs when another track was observed next`() {
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
     every { recentlyPlayedRepository.findMostRecentPlayedAt(userId) } returns null
-    every { spotifyPlayback.getRecentlyPlayed(userId, accessToken, null) } returns emptyList<RecentlyPlayedItem>().right()
+    every { spotifyPlayback.getRecentlyPlayed(accessToken, null) } returns emptyList<RecentlyPlayedItem>().right()
     every { recentlyPlayedRepository.findExistingPlayedAts(userId, any()) } returns emptySet()
     every { recentlyPartialPlayedRepository.findExistingPlayedAts(userId, any()) } returns emptySet()
     every { recentlyPartialPlayedRepository.saveAll(any()) } just runs
@@ -317,7 +317,7 @@ class RecentlyPlayedServiceTests {
   fun `update converts each item independently to a separate partial played record`() {
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
     every { recentlyPlayedRepository.findMostRecentPlayedAt(userId) } returns null
-    every { spotifyPlayback.getRecentlyPlayed(userId, accessToken, null) } returns emptyList<RecentlyPlayedItem>().right()
+    every { spotifyPlayback.getRecentlyPlayed(accessToken, null) } returns emptyList<RecentlyPlayedItem>().right()
     every { recentlyPlayedRepository.findExistingPlayedAts(userId, any()) } returns emptySet()
     every { recentlyPartialPlayedRepository.findExistingPlayedAts(userId, any()) } returns emptySet()
     every { recentlyPartialPlayedRepository.saveAll(any()) } just runs
@@ -342,7 +342,7 @@ class RecentlyPlayedServiceTests {
   fun `update computes playedSeconds using progressMs regardless of observation gap to next track`() {
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
     every { recentlyPlayedRepository.findMostRecentPlayedAt(userId) } returns null
-    every { spotifyPlayback.getRecentlyPlayed(userId, accessToken, null) } returns emptyList<RecentlyPlayedItem>().right()
+    every { spotifyPlayback.getRecentlyPlayed(accessToken, null) } returns emptyList<RecentlyPlayedItem>().right()
     every { recentlyPlayedRepository.findExistingPlayedAts(userId, any()) } returns emptySet()
     every { recentlyPartialPlayedRepository.findExistingPlayedAts(userId, any()) } returns emptySet()
     every { recentlyPartialPlayedRepository.saveAll(any()) } just runs
@@ -366,7 +366,7 @@ class RecentlyPlayedServiceTests {
   fun `update caps playedSeconds at track durationMs when progressMs exceeds track length`() {
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
     every { recentlyPlayedRepository.findMostRecentPlayedAt(userId) } returns null
-    every { spotifyPlayback.getRecentlyPlayed(userId, accessToken, null) } returns emptyList<RecentlyPlayedItem>().right()
+    every { spotifyPlayback.getRecentlyPlayed(accessToken, null) } returns emptyList<RecentlyPlayedItem>().right()
     every { recentlyPlayedRepository.findExistingPlayedAts(userId, any()) } returns emptySet()
     every { recentlyPartialPlayedRepository.findExistingPlayedAts(userId, any()) } returns emptySet()
     every { recentlyPartialPlayedRepository.saveAll(any()) } just runs
@@ -391,7 +391,7 @@ class RecentlyPlayedServiceTests {
     val completedItems = listOf(item(1))
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
     every { recentlyPlayedRepository.findMostRecentPlayedAt(userId) } returns null
-    every { spotifyPlayback.getRecentlyPlayed(userId, accessToken, null) } returns completedItems.right()
+    every { spotifyPlayback.getRecentlyPlayed(accessToken, null) } returns completedItems.right()
     every { recentlyPlayedRepository.findExistingPlayedAts(userId, any()) } returns emptySet()
     every { recentlyPlayedRepository.saveAll(any()) } just runs
 
@@ -408,7 +408,7 @@ class RecentlyPlayedServiceTests {
     val completedItems = listOf(item(1))
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
     every { recentlyPlayedRepository.findMostRecentPlayedAt(userId) } returns null
-    every { spotifyPlayback.getRecentlyPlayed(userId, accessToken, null) } returns completedItems.right()
+    every { spotifyPlayback.getRecentlyPlayed(accessToken, null) } returns completedItems.right()
     every { recentlyPlayedRepository.findExistingPlayedAts(userId, any()) } returns emptySet()
     every { recentlyPlayedRepository.saveAll(any()) } just runs
     every { recentlyPartialPlayedRepository.findExistingPlayedAts(userId, any()) } returns emptySet()
@@ -434,7 +434,7 @@ class RecentlyPlayedServiceTests {
   fun `update creates two partial played items when same track played twice`() {
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
     every { recentlyPlayedRepository.findMostRecentPlayedAt(userId) } returns null
-    every { spotifyPlayback.getRecentlyPlayed(userId, accessToken, null) } returns emptyList<RecentlyPlayedItem>().right()
+    every { spotifyPlayback.getRecentlyPlayed(accessToken, null) } returns emptyList<RecentlyPlayedItem>().right()
     every { recentlyPlayedRepository.findExistingPlayedAts(userId, any()) } returns emptySet()
     every { recentlyPartialPlayedRepository.findExistingPlayedAts(userId, any()) } returns emptySet()
     every { recentlyPartialPlayedRepository.saveAll(any()) } just runs
@@ -470,7 +470,7 @@ class RecentlyPlayedServiceTests {
   fun `update creates two partial played items when same track played twice consecutively with progress reset`() {
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
     every { recentlyPlayedRepository.findMostRecentPlayedAt(userId) } returns null
-    every { spotifyPlayback.getRecentlyPlayed(userId, accessToken, null) } returns emptyList<RecentlyPlayedItem>().right()
+    every { spotifyPlayback.getRecentlyPlayed(accessToken, null) } returns emptyList<RecentlyPlayedItem>().right()
     every { recentlyPlayedRepository.findExistingPlayedAts(userId, any()) } returns emptySet()
     every { recentlyPartialPlayedRepository.findExistingPlayedAts(userId, any()) } returns emptySet()
     every { recentlyPartialPlayedRepository.saveAll(any()) } just runs
@@ -503,7 +503,7 @@ class RecentlyPlayedServiceTests {
   fun `update does not convert the latest currently playing item`() {
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
     every { recentlyPlayedRepository.findMostRecentPlayedAt(userId) } returns null
-    every { spotifyPlayback.getRecentlyPlayed(userId, accessToken, null) } returns emptyList<RecentlyPlayedItem>().right()
+    every { spotifyPlayback.getRecentlyPlayed(accessToken, null) } returns emptyList<RecentlyPlayedItem>().right()
     every { recentlyPlayedRepository.findExistingPlayedAts(userId, any()) } returns emptySet()
 
     val latestTrack = currentlyPlayingItem("track-latest", progressMs = 60_000L, observedAt = now)
@@ -518,7 +518,7 @@ class RecentlyPlayedServiceTests {
   fun `update does not convert partial plays shorter than minimum progress but still deletes them`() {
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
     every { recentlyPlayedRepository.findMostRecentPlayedAt(userId) } returns null
-    every { spotifyPlayback.getRecentlyPlayed(userId, accessToken, null) } returns emptyList<RecentlyPlayedItem>().right()
+    every { spotifyPlayback.getRecentlyPlayed(accessToken, null) } returns emptyList<RecentlyPlayedItem>().right()
     every { recentlyPlayedRepository.findExistingPlayedAts(userId, any()) } returns emptySet()
 
     val olderTrack = currentlyPlayingItem("track-old", progressMs = 10_000L, observedAt = now - 5.minutes)
@@ -535,7 +535,7 @@ class RecentlyPlayedServiceTests {
   fun `update notifies dashboard when partial plays are converted`() {
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
     every { recentlyPlayedRepository.findMostRecentPlayedAt(userId) } returns null
-    every { spotifyPlayback.getRecentlyPlayed(userId, accessToken, null) } returns emptyList<RecentlyPlayedItem>().right()
+    every { spotifyPlayback.getRecentlyPlayed(accessToken, null) } returns emptyList<RecentlyPlayedItem>().right()
     every { recentlyPlayedRepository.findExistingPlayedAts(userId, any()) } returns emptySet()
     every { recentlyPartialPlayedRepository.findExistingPlayedAts(userId, any()) } returns emptySet()
     every { recentlyPartialPlayedRepository.saveAll(any()) } just runs
@@ -553,7 +553,7 @@ class RecentlyPlayedServiceTests {
   fun `update deletes converted currently playing entries at end`() {
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
     every { recentlyPlayedRepository.findMostRecentPlayedAt(userId) } returns null
-    every { spotifyPlayback.getRecentlyPlayed(userId, accessToken, null) } returns emptyList<RecentlyPlayedItem>().right()
+    every { spotifyPlayback.getRecentlyPlayed(accessToken, null) } returns emptyList<RecentlyPlayedItem>().right()
     every { recentlyPlayedRepository.findExistingPlayedAts(userId, any()) } returns emptySet()
     every { recentlyPartialPlayedRepository.findExistingPlayedAts(userId, any()) } returns emptySet()
     every { recentlyPartialPlayedRepository.saveAll(any()) } just runs
@@ -572,7 +572,7 @@ class RecentlyPlayedServiceTests {
     val completedItems = listOf(item(1))
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
     every { recentlyPlayedRepository.findMostRecentPlayedAt(userId) } returns null
-    every { spotifyPlayback.getRecentlyPlayed(userId, accessToken, null) } returns completedItems.right()
+    every { spotifyPlayback.getRecentlyPlayed(accessToken, null) } returns completedItems.right()
     every { recentlyPlayedRepository.findExistingPlayedAts(userId, any()) } returns emptySet()
     every { recentlyPlayedRepository.saveAll(any()) } just runs
     every { recentlyPartialPlayedRepository.findExistingPlayedAts(userId, any()) } returns emptySet()
@@ -591,7 +591,7 @@ class RecentlyPlayedServiceTests {
   fun `update does not delete latest item trackId even when older items of same track are converted`() {
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
     every { recentlyPlayedRepository.findMostRecentPlayedAt(userId) } returns null
-    every { spotifyPlayback.getRecentlyPlayed(userId, accessToken, null) } returns emptyList<RecentlyPlayedItem>().right()
+    every { spotifyPlayback.getRecentlyPlayed(accessToken, null) } returns emptyList<RecentlyPlayedItem>().right()
     every { recentlyPlayedRepository.findExistingPlayedAts(userId, any()) } returns emptySet()
     every { recentlyPartialPlayedRepository.findExistingPlayedAts(userId, any()) } returns emptySet()
     every { recentlyPartialPlayedRepository.saveAll(any()) } just runs
@@ -613,7 +613,7 @@ class RecentlyPlayedServiceTests {
   fun `update saves partial played item with first observedAt as playedAt`() {
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
     every { recentlyPlayedRepository.findMostRecentPlayedAt(userId) } returns null
-    every { spotifyPlayback.getRecentlyPlayed(userId, accessToken, null) } returns emptyList<RecentlyPlayedItem>().right()
+    every { spotifyPlayback.getRecentlyPlayed(accessToken, null) } returns emptyList<RecentlyPlayedItem>().right()
     every { recentlyPlayedRepository.findExistingPlayedAts(userId, any()) } returns emptySet()
     every { recentlyPartialPlayedRepository.findExistingPlayedAts(userId, any()) } returns emptySet()
     every { recentlyPartialPlayedRepository.saveAll(any()) } just runs
@@ -634,7 +634,7 @@ class RecentlyPlayedServiceTests {
   fun `update does not save partial played item to recently played repository`() {
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
     every { recentlyPlayedRepository.findMostRecentPlayedAt(userId) } returns null
-    every { spotifyPlayback.getRecentlyPlayed(userId, accessToken, null) } returns emptyList<RecentlyPlayedItem>().right()
+    every { spotifyPlayback.getRecentlyPlayed(accessToken, null) } returns emptyList<RecentlyPlayedItem>().right()
     every { recentlyPlayedRepository.findExistingPlayedAts(userId, any()) } returns emptySet()
     every { recentlyPartialPlayedRepository.findExistingPlayedAts(userId, any()) } returns emptySet()
     every { recentlyPartialPlayedRepository.saveAll(any()) } just runs
@@ -654,6 +654,7 @@ class RecentlyPlayedServiceTests {
     recentlyPlayed: List<RecentlyPlayedItem> = emptyList(),
     partialPlayed: List<RecentlyPartialPlayedItem> = emptyList(),
   ) {
+    every { currentUserResolver.userId() } returns userId
     every { appPlaybackRepository.findMostRecentPlayedAt(userId) } returns null
     every { recentlyPlayedRepository.findSince(userId, null) } returns recentlyPlayed
     every { recentlyPartialPlayedRepository.findSince(userId, null) } returns partialPlayed
@@ -667,7 +668,7 @@ class RecentlyPlayedServiceTests {
     val recentlyPlayedItem = item(1).copy(durationSeconds = 210L)
     setupAppendPlaybackData(recentlyPlayed = listOf(recentlyPlayedItem))
 
-    adapter.appendPlaybackData(userId)
+    adapter.appendPlaybackData()
 
     val savedSlot = slot<List<AppPlaybackItem>>()
     verify { appPlaybackRepository.saveAll(capture(savedSlot)) }
@@ -680,7 +681,7 @@ class RecentlyPlayedServiceTests {
     val recentlyPlayedItem = item(1).copy(durationSeconds = null)
     setupAppendPlaybackData(recentlyPlayed = listOf(recentlyPlayedItem))
 
-    adapter.appendPlaybackData(userId)
+    adapter.appendPlaybackData()
 
     val savedSlot = slot<List<AppPlaybackItem>>()
     verify { appPlaybackRepository.saveAll(capture(savedSlot)) }
@@ -693,12 +694,11 @@ class RecentlyPlayedServiceTests {
     val recentlyPlayedItem = item(1, albumId = "album-1")
     setupAppendPlaybackData(recentlyPlayed = listOf(recentlyPlayedItem))
 
-    adapter.appendPlaybackData(userId)
+    adapter.appendPlaybackData()
 
     verify {
       syncController.syncForTracks(
         listOf(CatalogSyncRequest("track-1", listOf("artist-id-1"), SyncCause.Playback("track-1"))),
-        userId,
       )
     }
   }
@@ -709,7 +709,7 @@ class RecentlyPlayedServiceTests {
     val item2 = item(2, albumId = "album-2")
     setupAppendPlaybackData(recentlyPlayed = listOf(item1, item2))
 
-    adapter.appendPlaybackData(userId)
+    adapter.appendPlaybackData()
 
     verify {
       syncController.syncForTracks(
@@ -718,7 +718,6 @@ class RecentlyPlayedServiceTests {
             requests.any { it.trackId == "track-1" } &&
             requests.any { it.trackId == "track-2" }
         },
-        userId,
       )
     }
   }
@@ -729,12 +728,11 @@ class RecentlyPlayedServiceTests {
     val item2 = item(2, albumId = "album-shared")
     setupAppendPlaybackData(recentlyPlayed = listOf(item1, item2))
 
-    adapter.appendPlaybackData(userId)
+    adapter.appendPlaybackData()
 
     verify {
       syncController.syncForTracks(
         match { requests -> requests.size == 2 },
-        userId,
       )
     }
   }
@@ -744,12 +742,11 @@ class RecentlyPlayedServiceTests {
     val recentlyPlayedItem = item(1) // no albumId
     setupAppendPlaybackData(recentlyPlayed = listOf(recentlyPlayedItem))
 
-    adapter.appendPlaybackData(userId)
+    adapter.appendPlaybackData()
 
     verify {
       syncController.syncForTracks(
         listOf(CatalogSyncRequest("track-1", listOf("artist-id-1"), SyncCause.Playback("track-1"))),
-        userId,
       )
     }
   }

--- a/domain-impl/src/test/kotlin/de/chrgroth/spotify/control/domain/playlist/PlaylistCheckServiceTests.kt
+++ b/domain-impl/src/test/kotlin/de/chrgroth/spotify/control/domain/playlist/PlaylistCheckServiceTests.kt
@@ -23,6 +23,7 @@ import de.chrgroth.spotify.control.domain.port.out.playlist.PlaylistCheckNotific
 import de.chrgroth.spotify.control.domain.port.out.playlist.PlaylistRepositoryPort
 import de.chrgroth.spotify.control.domain.port.out.user.SpotifyAccessTokenPort
 import de.chrgroth.spotify.control.domain.port.out.user.UserRepositoryPort
+import de.chrgroth.spotify.control.domain.user.CurrentUserResolver
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import io.mockk.every
 import io.mockk.just
@@ -46,6 +47,7 @@ class PlaylistCheckServiceTests {
   private val dashboardRefresh: DashboardRefreshPort = mockk()
   private val notification: PlaylistCheckNotificationPort = mockk()
   private val userRepository: UserRepositoryPort = mockk()
+  private val currentUserResolver: CurrentUserResolver = mockk()
   private val spotifyAccessToken: SpotifyAccessTokenPort = mockk()
   private val outboxPort: OutboxPort = mockk()
   private val meterRegistry = SimpleMeterRegistry()
@@ -60,6 +62,7 @@ class PlaylistCheckServiceTests {
     playlistRepository,
     playlistCheckRepository,
     userRepository,
+    currentUserResolver,
     dashboardRefresh,
     notification,
     spotifyAccessToken,
@@ -70,7 +73,7 @@ class PlaylistCheckServiceTests {
 
   private val userId = UserId("user-1")
   private val playlistId = "playlist-1"
-  private val event = DomainOutboxEvent.RunPlaylistChecks(userId, playlistId)
+  private val event = DomainOutboxEvent.RunPlaylistChecks(playlistId)
   private val checkId = "test-check"
   private val fullCheckId = "$playlistId:$checkId"
 
@@ -112,6 +115,7 @@ class PlaylistCheckServiceTests {
 
   @Test
   fun `handle returns success and skips notifications when playlist not found`() {
+    every { currentUserResolver.userId() } returns userId
     every { playlistRepository.findByUserIdAndPlaylistId(userId, playlistId) } returns null
 
     val result = adapter.handle(event)
@@ -127,6 +131,7 @@ class PlaylistCheckServiceTests {
     val playlist = buildPlaylist(listOf(buildTrack("t1"), buildTrack("t2")))
     val check = buildCheck(succeeded = true)
     setupCheckRunner(check)
+    every { currentUserResolver.userId() } returns userId
     every { playlistRepository.findByUserIdAndPlaylistId(userId, playlistId) } returns playlist
     every { playlistRepository.findByUserId(userId) } returns listOf(buildPlaylistInfo())
     every { playlistCheckRepository.findByCheckId(fullCheckId) } returns null
@@ -147,6 +152,7 @@ class PlaylistCheckServiceTests {
     val check = buildCheck(succeeded = true)
     val previousCheck = buildCheck(succeeded = false, violations = listOf("Artist – Track t1"))
     setupCheckRunner(check)
+    every { currentUserResolver.userId() } returns userId
     every { playlistRepository.findByUserIdAndPlaylistId(userId, playlistId) } returns playlist
     every { playlistRepository.findByUserId(userId) } returns listOf(buildPlaylistInfo())
     every { playlistCheckRepository.findByCheckId(fullCheckId) } returns previousCheck
@@ -167,6 +173,7 @@ class PlaylistCheckServiceTests {
     val check = buildCheck(succeeded = false, violations = listOf("Artist A – Track A", "Artist B – Track B"))
     val previousCheck = buildCheck(succeeded = false, violations = listOf("Artist A – Track A"))
     setupCheckRunner(check)
+    every { currentUserResolver.userId() } returns userId
     every { playlistRepository.findByUserIdAndPlaylistId(userId, playlistId) } returns playlist
     every { playlistRepository.findByUserId(userId) } returns listOf(buildPlaylistInfo())
     every { playlistCheckRepository.findByCheckId(fullCheckId) } returns previousCheck
@@ -188,6 +195,7 @@ class PlaylistCheckServiceTests {
     val check = buildCheck(succeeded = false, violations = violations)
     val previousCheck = buildCheck(succeeded = false, violations = violations)
     setupCheckRunner(check)
+    every { currentUserResolver.userId() } returns userId
     every { playlistRepository.findByUserIdAndPlaylistId(userId, playlistId) } returns playlist
     every { playlistRepository.findByUserId(userId) } returns listOf(buildPlaylistInfo())
     every { playlistCheckRepository.findByCheckId(fullCheckId) } returns previousCheck
@@ -207,6 +215,7 @@ class PlaylistCheckServiceTests {
     val check = buildCheck(succeeded = true)
     val previousCheck = buildCheck(succeeded = true)
     setupCheckRunner(check)
+    every { currentUserResolver.userId() } returns userId
     every { playlistRepository.findByUserIdAndPlaylistId(userId, playlistId) } returns playlist
     every { playlistRepository.findByUserId(userId) } returns listOf(buildPlaylistInfo())
     every { playlistCheckRepository.findByCheckId(fullCheckId) } returns previousCheck
@@ -222,6 +231,7 @@ class PlaylistCheckServiceTests {
 
   @Test
   fun `handle propagates unexpected exception`() {
+    every { currentUserResolver.userId() } returns userId
     every { playlistRepository.findByUserIdAndPlaylistId(userId, playlistId) } throws RuntimeException("DB error")
 
     org.assertj.core.api.Assertions.assertThatThrownBy { adapter.handle(event) }
@@ -234,6 +244,7 @@ class PlaylistCheckServiceTests {
     val playlist = buildPlaylist(listOf(buildTrack("t1")))
     every { checkRunner.isApplicable(any()) } returns false
     every { checkRunners.iterator() } answers { mutableListOf(checkRunner).iterator() }
+    every { currentUserResolver.userId() } returns userId
     every { playlistRepository.findByUserIdAndPlaylistId(userId, playlistId) } returns playlist
     every { playlistRepository.findByUserId(userId) } returns listOf(buildPlaylistInfo())
     every { dashboardRefresh.notifyUserPlaylistChecks() } just runs
@@ -256,6 +267,7 @@ class PlaylistCheckServiceTests {
     )
     val check = buildCheck(succeeded = true)
     val playlistInfo = buildPlaylistInfo()
+    every { currentUserResolver.userId() } returns userId
     every { userRepository.findById(userId) } returns user
     every { playlistRepository.findByUserId(userId) } returns listOf(playlistInfo)
     every { playlistCheckRepository.findAll() } returns listOf(check)
@@ -264,7 +276,7 @@ class PlaylistCheckServiceTests {
     every { checkRunner.displayName } returns "Test Check"
     every { checkRunner.canFix() } returns true
 
-    val dashboard = adapter.getCheckDashboard(userId)
+    val dashboard = adapter.getCheckDashboard()
 
     assertThat(dashboard.displayName).isEqualTo("John Doe")
     assertThat(dashboard.checks).containsExactly(check)
@@ -275,12 +287,13 @@ class PlaylistCheckServiceTests {
 
   @Test
   fun `getCheckDashboard falls back to userId when user not found`() {
+    every { currentUserResolver.userId() } returns userId
     every { userRepository.findById(userId) } returns null
     every { playlistRepository.findByUserId(userId) } returns emptyList()
     every { playlistCheckRepository.findAll() } returns emptyList()
     every { checkRunners.iterator() } answers { mutableListOf<PlaylistCheckRunner>().iterator() }
 
-    val dashboard = adapter.getCheckDashboard(userId)
+    val dashboard = adapter.getCheckDashboard()
 
     assertThat(dashboard.displayName).isEqualTo(userId.value)
   }
@@ -320,9 +333,10 @@ class PlaylistCheckServiceTests {
 
   @Test
   fun `runFix returns error when no runner with canFix found`() {
+    every { currentUserResolver.userId() } returns userId
     every { checkRunners.iterator() } returns mutableListOf<PlaylistCheckRunner>().iterator()
 
-    val result = adapter.runFix(userId, playlistId, "unknown-check")
+    val result = adapter.runFix(playlistId, "unknown-check")
 
     assertThat(result.isLeft()).isTrue()
     assertThat((result as arrow.core.Either.Left).value).isEqualTo(PlaylistFixError.FIX_NOT_FOUND)
@@ -330,12 +344,13 @@ class PlaylistCheckServiceTests {
 
   @Test
   fun `runFix returns error when playlist not found`() {
+    every { currentUserResolver.userId() } returns userId
     every { checkRunners.iterator() } returns mutableListOf(checkRunner).iterator()
     every { checkRunner.checkId } returns checkId
     every { checkRunner.canFix() } returns true
     every { playlistRepository.findByUserIdAndPlaylistId(userId, playlistId) } returns null
 
-    val result = adapter.runFix(userId, playlistId, checkId)
+    val result = adapter.runFix(playlistId, checkId)
 
     assertThat(result.isLeft()).isTrue()
     assertThat((result as arrow.core.Either.Left).value).isEqualTo(PlaylistFixError.PLAYLIST_NOT_FOUND)
@@ -345,6 +360,7 @@ class PlaylistCheckServiceTests {
   fun `runFix calls fix on runner and enqueues re-sync on success`() {
     val playlist = buildPlaylist(listOf(buildTrack("t1")))
     val playlistInfo = buildPlaylistInfo()
+    every { currentUserResolver.userId() } returns userId
     every { checkRunners.iterator() } returns mutableListOf(checkRunner).iterator()
     every { checkRunner.checkId } returns checkId
     every { checkRunner.canFix() } returns true
@@ -354,9 +370,9 @@ class PlaylistCheckServiceTests {
     every { checkRunner.fix(userId, AccessToken("token"), playlistId, playlist, playlistInfo, listOf(playlistInfo)) } returns Unit.right()
     every { outboxPort.enqueue(any()) } just runs
 
-    val result = adapter.runFix(userId, playlistId, checkId)
+    val result = adapter.runFix(playlistId, checkId)
 
     assertThat(result.isRight()).isTrue()
-    verify(exactly = 1) { outboxPort.enqueue(DomainOutboxEvent.SyncPlaylistData(userId, playlistId)) }
+    verify(exactly = 1) { outboxPort.enqueue(DomainOutboxEvent.SyncPlaylistData(playlistId)) }
   }
 }

--- a/domain-impl/src/test/kotlin/de/chrgroth/spotify/control/domain/playlist/PlaylistServiceTests.kt
+++ b/domain-impl/src/test/kotlin/de/chrgroth/spotify/control/domain/playlist/PlaylistServiceTests.kt
@@ -116,27 +116,28 @@ class PlaylistServiceTests {
 
     adapter.enqueueUpdates()
 
-    verify(exactly = 1) { outboxPort.enqueue(DomainOutboxEvent.SyncPlaylistInfo(UserId("user-1"))) }
+    verify(exactly = 1) { outboxPort.enqueue(DomainOutboxEvent.SyncPlaylistInfo()) }
   }
 
   // --- syncPlaylists tests ---
 
   @Test
   fun `syncPlaylists skips when user not found`() {
-    every { userRepository.findById(userId) } returns null
+    every { currentUserResolver.userId() } returns null
 
-    val result = adapter.syncPlaylists(userId)
+    val result = adapter.syncPlaylists()
 
     assertThat(result.isRight()).isTrue()
-    verify(exactly = 0) { spotifyPlaylist.getPlaylists(any(), any()) }
+    verify(exactly = 0) { spotifyPlaylist.getPlaylists(any()) }
   }
 
   @Test
   fun `syncPlaylists filters out playlists not owned by user`() {
     val user = buildUser()
     every { userRepository.findById(userId) } returns user
+    every { currentUserResolver.userId() } returns userId
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
-    every { spotifyPlaylist.getPlaylists(userId, accessToken) } returns listOf(
+    every { spotifyPlaylist.getPlaylists(accessToken) } returns listOf(
       buildSpotifyItem("p1", ownerId = "user-1"),
       buildSpotifyItem("p2", ownerId = "other-user"),
     ).right()
@@ -144,7 +145,7 @@ class PlaylistServiceTests {
     every { playlistRepository.replaceAll(any(), any()) } just runs
     every { dashboardRefresh.notifyUserPlaylistMetadata() } just runs
 
-    val result = adapter.syncPlaylists(userId)
+    val result = adapter.syncPlaylists()
 
     assertThat(result.isRight()).isTrue()
     val savedSlot = slot<List<PlaylistInfo>>()
@@ -157,13 +158,14 @@ class PlaylistServiceTests {
   fun `syncPlaylists persists new playlists with PASSIVE status`() {
     val user = buildUser()
     every { userRepository.findById(userId) } returns user
+    every { currentUserResolver.userId() } returns userId
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
-    every { spotifyPlaylist.getPlaylists(userId, accessToken) } returns listOf(buildSpotifyItem("p1")).right()
+    every { spotifyPlaylist.getPlaylists(accessToken) } returns listOf(buildSpotifyItem("p1")).right()
     every { playlistRepository.findByUserId(userId) } returns emptyList()
     every { playlistRepository.replaceAll(any(), any()) } just runs
     every { dashboardRefresh.notifyUserPlaylistMetadata() } just runs
 
-    val result = adapter.syncPlaylists(userId)
+    val result = adapter.syncPlaylists()
 
     assertThat(result.isRight()).isTrue()
     val savedSlot = slot<List<PlaylistInfo>>()
@@ -177,12 +179,13 @@ class PlaylistServiceTests {
   fun `syncPlaylists preserves existing syncStatus`() {
     val user = buildUser()
     every { userRepository.findById(userId) } returns user
+    every { currentUserResolver.userId() } returns userId
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
-    every { spotifyPlaylist.getPlaylists(userId, accessToken) } returns listOf(buildSpotifyItem("p1")).right()
+    every { spotifyPlaylist.getPlaylists(accessToken) } returns listOf(buildSpotifyItem("p1")).right()
     every { playlistRepository.findByUserId(userId) } returns listOf(buildPlaylistInfo("p1", syncStatus = PlaylistSyncStatus.PASSIVE))
     every { playlistRepository.replaceAll(any(), any()) } just runs
 
-    adapter.syncPlaylists(userId)
+    adapter.syncPlaylists()
 
     val savedSlot = slot<List<PlaylistInfo>>()
     verify { playlistRepository.replaceAll(userId, capture(savedSlot)) }
@@ -193,13 +196,14 @@ class PlaylistServiceTests {
   fun `syncPlaylists uses latest playlist state after Spotify API call to preserve syncStatus changes made in the meantime`() {
     val user = buildUser()
     every { userRepository.findById(userId) } returns user
+    every { currentUserResolver.userId() } returns userId
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
-    every { spotifyPlaylist.getPlaylists(userId, accessToken) } returns listOf(buildSpotifyItem("p1")).right()
+    every { spotifyPlaylist.getPlaylists(accessToken) } returns listOf(buildSpotifyItem("p1")).right()
     every { playlistRepository.findByUserId(userId) } returns listOf(buildPlaylistInfo("p1", syncStatus = PlaylistSyncStatus.ACTIVE))
     every { playlistRepository.replaceAll(any(), any()) } just runs
     every { playlistRepository.findByUserIdAndPlaylistId(userId, "p1") } returns mockk()
 
-    adapter.syncPlaylists(userId)
+    adapter.syncPlaylists()
 
     val savedSlot = slot<List<PlaylistInfo>>()
     verify { playlistRepository.replaceAll(userId, capture(savedSlot)) }
@@ -210,13 +214,14 @@ class PlaylistServiceTests {
   fun `syncPlaylists preserves lastSnapshotIdSyncTime when snapshotId is unchanged`() {
     val user = buildUser()
     every { userRepository.findById(userId) } returns user
+    every { currentUserResolver.userId() } returns userId
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
-    every { spotifyPlaylist.getPlaylists(userId, accessToken) } returns listOf(buildSpotifyItem("p1", snapshotId = "snap-1")).right()
+    every { spotifyPlaylist.getPlaylists(accessToken) } returns listOf(buildSpotifyItem("p1", snapshotId = "snap-1")).right()
     every { playlistRepository.findByUserId(userId) } returns listOf(buildPlaylistInfo("p1", snapshotId = "snap-1"))
     every { playlistRepository.replaceAll(any(), any()) } just runs
     every { playlistRepository.findByUserIdAndPlaylistId(userId, "p1") } returns mockk()
 
-    adapter.syncPlaylists(userId)
+    adapter.syncPlaylists()
 
     val savedSlot = slot<List<PlaylistInfo>>()
     verify { playlistRepository.replaceAll(userId, capture(savedSlot)) }
@@ -227,13 +232,14 @@ class PlaylistServiceTests {
   fun `syncPlaylists updates lastSnapshotIdSyncTime when snapshotId changes`() {
     val user = buildUser()
     every { userRepository.findById(userId) } returns user
+    every { currentUserResolver.userId() } returns userId
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
-    every { spotifyPlaylist.getPlaylists(userId, accessToken) } returns listOf(buildSpotifyItem("p1", snapshotId = "snap-2")).right()
+    every { spotifyPlaylist.getPlaylists(accessToken) } returns listOf(buildSpotifyItem("p1", snapshotId = "snap-2")).right()
     every { playlistRepository.findByUserId(userId) } returns listOf(buildPlaylistInfo("p1", snapshotId = "snap-1"))
     every { playlistRepository.replaceAll(any(), any()) } just runs
     every { outboxPort.enqueue(any()) } just runs
 
-    adapter.syncPlaylists(userId)
+    adapter.syncPlaylists()
 
     val savedSlot = slot<List<PlaylistInfo>>()
     verify { playlistRepository.replaceAll(userId, capture(savedSlot)) }
@@ -244,15 +250,16 @@ class PlaylistServiceTests {
   fun `syncPlaylists notifies dashboard when playlist count increases`() {
     val user = buildUser()
     every { userRepository.findById(userId) } returns user
+    every { currentUserResolver.userId() } returns userId
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
-    every { spotifyPlaylist.getPlaylists(userId, accessToken) } returns listOf(buildSpotifyItem("p1"), buildSpotifyItem("p2")).right()
+    every { spotifyPlaylist.getPlaylists(accessToken) } returns listOf(buildSpotifyItem("p1"), buildSpotifyItem("p2")).right()
     every { playlistRepository.findByUserId(userId) } returns listOf(buildPlaylistInfo("p1"))
     every { playlistRepository.replaceAll(any(), any()) } just runs
     every { playlistRepository.findByUserIdAndPlaylistId(userId, "p1") } returns mockk()
     every { outboxPort.enqueue(any()) } just runs
     every { dashboardRefresh.notifyUserPlaylistMetadata() } just runs
 
-    val result = adapter.syncPlaylists(userId)
+    val result = adapter.syncPlaylists()
 
     assertThat(result.isRight()).isTrue()
     verify(exactly = 1) { dashboardRefresh.notifyUserPlaylistMetadata() }
@@ -262,14 +269,15 @@ class PlaylistServiceTests {
   fun `syncPlaylists notifies dashboard when playlist count decreases`() {
     val user = buildUser()
     every { userRepository.findById(userId) } returns user
+    every { currentUserResolver.userId() } returns userId
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
-    every { spotifyPlaylist.getPlaylists(userId, accessToken) } returns listOf(buildSpotifyItem("p1")).right()
+    every { spotifyPlaylist.getPlaylists(accessToken) } returns listOf(buildSpotifyItem("p1")).right()
     every { playlistRepository.findByUserId(userId) } returns listOf(buildPlaylistInfo("p1"), buildPlaylistInfo("p2"))
     every { playlistRepository.replaceAll(any(), any()) } just runs
     every { playlistRepository.findByUserIdAndPlaylistId(userId, "p1") } returns mockk()
     every { dashboardRefresh.notifyUserPlaylistMetadata() } just runs
 
-    val result = adapter.syncPlaylists(userId)
+    val result = adapter.syncPlaylists()
 
     assertThat(result.isRight()).isTrue()
     verify(exactly = 1) { dashboardRefresh.notifyUserPlaylistMetadata() }
@@ -279,13 +287,14 @@ class PlaylistServiceTests {
   fun `syncPlaylists does not notify dashboard when playlist count is unchanged`() {
     val user = buildUser()
     every { userRepository.findById(userId) } returns user
+    every { currentUserResolver.userId() } returns userId
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
-    every { spotifyPlaylist.getPlaylists(userId, accessToken) } returns listOf(buildSpotifyItem("p1")).right()
+    every { spotifyPlaylist.getPlaylists(accessToken) } returns listOf(buildSpotifyItem("p1")).right()
     every { playlistRepository.findByUserId(userId) } returns listOf(buildPlaylistInfo("p1"))
     every { playlistRepository.replaceAll(any(), any()) } just runs
     every { playlistRepository.findByUserIdAndPlaylistId(userId, "p1") } returns mockk()
 
-    val result = adapter.syncPlaylists(userId)
+    val result = adapter.syncPlaylists()
 
     assertThat(result.isRight()).isTrue()
     verify(exactly = 0) { dashboardRefresh.notifyUserPlaylistMetadata() }
@@ -295,10 +304,11 @@ class PlaylistServiceTests {
   fun `syncPlaylists returns Left when spotify fetch fails`() {
     val user = buildUser()
     every { userRepository.findById(userId) } returns user
+    every { currentUserResolver.userId() } returns userId
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
-    every { spotifyPlaylist.getPlaylists(userId, accessToken) } returns PlaylistSyncError.PLAYLIST_FETCH_FAILED.left()
+    every { spotifyPlaylist.getPlaylists(accessToken) } returns PlaylistSyncError.PLAYLIST_FETCH_FAILED.left()
 
-    val result = adapter.syncPlaylists(userId)
+    val result = adapter.syncPlaylists()
 
     assertThat(result.isLeft()).isTrue()
     verify(exactly = 0) { playlistRepository.replaceAll(any(), any()) }
@@ -308,10 +318,11 @@ class PlaylistServiceTests {
   fun `syncPlaylists returns Left with SpotifyRateLimitError when rate limited`() {
     val user = buildUser()
     every { userRepository.findById(userId) } returns user
+    every { currentUserResolver.userId() } returns userId
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
-    every { spotifyPlaylist.getPlaylists(userId, accessToken) } returns SpotifyRateLimitError(30.seconds).left()
+    every { spotifyPlaylist.getPlaylists(accessToken) } returns SpotifyRateLimitError(30.seconds).left()
 
-    val result = adapter.syncPlaylists(userId)
+    val result = adapter.syncPlaylists()
 
     assertThat(result.isLeft()).isTrue()
     assertThat(result.leftOrNull()).isInstanceOf(SpotifyRateLimitError::class.java)
@@ -321,9 +332,9 @@ class PlaylistServiceTests {
 
   @Test
   fun `updateSyncStatus returns Left when user not found`() {
-    every { userRepository.findById(userId) } returns null
+    every { currentUserResolver.userId() } returns null
 
-    val result = adapter.updateSyncStatus(userId, "p1", PlaylistSyncStatus.PASSIVE)
+    val result = adapter.updateSyncStatus("p1", PlaylistSyncStatus.PASSIVE)
 
     assertThat(result.isLeft()).isTrue()
     assertThat(result.leftOrNull()).isEqualTo(PlaylistSyncError.PLAYLIST_NOT_FOUND)
@@ -333,9 +344,10 @@ class PlaylistServiceTests {
   fun `updateSyncStatus returns Left when playlist not found`() {
     val user = buildUser()
     every { userRepository.findById(userId) } returns user
+    every { currentUserResolver.userId() } returns userId
     every { playlistRepository.findByUserId(userId) } returns listOf(buildPlaylistInfo("p1"))
 
-    val result = adapter.updateSyncStatus(userId, "p-unknown", PlaylistSyncStatus.PASSIVE)
+    val result = adapter.updateSyncStatus("p-unknown", PlaylistSyncStatus.PASSIVE)
 
     assertThat(result.isLeft()).isTrue()
     assertThat(result.leftOrNull()).isEqualTo(PlaylistSyncError.PLAYLIST_NOT_FOUND)
@@ -345,6 +357,7 @@ class PlaylistServiceTests {
   fun `updateSyncStatus updates only the target playlist`() {
     val user = buildUser()
     every { userRepository.findById(userId) } returns user
+    every { currentUserResolver.userId() } returns userId
     every { playlistRepository.findByUserId(userId) } returns listOf(
       buildPlaylistInfo("p1", syncStatus = PlaylistSyncStatus.ACTIVE),
       buildPlaylistInfo("p2", syncStatus = PlaylistSyncStatus.ACTIVE),
@@ -354,7 +367,7 @@ class PlaylistServiceTests {
     every { dashboardRefresh.notifyUserPlaylistMetadata() } just runs
     every { playlistCheckRepository.deleteByPlaylistId("p1") } just runs
 
-    val result = adapter.updateSyncStatus(userId, "p1", PlaylistSyncStatus.PASSIVE)
+    val result = adapter.updateSyncStatus("p1", PlaylistSyncStatus.PASSIVE)
 
     assertThat(result.isRight()).isTrue()
     val savedSlot = slot<List<PlaylistInfo>>()
@@ -368,43 +381,46 @@ class PlaylistServiceTests {
   fun `syncPlaylists enqueues SyncPlaylistData for active playlist with changed snapshotId`() {
     val user = buildUser()
     every { userRepository.findById(userId) } returns user
+    every { currentUserResolver.userId() } returns userId
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
-    every { spotifyPlaylist.getPlaylists(userId, accessToken) } returns listOf(buildSpotifyItem("p1", snapshotId = "snap-2")).right()
+    every { spotifyPlaylist.getPlaylists(accessToken) } returns listOf(buildSpotifyItem("p1", snapshotId = "snap-2")).right()
     every { playlistRepository.findByUserId(userId) } returns listOf(buildPlaylistInfo("p1", snapshotId = "snap-1"))
     every { playlistRepository.replaceAll(any(), any()) } just runs
     every { outboxPort.enqueue(any()) } just runs
 
-    adapter.syncPlaylists(userId)
+    adapter.syncPlaylists()
 
-    verify(exactly = 1) { outboxPort.enqueue(DomainOutboxEvent.SyncPlaylistData(userId, "p1")) }
+    verify(exactly = 1) { outboxPort.enqueue(DomainOutboxEvent.SyncPlaylistData("p1")) }
   }
 
   @Test
   fun `syncPlaylists enqueues SyncPlaylistData for active playlist with no existing playlist data`() {
     val user = buildUser()
     every { userRepository.findById(userId) } returns user
+    every { currentUserResolver.userId() } returns userId
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
-    every { spotifyPlaylist.getPlaylists(userId, accessToken) } returns listOf(buildSpotifyItem("p1")).right()
+    every { spotifyPlaylist.getPlaylists(accessToken) } returns listOf(buildSpotifyItem("p1")).right()
     every { playlistRepository.findByUserId(userId) } returns listOf(buildPlaylistInfo("p1"))
     every { playlistRepository.replaceAll(any(), any()) } just runs
     every { playlistRepository.findByUserIdAndPlaylistId(userId, "p1") } returns null
     every { outboxPort.enqueue(any()) } just runs
 
-    adapter.syncPlaylists(userId)
+    adapter.syncPlaylists()
 
-    verify(exactly = 1) { outboxPort.enqueue(DomainOutboxEvent.SyncPlaylistData(userId, "p1")) }
+    verify(exactly = 1) { outboxPort.enqueue(DomainOutboxEvent.SyncPlaylistData("p1")) }
   }
 
   @Test
   fun `syncPlaylists does not enqueue SyncPlaylistData for passive playlist`() {
     val user = buildUser()
     every { userRepository.findById(userId) } returns user
+    every { currentUserResolver.userId() } returns userId
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
-    every { spotifyPlaylist.getPlaylists(userId, accessToken) } returns listOf(buildSpotifyItem("p1")).right()
+    every { spotifyPlaylist.getPlaylists(accessToken) } returns listOf(buildSpotifyItem("p1")).right()
     every { playlistRepository.findByUserId(userId) } returns listOf(buildPlaylistInfo("p1", syncStatus = PlaylistSyncStatus.PASSIVE))
     every { playlistRepository.replaceAll(any(), any()) } just runs
 
-    adapter.syncPlaylists(userId)
+    adapter.syncPlaylists()
 
     verify(exactly = 0) { outboxPort.enqueue(any<DomainOutboxEvent.SyncPlaylistData>()) }
   }
@@ -413,13 +429,14 @@ class PlaylistServiceTests {
   fun `syncPlaylists does not enqueue SyncPlaylistData for active playlist with unchanged snapshotId and existing data`() {
     val user = buildUser()
     every { userRepository.findById(userId) } returns user
+    every { currentUserResolver.userId() } returns userId
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
-    every { spotifyPlaylist.getPlaylists(userId, accessToken) } returns listOf(buildSpotifyItem("p1")).right()
+    every { spotifyPlaylist.getPlaylists(accessToken) } returns listOf(buildSpotifyItem("p1")).right()
     every { playlistRepository.findByUserId(userId) } returns listOf(buildPlaylistInfo("p1"))
     every { playlistRepository.replaceAll(any(), any()) } just runs
     every { playlistRepository.findByUserIdAndPlaylistId(userId, "p1") } returns mockk()
 
-    adapter.syncPlaylists(userId)
+    adapter.syncPlaylists()
 
     verify(exactly = 0) { outboxPort.enqueue(any<DomainOutboxEvent.SyncPlaylistData>()) }
   }
@@ -446,12 +463,12 @@ class PlaylistServiceTests {
 
   @Test
   fun `syncPlaylistData skips when user not found`() {
-    every { userRepository.findById(userId) } returns null
+    every { currentUserResolver.userId() } returns null
 
-    val result = adapter.syncPlaylistData(userId, "p1")
+    val result = adapter.syncPlaylistData("p1")
 
     assertThat(result.isRight()).isTrue()
-    verify(exactly = 0) { spotifyPlaylist.getPlaylistTracksPage(any(), any(), any(), any()) }
+    verify(exactly = 0) { spotifyPlaylist.getPlaylistTracksPage(any(), any(), any()) }
   }
 
   @Test
@@ -459,13 +476,14 @@ class PlaylistServiceTests {
     val user = buildUser()
     val page = buildTracksPage()
     every { userRepository.findById(userId) } returns user
+    every { currentUserResolver.userId() } returns userId
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
-    every { spotifyPlaylist.getPlaylistTracksPage(userId, accessToken, "p1", null) } returns page.right()
+    every { spotifyPlaylist.getPlaylistTracksPage(accessToken, "p1", null) } returns page.right()
     every { playlistRepository.save(userId, buildPlaylist("p1")) } just runs
     every { outboxPort.enqueue(any()) } just runs
     every { playlistRepository.updateLastSyncTime(userId, "p1", any()) } just runs
 
-    val result = adapter.syncPlaylistData(userId, "p1")
+    val result = adapter.syncPlaylistData("p1")
 
     assertThat(result.isRight()).isTrue()
     verify { playlistRepository.save(userId, buildPlaylist("p1")) }
@@ -476,18 +494,18 @@ class PlaylistServiceTests {
     val user = buildUser()
     val page = buildTracksPage()
     every { userRepository.findById(userId) } returns user
+    every { currentUserResolver.userId() } returns userId
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
-    every { spotifyPlaylist.getPlaylistTracksPage(userId, accessToken, "p1", null) } returns page.right()
+    every { spotifyPlaylist.getPlaylistTracksPage(accessToken, "p1", null) } returns page.right()
     every { playlistRepository.save(userId, any()) } just runs
     every { outboxPort.enqueue(any()) } just runs
     every { playlistRepository.updateLastSyncTime(userId, "p1", any()) } just runs
 
-    adapter.syncPlaylistData(userId, "p1")
+    adapter.syncPlaylistData("p1")
 
     verify {
       syncController.syncForTracks(
         listOf(CatalogSyncRequest("track-1", listOf("artist-1"), SyncCause.Playlist("p1", "track-1"))),
-        userId,
       )
     }
   }
@@ -497,13 +515,14 @@ class PlaylistServiceTests {
     val user = buildUser()
     val page = buildTracksPage()
     every { userRepository.findById(userId) } returns user
+    every { currentUserResolver.userId() } returns userId
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
-    every { spotifyPlaylist.getPlaylistTracksPage(userId, accessToken, "p1", null) } returns page.right()
+    every { spotifyPlaylist.getPlaylistTracksPage(accessToken, "p1", null) } returns page.right()
     every { playlistRepository.save(userId, any()) } just runs
     every { outboxPort.enqueue(any()) } just runs
     every { playlistRepository.updateLastSyncTime(userId, "p1", any()) } just runs
 
-    adapter.syncPlaylistData(userId, "p1")
+    adapter.syncPlaylistData("p1")
 
     verify(exactly = 1) { playlistRepository.updateLastSyncTime(eq(userId), eq("p1"), any()) }
   }
@@ -514,12 +533,13 @@ class PlaylistServiceTests {
     val nextPageUrl = "https://api.spotify.com/v1/playlists/p1/tracks?offset=50&limit=50"
     val page = buildTracksPage(nextUrl = nextPageUrl)
     every { userRepository.findById(userId) } returns user
+    every { currentUserResolver.userId() } returns userId
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
-    every { spotifyPlaylist.getPlaylistTracksPage(userId, accessToken, "p1", null) } returns page.right()
+    every { spotifyPlaylist.getPlaylistTracksPage(accessToken, "p1", null) } returns page.right()
     every { playlistRepository.save(userId, any()) } just runs
     every { outboxPort.enqueue(any()) } just runs
 
-    adapter.syncPlaylistData(userId, "p1")
+    adapter.syncPlaylistData("p1")
 
     verify(exactly = 0) { playlistRepository.updateLastSyncTime(any(), any(), any()) }
   }
@@ -530,14 +550,15 @@ class PlaylistServiceTests {
     val nextPageUrl = "https://api.spotify.com/v1/playlists/p1/tracks?offset=50&limit=50"
     val page = buildTracksPage(nextUrl = nextPageUrl)
     every { userRepository.findById(userId) } returns user
+    every { currentUserResolver.userId() } returns userId
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
-    every { spotifyPlaylist.getPlaylistTracksPage(userId, accessToken, "p1", null) } returns page.right()
+    every { spotifyPlaylist.getPlaylistTracksPage(accessToken, "p1", null) } returns page.right()
     every { playlistRepository.save(userId, any()) } just runs
     every { outboxPort.enqueue(any()) } just runs
 
-    adapter.syncPlaylistData(userId, "p1")
+    adapter.syncPlaylistData("p1")
 
-    verify(exactly = 1) { outboxPort.enqueue(DomainOutboxEvent.SyncPlaylistData(userId, "p1", nextPageUrl, "snap-1")) }
+    verify(exactly = 1) { outboxPort.enqueue(DomainOutboxEvent.SyncPlaylistData("p1", nextPageUrl, "snap-1")) }
     verify(exactly = 0) { outboxPort.enqueue(any<DomainOutboxEvent.RunPlaylistChecks>()) }
   }
 
@@ -546,15 +567,16 @@ class PlaylistServiceTests {
     val user = buildUser()
     val page = buildTracksPage()
     every { userRepository.findById(userId) } returns user
+    every { currentUserResolver.userId() } returns userId
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
-    every { spotifyPlaylist.getPlaylistTracksPage(userId, accessToken, "p1", null) } returns page.right()
+    every { spotifyPlaylist.getPlaylistTracksPage(accessToken, "p1", null) } returns page.right()
     every { playlistRepository.save(userId, any()) } just runs
     every { outboxPort.enqueue(any()) } just runs
     every { playlistRepository.updateLastSyncTime(userId, "p1", any()) } just runs
 
-    adapter.syncPlaylistData(userId, "p1")
+    adapter.syncPlaylistData("p1")
 
-    verify(exactly = 1) { outboxPort.enqueue(DomainOutboxEvent.RunPlaylistChecks(userId, "p1")) }
+    verify(exactly = 1) { outboxPort.enqueue(DomainOutboxEvent.RunPlaylistChecks("p1")) }
     verify(exactly = 0) { outboxPort.enqueue(any<DomainOutboxEvent.SyncPlaylistData>()) }
   }
 
@@ -564,13 +586,14 @@ class PlaylistServiceTests {
     val nextPageUrl = "https://api.spotify.com/v1/playlists/p1/tracks?offset=50&limit=50"
     val page = buildTracksPage()
     every { userRepository.findById(userId) } returns user
+    every { currentUserResolver.userId() } returns userId
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
-    every { spotifyPlaylist.getPlaylistTracksPage(userId, accessToken, "p1", nextPageUrl) } returns page.right()
+    every { spotifyPlaylist.getPlaylistTracksPage(accessToken, "p1", nextPageUrl) } returns page.right()
     every { playlistRepository.appendTracks(userId, "p1", page.tracks) } just runs
     every { outboxPort.enqueue(any()) } just runs
     every { playlistRepository.updateLastSyncTime(userId, "p1", any()) } just runs
 
-    val result = adapter.syncPlaylistData(userId, "p1", nextPageUrl)
+    val result = adapter.syncPlaylistData("p1", nextPageUrl)
 
     assertThat(result.isRight()).isTrue()
     verify(exactly = 1) { playlistRepository.appendTracks(userId, "p1", page.tracks) }
@@ -583,14 +606,15 @@ class PlaylistServiceTests {
     val nextPageUrl = "https://api.spotify.com/v1/playlists/p1/tracks?offset=50&limit=50"
     val page = buildTracksPage(snapshotId = "snap-2")  // snapshot changed
     every { userRepository.findById(userId) } returns user
+    every { currentUserResolver.userId() } returns userId
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
-    every { spotifyPlaylist.getPlaylistTracksPage(userId, accessToken, "p1", nextPageUrl) } returns page.right()
+    every { spotifyPlaylist.getPlaylistTracksPage(accessToken, "p1", nextPageUrl) } returns page.right()
     every { outboxPort.enqueue(any()) } just runs
 
-    val result = adapter.syncPlaylistData(userId, "p1", nextPageUrl, "snap-1")
+    val result = adapter.syncPlaylistData("p1", nextPageUrl, "snap-1")
 
     assertThat(result.isRight()).isTrue()
-    verify(exactly = 1) { outboxPort.enqueue(DomainOutboxEvent.SyncPlaylistData(userId, "p1")) }
+    verify(exactly = 1) { outboxPort.enqueue(DomainOutboxEvent.SyncPlaylistData("p1")) }
     verify(exactly = 0) { playlistRepository.appendTracks(any(), any(), any()) }
     verify(exactly = 0) { playlistRepository.save(any(), any()) }
   }
@@ -601,17 +625,18 @@ class PlaylistServiceTests {
     val nextPageUrl = "https://api.spotify.com/v1/playlists/p1/tracks?offset=50&limit=50"
     val page = buildTracksPage(snapshotId = "snap-1")
     every { userRepository.findById(userId) } returns user
+    every { currentUserResolver.userId() } returns userId
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
-    every { spotifyPlaylist.getPlaylistTracksPage(userId, accessToken, "p1", nextPageUrl) } returns page.right()
+    every { spotifyPlaylist.getPlaylistTracksPage(accessToken, "p1", nextPageUrl) } returns page.right()
     every { playlistRepository.appendTracks(userId, "p1", page.tracks) } just runs
     every { outboxPort.enqueue(any()) } just runs
     every { playlistRepository.updateLastSyncTime(userId, "p1", any()) } just runs
 
-    val result = adapter.syncPlaylistData(userId, "p1", nextPageUrl, "snap-1")
+    val result = adapter.syncPlaylistData("p1", nextPageUrl, "snap-1")
 
     assertThat(result.isRight()).isTrue()
     verify(exactly = 1) { playlistRepository.appendTracks(userId, "p1", page.tracks) }
-    verify(exactly = 0) { outboxPort.enqueue(DomainOutboxEvent.SyncPlaylistData(userId, "p1")) }
+    verify(exactly = 0) { outboxPort.enqueue(DomainOutboxEvent.SyncPlaylistData("p1")) }
   }
 
 
@@ -619,10 +644,11 @@ class PlaylistServiceTests {
   fun `syncPlaylistData returns Left when tracks fetch fails`() {
     val user = buildUser()
     every { userRepository.findById(userId) } returns user
+    every { currentUserResolver.userId() } returns userId
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
-    every { spotifyPlaylist.getPlaylistTracksPage(userId, accessToken, "p1", null) } returns PlaylistSyncError.PLAYLIST_TRACKS_FETCH_FAILED.left()
+    every { spotifyPlaylist.getPlaylistTracksPage(accessToken, "p1", null) } returns PlaylistSyncError.PLAYLIST_TRACKS_FETCH_FAILED.left()
 
-    val result = adapter.syncPlaylistData(userId, "p1")
+    val result = adapter.syncPlaylistData("p1")
 
     assertThat(result.isLeft()).isTrue()
     verify(exactly = 0) { playlistRepository.save(any(), any()) }
@@ -634,30 +660,32 @@ class PlaylistServiceTests {
   fun `updateSyncStatus enqueues SyncPlaylistData when activating playlist with no existing data`() {
     val user = buildUser()
     every { userRepository.findById(userId) } returns user
+    every { currentUserResolver.userId() } returns userId
     every { playlistRepository.findByUserId(userId) } returns listOf(buildPlaylistInfo("p1", syncStatus = PlaylistSyncStatus.PASSIVE))
     every { playlistRepository.replaceAll(any(), any()) } just runs
     every { outboxPort.enqueue(any()) } just runs
     every { dashboardRefresh.notifyUserPlaylistMetadata() } just runs
 
-    val result = adapter.updateSyncStatus(userId, "p1", PlaylistSyncStatus.ACTIVE)
+    val result = adapter.updateSyncStatus("p1", PlaylistSyncStatus.ACTIVE)
 
     assertThat(result.isRight()).isTrue()
-    verify(exactly = 1) { outboxPort.enqueue(DomainOutboxEvent.SyncPlaylistData(userId, "p1")) }
+    verify(exactly = 1) { outboxPort.enqueue(DomainOutboxEvent.SyncPlaylistData("p1")) }
   }
 
   @Test
   fun `updateSyncStatus enqueues SyncPlaylistData when activating playlist with existing data`() {
     val user = buildUser()
     every { userRepository.findById(userId) } returns user
+    every { currentUserResolver.userId() } returns userId
     every { playlistRepository.findByUserId(userId) } returns listOf(buildPlaylistInfo("p1", syncStatus = PlaylistSyncStatus.PASSIVE))
     every { playlistRepository.replaceAll(any(), any()) } just runs
     every { outboxPort.enqueue(any()) } just runs
     every { dashboardRefresh.notifyUserPlaylistMetadata() } just runs
 
-    val result = adapter.updateSyncStatus(userId, "p1", PlaylistSyncStatus.ACTIVE)
+    val result = adapter.updateSyncStatus("p1", PlaylistSyncStatus.ACTIVE)
 
     assertThat(result.isRight()).isTrue()
-    verify(exactly = 1) { outboxPort.enqueue(DomainOutboxEvent.SyncPlaylistData(userId, "p1")) }
+    verify(exactly = 1) { outboxPort.enqueue(DomainOutboxEvent.SyncPlaylistData("p1")) }
     verify(exactly = 0) { outboxPort.enqueue(any<DomainOutboxEvent.RunPlaylistChecks>()) }
   }
 
@@ -665,13 +693,14 @@ class PlaylistServiceTests {
   fun `updateSyncStatus notifies dashboard refresh after updating sync status`() {
     val user = buildUser()
     every { userRepository.findById(userId) } returns user
+    every { currentUserResolver.userId() } returns userId
     every { playlistRepository.findByUserId(userId) } returns listOf(buildPlaylistInfo("p1", syncStatus = PlaylistSyncStatus.ACTIVE))
     every { playlistRepository.replaceAll(any(), any()) } just runs
     every { playlistRepository.findByUserIdAndPlaylistId(userId, "p1") } returns mockk()
     every { dashboardRefresh.notifyUserPlaylistMetadata() } just runs
     every { playlistCheckRepository.deleteByPlaylistId("p1") } just runs
 
-    val result = adapter.updateSyncStatus(userId, "p1", PlaylistSyncStatus.PASSIVE)
+    val result = adapter.updateSyncStatus("p1", PlaylistSyncStatus.PASSIVE)
 
     assertThat(result.isRight()).isTrue()
     verify(exactly = 1) { dashboardRefresh.notifyUserPlaylistMetadata() }
@@ -681,13 +710,14 @@ class PlaylistServiceTests {
   fun `updateSyncStatus notifies dashboard refresh when activating playlist`() {
     val user = buildUser()
     every { userRepository.findById(userId) } returns user
+    every { currentUserResolver.userId() } returns userId
     every { playlistRepository.findByUserId(userId) } returns listOf(buildPlaylistInfo("p1", syncStatus = PlaylistSyncStatus.PASSIVE))
     every { playlistRepository.replaceAll(any(), any()) } just runs
     every { playlistRepository.findByUserIdAndPlaylistId(userId, "p1") } returns mockk()
     every { outboxPort.enqueue(any()) } just runs
     every { dashboardRefresh.notifyUserPlaylistMetadata() } just runs
 
-    val result = adapter.updateSyncStatus(userId, "p1", PlaylistSyncStatus.ACTIVE)
+    val result = adapter.updateSyncStatus("p1", PlaylistSyncStatus.ACTIVE)
 
     assertThat(result.isRight()).isTrue()
     verify(exactly = 1) { dashboardRefresh.notifyUserPlaylistMetadata() }
@@ -697,13 +727,14 @@ class PlaylistServiceTests {
   fun `updateSyncStatus deletes check documents when deactivating playlist`() {
     val user = buildUser()
     every { userRepository.findById(userId) } returns user
+    every { currentUserResolver.userId() } returns userId
     every { playlistRepository.findByUserId(userId) } returns listOf(buildPlaylistInfo("p1", syncStatus = PlaylistSyncStatus.ACTIVE))
     every { playlistRepository.replaceAll(any(), any()) } just runs
     every { playlistRepository.findByUserIdAndPlaylistId(userId, "p1") } returns mockk()
     every { dashboardRefresh.notifyUserPlaylistMetadata() } just runs
     every { playlistCheckRepository.deleteByPlaylistId("p1") } just runs
 
-    val result = adapter.updateSyncStatus(userId, "p1", PlaylistSyncStatus.PASSIVE)
+    val result = adapter.updateSyncStatus("p1", PlaylistSyncStatus.PASSIVE)
 
     assertThat(result.isRight()).isTrue()
     verify(exactly = 1) { playlistCheckRepository.deleteByPlaylistId("p1") }
@@ -713,13 +744,14 @@ class PlaylistServiceTests {
   fun `updateSyncStatus does not delete check documents when activating playlist`() {
     val user = buildUser()
     every { userRepository.findById(userId) } returns user
+    every { currentUserResolver.userId() } returns userId
     every { playlistRepository.findByUserId(userId) } returns listOf(buildPlaylistInfo("p1", syncStatus = PlaylistSyncStatus.PASSIVE))
     every { playlistRepository.replaceAll(any(), any()) } just runs
     every { playlistRepository.findByUserIdAndPlaylistId(userId, "p1") } returns mockk()
     every { outboxPort.enqueue(any()) } just runs
     every { dashboardRefresh.notifyUserPlaylistMetadata() } just runs
 
-    val result = adapter.updateSyncStatus(userId, "p1", PlaylistSyncStatus.ACTIVE)
+    val result = adapter.updateSyncStatus("p1", PlaylistSyncStatus.ACTIVE)
 
     assertThat(result.isRight()).isTrue()
     verify(exactly = 0) { playlistCheckRepository.deleteByPlaylistId(any()) }
@@ -729,12 +761,13 @@ class PlaylistServiceTests {
   fun `updateSyncStatus sets type ALL when activating playlist named All`() {
     val user = buildUser()
     every { userRepository.findById(userId) } returns user
+    every { currentUserResolver.userId() } returns userId
     every { playlistRepository.findByUserId(userId) } returns listOf(buildPlaylistInfo("p1", syncStatus = PlaylistSyncStatus.PASSIVE, name = "All"))
     every { playlistRepository.replaceAll(any(), any()) } just runs
     every { outboxPort.enqueue(any()) } just runs
     every { dashboardRefresh.notifyUserPlaylistMetadata() } just runs
 
-    val result = adapter.updateSyncStatus(userId, "p1", PlaylistSyncStatus.ACTIVE)
+    val result = adapter.updateSyncStatus("p1", PlaylistSyncStatus.ACTIVE)
 
     assertThat(result.isRight()).isTrue()
     val savedSlot = slot<List<PlaylistInfo>>()
@@ -746,12 +779,13 @@ class PlaylistServiceTests {
   fun `updateSyncStatus sets type ALL when activating playlist named all case-insensitive`() {
     val user = buildUser()
     every { userRepository.findById(userId) } returns user
+    every { currentUserResolver.userId() } returns userId
     every { playlistRepository.findByUserId(userId) } returns listOf(buildPlaylistInfo("p1", syncStatus = PlaylistSyncStatus.PASSIVE, name = "ALL"))
     every { playlistRepository.replaceAll(any(), any()) } just runs
     every { outboxPort.enqueue(any()) } just runs
     every { dashboardRefresh.notifyUserPlaylistMetadata() } just runs
 
-    val result = adapter.updateSyncStatus(userId, "p1", PlaylistSyncStatus.ACTIVE)
+    val result = adapter.updateSyncStatus("p1", PlaylistSyncStatus.ACTIVE)
 
     assertThat(result.isRight()).isTrue()
     val savedSlot = slot<List<PlaylistInfo>>()
@@ -763,9 +797,9 @@ class PlaylistServiceTests {
 
   @Test
   fun `enqueueSyncPlaylistData returns Left when user not found`() {
-    every { userRepository.findById(userId) } returns null
+    every { currentUserResolver.userId() } returns null
 
-    val result = adapter.enqueueSyncPlaylistData(userId, "p1")
+    val result = adapter.enqueueSyncPlaylistData("p1")
 
     assertThat(result.isLeft()).isTrue()
     assertThat(result.leftOrNull()).isEqualTo(PlaylistSyncError.PLAYLIST_NOT_FOUND)
@@ -776,9 +810,10 @@ class PlaylistServiceTests {
   fun `enqueueSyncPlaylistData returns Left when playlist not found`() {
     val user = buildUser()
     every { userRepository.findById(userId) } returns user
+    every { currentUserResolver.userId() } returns userId
     every { playlistRepository.findByUserId(userId) } returns emptyList()
 
-    val result = adapter.enqueueSyncPlaylistData(userId, "p1")
+    val result = adapter.enqueueSyncPlaylistData("p1")
 
     assertThat(result.isLeft()).isTrue()
     assertThat(result.leftOrNull()).isEqualTo(PlaylistSyncError.PLAYLIST_NOT_FOUND)
@@ -789,9 +824,10 @@ class PlaylistServiceTests {
   fun `enqueueSyncPlaylistData returns Left when playlist is not active`() {
     val user = buildUser()
     every { userRepository.findById(userId) } returns user
+    every { currentUserResolver.userId() } returns userId
     every { playlistRepository.findByUserId(userId) } returns listOf(buildPlaylistInfo("p1", syncStatus = PlaylistSyncStatus.PASSIVE))
 
-    val result = adapter.enqueueSyncPlaylistData(userId, "p1")
+    val result = adapter.enqueueSyncPlaylistData("p1")
 
     assertThat(result.isLeft()).isTrue()
     assertThat(result.leftOrNull()).isEqualTo(PlaylistSyncError.PLAYLIST_SYNC_INACTIVE)
@@ -802,12 +838,13 @@ class PlaylistServiceTests {
   fun `enqueueSyncPlaylistData enqueues SyncPlaylistData and returns Right`() {
     val user = buildUser()
     every { userRepository.findById(userId) } returns user
+    every { currentUserResolver.userId() } returns userId
     every { playlistRepository.findByUserId(userId) } returns listOf(buildPlaylistInfo("p1"))
     every { outboxPort.enqueue(any()) } just runs
 
-    val result = adapter.enqueueSyncPlaylistData(userId, "p1")
+    val result = adapter.enqueueSyncPlaylistData("p1")
 
     assertThat(result.isRight()).isTrue()
-    verify(exactly = 1) { outboxPort.enqueue(DomainOutboxEvent.SyncPlaylistData(userId, "p1")) }
+    verify(exactly = 1) { outboxPort.enqueue(DomainOutboxEvent.SyncPlaylistData("p1")) }
   }
 }

--- a/domain-impl/src/test/kotlin/de/chrgroth/spotify/control/domain/playlist/check/DuplicateTrackIdsCheckRunnerTests.kt
+++ b/domain-impl/src/test/kotlin/de/chrgroth/spotify/control/domain/playlist/check/DuplicateTrackIdsCheckRunnerTests.kt
@@ -138,70 +138,70 @@ class DuplicateTrackIdsCheckRunnerTests {
     val result = runner.fix(userId, accessToken, playlistId, playlist, null, emptyList())
 
     assertThat(result.isRight()).isTrue()
-    verify(exactly = 0) { spotifyPlaylist.removePlaylistTracks(any(), any(), any(), any()) }
-    verify(exactly = 0) { spotifyPlaylist.addPlaylistTracks(any(), any(), any(), any()) }
+    verify(exactly = 0) { spotifyPlaylist.removePlaylistTracks(any(), any(), any()) }
+    verify(exactly = 0) { spotifyPlaylist.addPlaylistTracks(any(), any(), any()) }
   }
 
   @Test
   fun `fix removes all occurrences and re-adds once when track appears twice`() {
     val playlist = buildPlaylist(listOf(buildTrack("t1"), buildTrack("t2"), buildTrack("t1")))
-    every { spotifyPlaylist.removePlaylistTracks(userId, accessToken, playlistId, listOf("t1")) } returns Unit.right()
-    every { spotifyPlaylist.addPlaylistTracks(userId, accessToken, playlistId, listOf("t1")) } returns Unit.right()
+    every { spotifyPlaylist.removePlaylistTracks(accessToken, playlistId, listOf("t1")) } returns Unit.right()
+    every { spotifyPlaylist.addPlaylistTracks(accessToken, playlistId, listOf("t1")) } returns Unit.right()
 
     val result = runner.fix(userId, accessToken, playlistId, playlist, null, emptyList())
 
     assertThat(result.isRight()).isTrue()
-    verify(exactly = 1) { spotifyPlaylist.removePlaylistTracks(userId, accessToken, playlistId, listOf("t1")) }
-    verify(exactly = 1) { spotifyPlaylist.addPlaylistTracks(userId, accessToken, playlistId, listOf("t1")) }
+    verify(exactly = 1) { spotifyPlaylist.removePlaylistTracks(accessToken, playlistId, listOf("t1")) }
+    verify(exactly = 1) { spotifyPlaylist.addPlaylistTracks(accessToken, playlistId, listOf("t1")) }
   }
 
   @Test
   fun `fix removes all occurrences and re-adds once when track appears three times`() {
     val playlist = buildPlaylist(listOf(buildTrack("t1"), buildTrack("t1"), buildTrack("t1")))
-    every { spotifyPlaylist.removePlaylistTracks(userId, accessToken, playlistId, listOf("t1")) } returns Unit.right()
-    every { spotifyPlaylist.addPlaylistTracks(userId, accessToken, playlistId, listOf("t1")) } returns Unit.right()
+    every { spotifyPlaylist.removePlaylistTracks(accessToken, playlistId, listOf("t1")) } returns Unit.right()
+    every { spotifyPlaylist.addPlaylistTracks(accessToken, playlistId, listOf("t1")) } returns Unit.right()
 
     val result = runner.fix(userId, accessToken, playlistId, playlist, null, emptyList())
 
     assertThat(result.isRight()).isTrue()
-    verify(exactly = 1) { spotifyPlaylist.removePlaylistTracks(userId, accessToken, playlistId, listOf("t1")) }
-    verify(exactly = 1) { spotifyPlaylist.addPlaylistTracks(userId, accessToken, playlistId, listOf("t1")) }
+    verify(exactly = 1) { spotifyPlaylist.removePlaylistTracks(accessToken, playlistId, listOf("t1")) }
+    verify(exactly = 1) { spotifyPlaylist.addPlaylistTracks(accessToken, playlistId, listOf("t1")) }
   }
 
   @Test
   fun `fix handles multiple different duplicate tracks`() {
     val playlist = buildPlaylist(listOf(buildTrack("t1"), buildTrack("t2"), buildTrack("t1"), buildTrack("t2")))
     every {
-      spotifyPlaylist.removePlaylistTracks(userId, accessToken, playlistId, listOf("t1", "t2"))
+      spotifyPlaylist.removePlaylistTracks(accessToken, playlistId, listOf("t1", "t2"))
     } returns Unit.right()
     every {
-      spotifyPlaylist.addPlaylistTracks(userId, accessToken, playlistId, listOf("t1", "t2"))
+      spotifyPlaylist.addPlaylistTracks(accessToken, playlistId, listOf("t1", "t2"))
     } returns Unit.right()
 
     val result = runner.fix(userId, accessToken, playlistId, playlist, null, emptyList())
 
     assertThat(result.isRight()).isTrue()
-    verify(exactly = 1) { spotifyPlaylist.removePlaylistTracks(userId, accessToken, playlistId, listOf("t1", "t2")) }
-    verify(exactly = 1) { spotifyPlaylist.addPlaylistTracks(userId, accessToken, playlistId, listOf("t1", "t2")) }
+    verify(exactly = 1) { spotifyPlaylist.removePlaylistTracks(accessToken, playlistId, listOf("t1", "t2")) }
+    verify(exactly = 1) { spotifyPlaylist.addPlaylistTracks(accessToken, playlistId, listOf("t1", "t2")) }
   }
 
   @Test
   fun `fix propagates error from removePlaylistTracks`() {
     val playlist = buildPlaylist(listOf(buildTrack("t1"), buildTrack("t1")))
-    every { spotifyPlaylist.removePlaylistTracks(any(), any(), any(), any()) } returns PlaylistFixError.FIX_FAILED.left()
+    every { spotifyPlaylist.removePlaylistTracks(any(), any(), any()) } returns PlaylistFixError.FIX_FAILED.left()
 
     val result = runner.fix(userId, accessToken, playlistId, playlist, null, emptyList())
 
     assertThat(result.isLeft()).isTrue()
     assertThat((result as Either.Left).value).isEqualTo(PlaylistFixError.FIX_FAILED)
-    verify(exactly = 0) { spotifyPlaylist.addPlaylistTracks(any(), any(), any(), any()) }
+    verify(exactly = 0) { spotifyPlaylist.addPlaylistTracks(any(), any(), any()) }
   }
 
   @Test
   fun `fix propagates error from addPlaylistTracks`() {
     val playlist = buildPlaylist(listOf(buildTrack("t1"), buildTrack("t1")))
-    every { spotifyPlaylist.removePlaylistTracks(any(), any(), any(), any()) } returns Unit.right()
-    every { spotifyPlaylist.addPlaylistTracks(any(), any(), any(), any()) } returns PlaylistFixError.FIX_FAILED.left()
+    every { spotifyPlaylist.removePlaylistTracks(any(), any(), any()) } returns Unit.right()
+    every { spotifyPlaylist.addPlaylistTracks(any(), any(), any()) } returns PlaylistFixError.FIX_FAILED.left()
 
     val result = runner.fix(userId, accessToken, playlistId, playlist, null, emptyList())
 

--- a/domain-impl/src/test/kotlin/de/chrgroth/spotify/control/domain/playlist/check/TrackFromLatestReleaseCheckRunnerTests.kt
+++ b/domain-impl/src/test/kotlin/de/chrgroth/spotify/control/domain/playlist/check/TrackFromLatestReleaseCheckRunnerTests.kt
@@ -223,7 +223,7 @@ class TrackFromLatestReleaseCheckRunnerTests {
     val result = runner.fix(userId, accessToken, playlistId, buildPlaylist(track), null, emptyList())
 
     assertThat(result.isRight()).isTrue()
-    verify(exactly = 0) { spotifyPlaylist.replacePlaylistTrack(any(), any(), any(), any(), any(), any()) }
+    verify(exactly = 0) { spotifyPlaylist.replacePlaylistTrack(any(), any(), any(), any(), any()) }
   }
 
   @Test
@@ -238,12 +238,12 @@ class TrackFromLatestReleaseCheckRunnerTests {
     every { appAlbumRepository.findByArtistId(artistId) } returns listOf(albumOld, albumNew)
     every { appTrackRepository.findByAlbumId(AlbumId("album-old")) } returns listOf(appTrackOld)
     every { appTrackRepository.findByAlbumId(AlbumId("album-new")) } returns listOf(appTrackNew)
-    every { spotifyPlaylist.replacePlaylistTrack(userId, accessToken, playlistId, "t1", "t2", 0) } returns Unit.right()
+    every { spotifyPlaylist.replacePlaylistTrack(accessToken, playlistId, "t1", "t2", 0) } returns Unit.right()
 
     val result = runner.fix(userId, accessToken, playlistId, buildPlaylist(track), null, emptyList())
 
     assertThat(result.isRight()).isTrue()
-    verify(exactly = 1) { spotifyPlaylist.replacePlaylistTrack(userId, accessToken, playlistId, "t1", "t2", 0) }
+    verify(exactly = 1) { spotifyPlaylist.replacePlaylistTrack(accessToken, playlistId, "t1", "t2", 0) }
   }
 
   @Test
@@ -266,15 +266,15 @@ class TrackFromLatestReleaseCheckRunnerTests {
     every { appTrackRepository.findByAlbumId(AlbumId("album-old")) } returns listOf(appTrackOld1, appTrackOld2)
     every { appTrackRepository.findByAlbumId(AlbumId("album-new")) } returns listOf(appTrackNew1, appTrackNew2)
     every { appTrackRepository.findByAlbumId(AlbumId("album-current")) } returns listOf(appTrackCurrent)
-    every { spotifyPlaylist.replacePlaylistTrack(userId, accessToken, playlistId, "t5", "t6", 2) } returns Unit.right()
-    every { spotifyPlaylist.replacePlaylistTrack(userId, accessToken, playlistId, "t1", "t2", 0) } returns Unit.right()
+    every { spotifyPlaylist.replacePlaylistTrack(accessToken, playlistId, "t5", "t6", 2) } returns Unit.right()
+    every { spotifyPlaylist.replacePlaylistTrack(accessToken, playlistId, "t1", "t2", 0) } returns Unit.right()
 
     val result = runner.fix(userId, accessToken, playlistId, buildPlaylist(track0, track1, track2), null, emptyList())
 
     assertThat(result.isRight()).isTrue()
     verifyOrder {
-      spotifyPlaylist.replacePlaylistTrack(userId, accessToken, playlistId, "t5", "t6", 2)
-      spotifyPlaylist.replacePlaylistTrack(userId, accessToken, playlistId, "t1", "t2", 0)
+      spotifyPlaylist.replacePlaylistTrack(accessToken, playlistId, "t5", "t6", 2)
+      spotifyPlaylist.replacePlaylistTrack(accessToken, playlistId, "t1", "t2", 0)
     }
   }
 
@@ -293,12 +293,12 @@ class TrackFromLatestReleaseCheckRunnerTests {
     every { appAlbumRepository.findByArtistId(artistId) } returns listOf(albumOld, albumNew)
     every { appTrackRepository.findByAlbumId(AlbumId("album-old")) } returns listOf(appTrackOld1, appTrackOld2)
     every { appTrackRepository.findByAlbumId(AlbumId("album-new")) } returns listOf(appTrackNew1, appTrackNew2)
-    every { spotifyPlaylist.replacePlaylistTrack(userId, accessToken, playlistId, "t3", "t4", 1) } returns PlaylistFixError.FIX_FAILED.left()
+    every { spotifyPlaylist.replacePlaylistTrack(accessToken, playlistId, "t3", "t4", 1) } returns PlaylistFixError.FIX_FAILED.left()
 
     val result = runner.fix(userId, accessToken, playlistId, buildPlaylist(track0, track1), null, emptyList())
 
     assertThat(result.isLeft()).isTrue()
     assertThat((result as Either.Left).value).isEqualTo(PlaylistFixError.FIX_FAILED)
-    verify(exactly = 0) { spotifyPlaylist.replacePlaylistTrack(userId, accessToken, playlistId, "t1", "t2", 0) }
+    verify(exactly = 0) { spotifyPlaylist.replacePlaylistTrack(accessToken, playlistId, "t1", "t2", 0) }
   }
 }

--- a/domain-impl/src/test/kotlin/de/chrgroth/spotify/control/domain/playlist/check/YearSongsInAllCheckRunnerTests.kt
+++ b/domain-impl/src/test/kotlin/de/chrgroth/spotify/control/domain/playlist/check/YearSongsInAllCheckRunnerTests.kt
@@ -199,7 +199,7 @@ class YearSongsInAllCheckRunnerTests {
 
     assertThat(result.isLeft()).isTrue()
     assertThat((result as Either.Left).value).isEqualTo(PlaylistFixError.FIX_NOT_FOUND)
-    verify(exactly = 0) { spotifyPlaylist.addPlaylistTracks(any(), any(), any(), any()) }
+    verify(exactly = 0) { spotifyPlaylist.addPlaylistTracks(any(), any(), any()) }
   }
 
   @Test
@@ -216,7 +216,7 @@ class YearSongsInAllCheckRunnerTests {
 
     assertThat(result.isLeft()).isTrue()
     assertThat((result as Either.Left).value).isEqualTo(PlaylistFixError.PLAYLIST_NOT_FOUND)
-    verify(exactly = 0) { spotifyPlaylist.addPlaylistTracks(any(), any(), any(), any()) }
+    verify(exactly = 0) { spotifyPlaylist.addPlaylistTracks(any(), any(), any()) }
   }
 
   @Test
@@ -233,7 +233,7 @@ class YearSongsInAllCheckRunnerTests {
     val result = runner.fix(userId, accessToken, playlistId, playlist, currentPlaylistInfo, playlistInfos)
 
     assertThat(result.isRight()).isTrue()
-    verify(exactly = 0) { spotifyPlaylist.addPlaylistTracks(any(), any(), any(), any()) }
+    verify(exactly = 0) { spotifyPlaylist.addPlaylistTracks(any(), any(), any()) }
   }
 
   @Test
@@ -246,13 +246,13 @@ class YearSongsInAllCheckRunnerTests {
       buildPlaylistInfo(spotifyPlaylistId = allPlaylistId, type = PlaylistType.ALL),
     )
     every { playlistRepository.findByUserIdAndPlaylistId(userId, allPlaylistId) } returns allPlaylist
-    every { spotifyPlaylist.addPlaylistTracks(userId, accessToken, allPlaylistId, any()) } returns Unit.right()
+    every { spotifyPlaylist.addPlaylistTracks(accessToken, allPlaylistId, any()) } returns Unit.right()
 
     val result = runner.fix(userId, accessToken, playlistId, playlist, currentPlaylistInfo, playlistInfos)
 
     assertThat(result.isRight()).isTrue()
     verify(exactly = 1) {
-      spotifyPlaylist.addPlaylistTracks(userId, accessToken, allPlaylistId, match { it.containsAll(listOf("t2", "t3")) && it.size == 2 })
+      spotifyPlaylist.addPlaylistTracks(accessToken, allPlaylistId, match { it.containsAll(listOf("t2", "t3")) && it.size == 2 })
     }
   }
 
@@ -266,12 +266,12 @@ class YearSongsInAllCheckRunnerTests {
       buildPlaylistInfo(spotifyPlaylistId = allPlaylistId, type = PlaylistType.ALL),
     )
     every { playlistRepository.findByUserIdAndPlaylistId(userId, allPlaylistId) } returns allPlaylist
-    every { spotifyPlaylist.addPlaylistTracks(userId, accessToken, allPlaylistId, listOf("t2")) } returns Unit.right()
+    every { spotifyPlaylist.addPlaylistTracks(accessToken, allPlaylistId, listOf("t2")) } returns Unit.right()
 
     val result = runner.fix(userId, accessToken, playlistId, playlist, currentPlaylistInfo, playlistInfos)
 
     assertThat(result.isRight()).isTrue()
-    verify(exactly = 1) { spotifyPlaylist.addPlaylistTracks(userId, accessToken, allPlaylistId, listOf("t2")) }
+    verify(exactly = 1) { spotifyPlaylist.addPlaylistTracks(accessToken, allPlaylistId, listOf("t2")) }
   }
 
   @Test
@@ -284,7 +284,7 @@ class YearSongsInAllCheckRunnerTests {
       buildPlaylistInfo(spotifyPlaylistId = allPlaylistId, type = PlaylistType.ALL),
     )
     every { playlistRepository.findByUserIdAndPlaylistId(userId, allPlaylistId) } returns allPlaylist
-    every { spotifyPlaylist.addPlaylistTracks(any(), any(), any(), any()) } returns PlaylistFixError.FIX_FAILED.left()
+    every { spotifyPlaylist.addPlaylistTracks(any(), any(), any()) } returns PlaylistFixError.FIX_FAILED.left()
 
     val result = runner.fix(userId, accessToken, playlistId, playlist, currentPlaylistInfo, playlistInfos)
 


### PR DESCRIPTION
## Summary
- Drops `UserId` from `PlaybackPort`, `PlaybackEventViewerPort`, `PlaylistPort`, `PlaylistCheckPort`, `CatalogPort.syncArtistDetails`, and their Spotify out-ports (`SpotifyPlaybackPort`, `SpotifyPlaylistPort`, `SpotifyCatalogPort`), resolving the single stored user internally via `CurrentUserResolver`.
- Outbox events that only carried `userId` to route to "the current user" drop the field, following the existing placeholder-payload pattern; in-flight outbox payloads from before this change are tolerated by `fromKey`/`fromPayload` without a separate legacy path.
- Updates ~40 tests and the migration plan/arc42 docs to reflect Phase 3 being fully done.
- Adds the required release note snippet.

Completes Phase 3 of [docs/plans/single-user-simplification.md](docs/plans/single-user-simplification.md). Phase 4 (MongoDB schema/index cleanup) can now proceed.

Closes #737.

Generated with [Claude Code](https://claude.ai/code)