### PR TITLE
Implement Phase 4 of single-user simplification: MongoDB schema cleanup

### DIFF
--- a/adapter-in-starter/src/main/kotlin/de/chrgroth/spotify/control/adapter/in/starter/SimplifySingleUserSchemaStarter.kt
+++ b/adapter-in-starter/src/main/kotlin/de/chrgroth/spotify/control/adapter/in/starter/SimplifySingleUserSchemaStarter.kt
@@ -1,0 +1,81 @@
+package de.chrgroth.spotify.control.adapter.`in`.starter
+
+import com.mongodb.client.MongoClient
+import com.mongodb.client.MongoCollection
+import com.mongodb.client.MongoDatabase
+import com.mongodb.client.model.Filters
+import com.mongodb.client.model.Updates
+import de.chrgroth.quarkus.starters.domain.Starter
+import jakarta.enterprise.context.ApplicationScoped
+import mu.KLogging
+import org.bson.Document
+import org.eclipse.microprofile.config.inject.ConfigProperty
+
+// Phase 4 of the single-user simplification (docs/plans/single-user-simplification.md): the app_playback,
+// app_playback_aggregation, spotify_playlist and spotify_playlist_metadata collections used to key documents by
+// "${spotifyUserId}:...", and spotify_currently_playing/spotify_recently_played/spotify_recently_partial_played
+// carried a spotifyUserId field, all to disambiguate between users. Since there is now only ever one user, this
+// rewrites existing documents to drop that prefix/field. MongoDB doesn't allow changing an existing _id in place,
+// so the composite-key collections are migrated via insert-then-delete rather than a simple field update.
+@ApplicationScoped
+@Suppress("Unused")
+class SimplifySingleUserSchemaStarter(
+  private val mongoClient: MongoClient,
+  @param:ConfigProperty(name = "quarkus.mongodb.database")
+  private val databaseName: String,
+) : Starter {
+
+  override val id = "SimplifySingleUserSchemaStarter-v1"
+
+  override fun execute() {
+    val database = mongoClient.getDatabase(databaseName)
+    unsetSpotifyUserId(database, CURRENTLY_PLAYING_COLLECTION)
+    unsetSpotifyUserId(database, RECENTLY_PLAYED_COLLECTION)
+    unsetSpotifyUserId(database, RECENTLY_PARTIAL_PLAYED_COLLECTION)
+    rewriteIds(database, APP_PLAYBACK_COLLECTION) { doc -> doc.getDate(PLAYED_AT_FIELD).time.toString() }
+    rewriteIds(database, APP_PLAYBACK_AGGREGATION_COLLECTION) { doc -> "${doc.getString(TYPE_FIELD)}:${doc.getString(PERIOD_START_FIELD)}" }
+    rewriteIds(database, PLAYLIST_COLLECTION) { doc -> doc.getString(SPOTIFY_PLAYLIST_ID_FIELD) }
+    rewriteIds(database, PLAYLIST_METADATA_COLLECTION) { doc -> doc.getString(SPOTIFY_PLAYLIST_ID_FIELD) }
+  }
+
+  private fun unsetSpotifyUserId(database: MongoDatabase, collectionName: String) {
+    val result = database.getCollection(collectionName)
+      .updateMany(Filters.exists(SPOTIFY_USER_ID_FIELD), Updates.unset(SPOTIFY_USER_ID_FIELD))
+    logger.info { "Removed spotifyUserId from ${result.modifiedCount} document(s) in $collectionName" }
+  }
+
+  private fun rewriteIds(database: MongoDatabase, collectionName: String, newId: (Document) -> String) {
+    val collection = database.getCollection(collectionName)
+    val staleDocs = collection.find(Filters.exists(SPOTIFY_USER_ID_FIELD)).toList()
+    if (staleDocs.isEmpty()) {
+      logger.info { "No $collectionName document(s) with a legacy spotifyUserId found" }
+      return
+    }
+    val rewritten = staleDocs.map { doc ->
+      Document(doc).apply {
+        put("_id", newId(doc))
+        remove(SPOTIFY_USER_ID_FIELD)
+      }
+    }
+    collection.insertMany(rewritten)
+    collection.deleteMany(Filters.`in`("_id", staleDocs.map { it.getString("_id") }))
+    logger.info { "Rewrote ${rewritten.size} $collectionName document id(s) to drop the spotifyUserId prefix" }
+  }
+
+  private fun MongoDatabase.getCollection(name: String): MongoCollection<Document> = getCollection(name, Document::class.java)
+
+  companion object : KLogging() {
+    private const val CURRENTLY_PLAYING_COLLECTION = "spotify_currently_playing"
+    private const val RECENTLY_PLAYED_COLLECTION = "spotify_recently_played"
+    private const val RECENTLY_PARTIAL_PLAYED_COLLECTION = "spotify_recently_partial_played"
+    private const val APP_PLAYBACK_COLLECTION = "app_playback"
+    private const val APP_PLAYBACK_AGGREGATION_COLLECTION = "app_playback_aggregation"
+    private const val PLAYLIST_COLLECTION = "spotify_playlist"
+    private const val PLAYLIST_METADATA_COLLECTION = "spotify_playlist_metadata"
+    private const val SPOTIFY_USER_ID_FIELD = "spotifyUserId"
+    private const val SPOTIFY_PLAYLIST_ID_FIELD = "spotifyPlaylistId"
+    private const val PLAYED_AT_FIELD = "playedAt"
+    private const val TYPE_FIELD = "type"
+    private const val PERIOD_START_FIELD = "periodStart"
+  }
+}

--- a/adapter-in-web/src/main/kotlin/de/chrgroth/spotify/control/adapter/in/web/PlaylistsResource.kt
+++ b/adapter-in-web/src/main/kotlin/de/chrgroth/spotify/control/adapter/in/web/PlaylistsResource.kt
@@ -69,7 +69,7 @@ class PlaylistsResource(
     val (user, playlistNameById, checks) = runBlocking {
       val userAsync = async(Dispatchers.IO) { userRepository.findById(userId) }
       val playlistNamesAsync = async(Dispatchers.IO) {
-        playlistRepository.findByUserId(userId).associateBy({ it.spotifyPlaylistId }, { it.name })
+        playlistRepository.findAll().associateBy({ it.spotifyPlaylistId }, { it.name })
       }
       val checksAsync = async(Dispatchers.IO) { playlistCheckRepository.findAll() }
       Triple(userAsync.await(), playlistNamesAsync.await(), checksAsync.await())

--- a/adapter-in-web/src/main/kotlin/de/chrgroth/spotify/control/adapter/in/web/StatsResource.kt
+++ b/adapter-in-web/src/main/kotlin/de/chrgroth/spotify/control/adapter/in/web/StatsResource.kt
@@ -7,7 +7,6 @@ import de.chrgroth.spotify.control.domain.model.catalog.displayArtistName
 import de.chrgroth.spotify.control.domain.model.playback.aggregation.ActivityTimeWindow
 import de.chrgroth.spotify.control.domain.model.playback.aggregation.AggregationPeriodType
 import de.chrgroth.spotify.control.domain.model.playback.aggregation.PlaybackAggregation
-import de.chrgroth.spotify.control.domain.model.user.UserId
 import de.chrgroth.spotify.control.domain.port.out.catalog.AppAlbumRepositoryPort
 import de.chrgroth.spotify.control.domain.port.out.catalog.AppArtistRepositoryPort
 import de.chrgroth.spotify.control.domain.port.out.catalog.AppTrackRepositoryPort
@@ -16,7 +15,6 @@ import io.quarkus.qute.Location
 import io.quarkus.qute.Template
 import io.quarkus.qute.TemplateInstance
 import io.quarkus.security.Authenticated
-import io.quarkus.security.identity.SecurityIdentity
 import jakarta.enterprise.context.ApplicationScoped
 import jakarta.ws.rs.GET
 import jakarta.ws.rs.Path
@@ -34,7 +32,6 @@ import java.time.DayOfWeek
 class StatsResource(
   @param:Location("stats.html")
   private val statsTemplate: Template,
-  private val securityIdentity: SecurityIdentity,
   private val aggregationRepository: PlaybackAggregationRepositoryPort,
   private val appTrackRepository: AppTrackRepositoryPort,
   private val appAlbumRepository: AppAlbumRepositoryPort,
@@ -45,10 +42,9 @@ class StatsResource(
   @Authenticated
   @Produces(MediaType.TEXT_HTML)
   fun stats(): TemplateInstance {
-    val userId = UserId(securityIdentity.principal.name)
     val periodStartsByType = AggregationPeriodType.entries.associateWith { threePeriodStarts(it) }
     val requestedPeriods = periodStartsByType.flatMap { (type, periodStarts) -> periodStarts.map { type to it } }
-    val aggregationsByTypeAndPeriod = aggregationRepository.findByUserAndPeriods(userId, requestedPeriods)
+    val aggregationsByTypeAndPeriod = aggregationRepository.findByPeriods(requestedPeriods)
     val tabs = AggregationPeriodType.entries.mapIndexed { index, type ->
       val periodStarts = periodStartsByType.getValue(type)
       AggregationTab(

--- a/adapter-out-mongodb/src/main/kotlin/de/chrgroth/spotify/control/adapter/out/mongodb/AppPlaybackDocument.kt
+++ b/adapter-out-mongodb/src/main/kotlin/de/chrgroth/spotify/control/adapter/out/mongodb/AppPlaybackDocument.kt
@@ -8,13 +8,11 @@ import java.time.Instant
 class AppPlaybackDocument {
 
   /**
-   * Single key: "${spotifyUserId}:${playedAt.toEpochMilli()}"
-   * A user can only play one track at any given moment, so the combination of
-   * user + playedAt is a natural unique identifier for a playback event.
+   * Single key: "${playedAt.toEpochMilli()}"
+   * Single-user application: playedAt alone is a natural unique identifier for a playback event.
    */
   @BsonId
   lateinit var id: String
-  lateinit var spotifyUserId: String
   lateinit var playedAt: Instant
   lateinit var trackId: String
   var secondsPlayed: Long = 0L

--- a/adapter-out-mongodb/src/main/kotlin/de/chrgroth/spotify/control/adapter/out/mongodb/AppPlaybackRepositoryAdapter.kt
+++ b/adapter-out-mongodb/src/main/kotlin/de/chrgroth/spotify/control/adapter/out/mongodb/AppPlaybackRepositoryAdapter.kt
@@ -5,7 +5,6 @@ import com.mongodb.client.model.Aggregates
 import com.mongodb.client.model.Filters
 import com.mongodb.client.model.Sorts
 import de.chrgroth.spotify.control.domain.model.playback.AppPlaybackItem
-import de.chrgroth.spotify.control.domain.model.user.UserId
 import de.chrgroth.spotify.control.domain.port.out.playback.AppPlaybackRepositoryPort
 import io.quarkus.panache.common.Sort
 import jakarta.enterprise.context.ApplicationScoped
@@ -25,8 +24,7 @@ class AppPlaybackRepositoryAdapter(
     if (items.isEmpty()) return
     val documents = items.map { item ->
       AppPlaybackDocument().apply {
-        id = "${item.userId.value}:${item.playedAt.toEpochMilliseconds()}"
-        spotifyUserId = item.userId.value
+        id = item.playedAt.toEpochMilliseconds().toString()
         playedAt = item.playedAt.toJavaInstant()
         trackId = item.trackId
         secondsPlayed = item.secondsPlayed
@@ -37,9 +35,9 @@ class AppPlaybackRepositoryAdapter(
     }
   }
 
-  override fun deleteAllByUserId(userId: UserId) {
-    mongoQueryMetrics.timed("app_playback.deleteAllByUserId") {
-      appPlaybackDocumentRepository.delete("spotifyUserId = ?1", userId.value)
+  override fun deleteAll() {
+    mongoQueryMetrics.timed("app_playback.deleteAll") {
+      appPlaybackDocumentRepository.deleteAll()
     }
   }
 
@@ -50,18 +48,18 @@ class AppPlaybackRepositoryAdapter(
     }
   }
 
-  override fun deleteByUserAndPlayedAts(userId: UserId, playedAts: Set<Instant>) {
+  override fun deleteByPlayedAts(playedAts: Set<Instant>) {
     if (playedAts.isEmpty()) return
     val javaPlayedAts = playedAts.map { it.toJavaInstant() }
-    mongoQueryMetrics.timed("app_playback.deleteByUserAndPlayedAts") {
-      appPlaybackDocumentRepository.delete("spotifyUserId = ?1 and playedAt in ?2", userId.value, javaPlayedAts)
+    mongoQueryMetrics.timed("app_playback.deleteByPlayedAts") {
+      appPlaybackDocumentRepository.delete("playedAt in ?1", javaPlayedAts)
     }
   }
 
-  override fun findMostRecentPlayedAt(userId: UserId): Instant? =
+  override fun findMostRecentPlayedAt(): Instant? =
     mongoQueryMetrics.timed("app_playback.findMostRecentPlayedAt") {
       appPlaybackDocumentRepository
-        .find("spotifyUserId = ?1", Sort.by("playedAt").descending(), userId.value)
+        .findAll(Sort.by("playedAt").descending())
         .firstResult()
         ?.playedAt?.toKotlinInstant()
     }
@@ -73,39 +71,31 @@ class AppPlaybackRepositoryAdapter(
         .firstResult()
         ?.playedAt?.toKotlinInstant()
     }
-  override fun findExistingPlayedAts(userId: UserId, playedAts: Set<Instant>): Set<Instant> {
+
+  override fun findExistingPlayedAts(playedAts: Set<Instant>): Set<Instant> {
     if (playedAts.isEmpty()) return emptySet()
     val javaPlayedAts = playedAts.map { it.toJavaInstant() }
     return mongoQueryMetrics.timed("app_playback.findExistingPlayedAts") {
       appPlaybackDocumentRepository
-        .list("spotifyUserId = ?1 and playedAt in ?2", userId.value, javaPlayedAts)
+        .list("playedAt in ?1", javaPlayedAts)
         .map { it.playedAt.toKotlinInstant() }
         .toSet()
     }
   }
 
-  override fun countAll(userId: UserId): Long =
+  override fun countAll(): Long =
     mongoQueryMetrics.timed("app_playback.countAll") {
-      appPlaybackDocumentRepository.count("spotifyUserId = ?1", userId.value)
+      appPlaybackDocumentRepository.count()
     }
 
-  override fun countSince(userId: UserId, since: Instant): Long =
+  override fun countSince(since: Instant): Long =
     mongoQueryMetrics.timed("app_playback.countSince") {
-      appPlaybackDocumentRepository.count(
-        "spotifyUserId = ?1 and playedAt >= ?2",
-        userId.value,
-        since.toJavaInstant(),
-      )
+      appPlaybackDocumentRepository.count("playedAt >= ?1", since.toJavaInstant())
     }
 
-  override fun countPerDaySince(userId: UserId, since: Instant): List<Pair<LocalDate, Long>> {
+  override fun countPerDaySince(since: Instant): List<Pair<LocalDate, Long>> {
     val pipeline = listOf(
-      Aggregates.match(
-        Filters.and(
-          Filters.eq(SPOTIFY_USER_ID_FIELD, userId.value),
-          Filters.gte(PLAYED_AT_FIELD, since.toJavaInstant()),
-        ),
-      ),
+      Aggregates.match(Filters.gte(PLAYED_AT_FIELD, since.toJavaInstant())),
       Aggregates.group(
         Document("\$dateToString", Document("format", "%Y-%m-%d").append("date", "\$$PLAYED_AT_FIELD")),
         Accumulators.sum("count", 1),
@@ -124,63 +114,40 @@ class AppPlaybackRepositoryAdapter(
     }
   }
 
-  override fun findRecentlyPlayed(userId: UserId, limit: Int): List<AppPlaybackItem> =
+  override fun findRecentlyPlayed(limit: Int): List<AppPlaybackItem> =
     mongoQueryMetrics.timed("app_playback.findRecentlyPlayed") {
       appPlaybackDocumentRepository
-        .find("spotifyUserId = ?1", Sort.by("playedAt").descending(), userId.value)
+        .findAll(Sort.by("playedAt").descending())
         .page(0, limit)
         .list()
-        .map { doc ->
-          AppPlaybackItem(
-            userId = UserId(doc.spotifyUserId),
-            playedAt = doc.playedAt.toKotlinInstant(),
-            trackId = doc.trackId,
-            secondsPlayed = doc.secondsPlayed,
-          )
-        }
+        .map { doc -> doc.toItem() }
     }
 
-  override fun findAllSince(userId: UserId, since: Instant): List<AppPlaybackItem> =
+  override fun findAllSince(since: Instant): List<AppPlaybackItem> =
     mongoQueryMetrics.timed("app_playback.findAllSince") {
       appPlaybackDocumentRepository
-        .list("spotifyUserId = ?1 and playedAt >= ?2", userId.value, since.toJavaInstant())
-        .map { doc ->
-          AppPlaybackItem(
-            userId = UserId(doc.spotifyUserId),
-            playedAt = doc.playedAt.toKotlinInstant(),
-            trackId = doc.trackId,
-            secondsPlayed = doc.secondsPlayed,
-          )
-        }
+        .list("playedAt >= ?1", since.toJavaInstant())
+        .map { doc -> doc.toItem() }
     }
 
-  override fun findAllBetween(userId: UserId, from: Instant, to: Instant): List<AppPlaybackItem> =
+  override fun findAllBetween(from: Instant, to: Instant): List<AppPlaybackItem> =
     mongoQueryMetrics.timed("app_playback.findAllBetween") {
       appPlaybackDocumentRepository
         .mongoCollection()
         .find(
           Filters.and(
-            Filters.eq(SPOTIFY_USER_ID_FIELD, userId.value),
             Filters.gte(PLAYED_AT_FIELD, from.toJavaInstant()),
             Filters.lt(PLAYED_AT_FIELD, to.toJavaInstant()),
           ),
         )
         .toList()
-        .map { doc ->
-          AppPlaybackItem(
-            userId = UserId(doc.spotifyUserId),
-            playedAt = doc.playedAt.toKotlinInstant(),
-            trackId = doc.trackId,
-            secondsPlayed = doc.secondsPlayed,
-          )
-        }
+        .map { doc -> doc.toItem() }
     }
 
-  override fun sumSecondsPlayedByTrackIdSince(userId: UserId, since: Instant): Map<String, Long> {
+  override fun sumSecondsPlayedByTrackIdSince(since: Instant): Map<String, Long> {
     val pipeline = listOf(
       Aggregates.match(
         Filters.and(
-          Filters.eq(SPOTIFY_USER_ID_FIELD, userId.value),
           Filters.gte(PLAYED_AT_FIELD, since.toJavaInstant()),
           Filters.gt(SECONDS_PLAYED_FIELD, 0),
         ),
@@ -206,8 +173,13 @@ class AppPlaybackRepositoryAdapter(
         .toSet()
     }
 
+  private fun AppPlaybackDocument.toItem() = AppPlaybackItem(
+    playedAt = playedAt.toKotlinInstant(),
+    trackId = trackId,
+    secondsPlayed = secondsPlayed,
+  )
+
   companion object {
-    internal const val SPOTIFY_USER_ID_FIELD = "spotifyUserId"
     internal const val PLAYED_AT_FIELD = "playedAt"
     internal const val TRACK_ID_FIELD = "trackId"
     internal const val SECONDS_PLAYED_FIELD = "secondsPlayed"

--- a/adapter-out-mongodb/src/main/kotlin/de/chrgroth/spotify/control/adapter/out/mongodb/CurrentlyPlayingDocument.kt
+++ b/adapter-out-mongodb/src/main/kotlin/de/chrgroth/spotify/control/adapter/out/mongodb/CurrentlyPlayingDocument.kt
@@ -10,7 +10,6 @@ class CurrentlyPlayingDocument {
 
   @BsonId
   var id: ObjectId = ObjectId()
-  lateinit var spotifyUserId: String
   lateinit var trackId: String
   lateinit var trackName: String
   lateinit var artistIds: List<String>

--- a/adapter-out-mongodb/src/main/kotlin/de/chrgroth/spotify/control/adapter/out/mongodb/CurrentlyPlayingRepositoryAdapter.kt
+++ b/adapter-out-mongodb/src/main/kotlin/de/chrgroth/spotify/control/adapter/out/mongodb/CurrentlyPlayingRepositoryAdapter.kt
@@ -8,7 +8,6 @@ import de.chrgroth.spotify.control.domain.model.catalog.AlbumId
 import de.chrgroth.spotify.control.domain.model.catalog.ArtistId
 import de.chrgroth.spotify.control.domain.model.catalog.TrackId
 import de.chrgroth.spotify.control.domain.model.playback.CurrentlyPlayingItem
-import de.chrgroth.spotify.control.domain.model.user.UserId
 import de.chrgroth.spotify.control.domain.port.out.playback.CurrentlyPlayingRepositoryPort
 import io.quarkus.panache.common.Sort
 import jakarta.enterprise.context.ApplicationScoped
@@ -23,7 +22,6 @@ class CurrentlyPlayingRepositoryAdapter(
 
   override fun save(item: CurrentlyPlayingItem) {
     val document = CurrentlyPlayingDocument().apply {
-      spotifyUserId = item.spotifyUserId.value
       trackId = item.trackId.value
       trackName = item.trackName
       artistIds = item.artistIds.map { it.value }
@@ -40,35 +38,18 @@ class CurrentlyPlayingRepositoryAdapter(
     }
   }
 
-  override fun findMostRecentByUserAndTrack(userId: UserId, trackId: TrackId): CurrentlyPlayingItem? =
-    mongoQueryMetrics.timed("spotify_currently_playing.findMostRecentByUserAndTrack") {
+  override fun findMostRecentByTrack(trackId: TrackId): CurrentlyPlayingItem? =
+    mongoQueryMetrics.timed("spotify_currently_playing.findMostRecentByTrack") {
       currentlyPlayingDocumentRepository
-        .find("spotifyUserId = ?1 and trackId = ?2", Sort.by(OBSERVED_AT_FIELD).descending(), userId.value, trackId.value)
+        .find("trackId = ?1", Sort.by(OBSERVED_AT_FIELD).descending(), trackId.value)
         .firstResult()
-        ?.let { doc ->
-          CurrentlyPlayingItem(
-            spotifyUserId = UserId(doc.spotifyUserId),
-            trackId = TrackId(doc.trackId),
-            trackName = doc.trackName,
-            artistIds = doc.artistIds.map { ArtistId(it) },
-            artistNames = doc.artistNames,
-            progressMs = doc.progressMs,
-            durationMs = doc.durationMs,
-            isPlaying = doc.isPlaying,
-            observedAt = doc.observedAt.toKotlinInstant(),
-            startTime = doc.startTime.toKotlinInstant(),
-            albumId = doc.albumId?.let { AlbumId(it) },
-          )
-        }
+        ?.toItem()
     }
 
   override fun updateProgress(item: CurrentlyPlayingItem) {
     mongoQueryMetrics.timed("spotify_currently_playing.updateProgress") {
       currentlyPlayingDocumentRepository.mongoCollection().findOneAndUpdate(
-        Filters.and(
-          Filters.eq(SPOTIFY_USER_ID_FIELD, item.spotifyUserId.value),
-          Filters.eq(TRACK_ID_FIELD, item.trackId.value),
-        ),
+        Filters.eq(TRACK_ID_FIELD, item.trackId.value),
         Updates.combine(
           Updates.set(PROGRESS_MS_FIELD, item.progressMs),
           Updates.set(IS_PLAYING_FIELD, item.isPlaying),
@@ -80,40 +61,34 @@ class CurrentlyPlayingRepositoryAdapter(
     }
   }
 
-  override fun findByUserId(userId: UserId): List<CurrentlyPlayingItem> =
-    mongoQueryMetrics.timed("spotify_currently_playing.findByUserId") {
+  override fun findAll(): List<CurrentlyPlayingItem> =
+    mongoQueryMetrics.timed("spotify_currently_playing.findAll") {
       currentlyPlayingDocumentRepository
-        .list("spotifyUserId = ?1", userId.value)
-        .map { doc ->
-          CurrentlyPlayingItem(
-            spotifyUserId = UserId(doc.spotifyUserId),
-            trackId = TrackId(doc.trackId),
-            trackName = doc.trackName,
-            artistIds = doc.artistIds.map { ArtistId(it) },
-            artistNames = doc.artistNames,
-            progressMs = doc.progressMs,
-            durationMs = doc.durationMs,
-            isPlaying = doc.isPlaying,
-            observedAt = doc.observedAt.toKotlinInstant(),
-            startTime = doc.startTime.toKotlinInstant(),
-            albumId = doc.albumId?.let { AlbumId(it) },
-          )
-        }
+        .listAll()
+        .map { doc -> doc.toItem() }
     }
 
-  override fun deleteByUserIdAndTrackIds(userId: UserId, trackIds: Set<String>) {
+  override fun deleteByTrackIds(trackIds: Set<String>) {
     if (trackIds.isEmpty()) return
-    mongoQueryMetrics.timed("spotify_currently_playing.deleteByUserIdAndTrackIds") {
-      currentlyPlayingDocumentRepository.delete(
-        "spotifyUserId = ?1 and trackId in ?2",
-        userId.value,
-        trackIds.toList(),
-      )
+    mongoQueryMetrics.timed("spotify_currently_playing.deleteByTrackIds") {
+      currentlyPlayingDocumentRepository.delete("trackId in ?1", trackIds.toList())
     }
   }
 
+  private fun CurrentlyPlayingDocument.toItem() = CurrentlyPlayingItem(
+    trackId = TrackId(trackId),
+    trackName = trackName,
+    artistIds = artistIds.map { ArtistId(it) },
+    artistNames = artistNames,
+    progressMs = progressMs,
+    durationMs = durationMs,
+    isPlaying = isPlaying,
+    observedAt = observedAt.toKotlinInstant(),
+    startTime = startTime.toKotlinInstant(),
+    albumId = albumId?.let { AlbumId(it) },
+  )
+
   companion object {
-    internal const val SPOTIFY_USER_ID_FIELD = "spotifyUserId"
     internal const val TRACK_ID_FIELD = "trackId"
     internal const val OBSERVED_AT_FIELD = "observedAt"
     internal const val START_TIME_FIELD = "startTime"

--- a/adapter-out-mongodb/src/main/kotlin/de/chrgroth/spotify/control/adapter/out/mongodb/MongoIndexInitializer.kt
+++ b/adapter-out-mongodb/src/main/kotlin/de/chrgroth/spotify/control/adapter/out/mongodb/MongoIndexInitializer.kt
@@ -19,7 +19,6 @@ class MongoIndexInitializer(
   private val appAlbumDocumentRepository: AppAlbumDocumentRepository,
   private val appTrackDocumentRepository: AppTrackDocumentRepository,
   private val playlistMetadataDocumentRepository: PlaylistMetadataDocumentRepository,
-  private val playlistDocumentRepository: PlaylistDocumentRepository,
   private val appPlaylistCheckDocumentRepository: AppPlaylistCheckDocumentRepository,
 ) {
 
@@ -34,42 +33,35 @@ class MongoIndexInitializer(
 
   private fun ensurePlaybackCollectionIndexes() {
     recentlyPlayedDocumentRepository.mongoCollection().createIndex(
-      Document(AppPlaybackRepositoryAdapter.SPOTIFY_USER_ID_FIELD, 1).append(AppPlaybackRepositoryAdapter.PLAYED_AT_FIELD, 1),
-      IndexOptions().name("spotifyUserId_1_playedAt_1"),
+      Document(AppPlaybackRepositoryAdapter.PLAYED_AT_FIELD, 1),
+      IndexOptions().name("playedAt_1"),
     )
     currentlyPlayingDocumentRepository.mongoCollection().createIndex(
-      Document(CurrentlyPlayingRepositoryAdapter.SPOTIFY_USER_ID_FIELD, 1)
-        .append(CurrentlyPlayingRepositoryAdapter.TRACK_ID_FIELD, 1)
+      Document(CurrentlyPlayingRepositoryAdapter.TRACK_ID_FIELD, 1)
         .append(CurrentlyPlayingRepositoryAdapter.OBSERVED_AT_FIELD, 1),
-      IndexOptions().name("spotifyUserId_1_trackId_1_observedAt_1"),
+      IndexOptions().name("trackId_1_observedAt_1"),
     )
     recentlyPartialPlayedDocumentRepository.mongoCollection().createIndex(
-      Document(AppPlaybackRepositoryAdapter.SPOTIFY_USER_ID_FIELD, 1).append(AppPlaybackRepositoryAdapter.PLAYED_AT_FIELD, 1),
-      IndexOptions().name("rpp_spotifyUserId_1_playedAt_1"),
-    )
-    appPlaybackDocumentRepository.mongoCollection().createIndex(
-      Document(AppPlaybackRepositoryAdapter.SPOTIFY_USER_ID_FIELD, 1).append(AppPlaybackRepositoryAdapter.PLAYED_AT_FIELD, 1),
-      IndexOptions().name("app_playback_spotifyUserId_1_playedAt_1"),
+      Document(AppPlaybackRepositoryAdapter.PLAYED_AT_FIELD, 1),
+      IndexOptions().name("rpp_playedAt_1"),
     )
     appPlaybackDocumentRepository.mongoCollection().createIndex(
       Document(AppPlaybackRepositoryAdapter.TRACK_ID_FIELD, 1),
       IndexOptions().name("app_playback_trackId_1"),
     )
     appPlaybackDocumentRepository.mongoCollection().createIndex(
-      Document(AppPlaybackRepositoryAdapter.SPOTIFY_USER_ID_FIELD, 1)
-        .append(AppPlaybackRepositoryAdapter.PLAYED_AT_FIELD, 1)
+      Document(AppPlaybackRepositoryAdapter.PLAYED_AT_FIELD, 1)
         .append(AppPlaybackRepositoryAdapter.TRACK_ID_FIELD, 1)
         .append(AppPlaybackRepositoryAdapter.SECONDS_PLAYED_FIELD, 1),
-      IndexOptions().name("app_playback_spotifyUserId_1_playedAt_1_trackId_1_secondsPlayed_1"),
+      IndexOptions().name("app_playback_playedAt_1_trackId_1_secondsPlayed_1"),
     )
   }
 
   private fun ensurePlaybackAggregationCollectionIndexes() {
     playbackAggregationDocumentRepository.mongoCollection().createIndex(
-      Document(PlaybackAggregationRepositoryAdapter.SPOTIFY_USER_ID_FIELD, 1)
-        .append(PlaybackAggregationRepositoryAdapter.TYPE_FIELD, 1)
+      Document(PlaybackAggregationRepositoryAdapter.TYPE_FIELD, 1)
         .append(PlaybackAggregationRepositoryAdapter.PERIOD_START_FIELD, 1),
-      IndexOptions().name("app_playback_aggregation_spotifyUserId_1_type_1_periodStart_1"),
+      IndexOptions().name("app_playback_aggregation_type_1_periodStart_1"),
     )
   }
 
@@ -101,14 +93,6 @@ class MongoIndexInitializer(
   }
 
   private fun ensurePlaylistCollectionIndexes() {
-    playlistDocumentRepository.mongoCollection().createIndex(
-      Document(AppPlaybackRepositoryAdapter.SPOTIFY_USER_ID_FIELD, 1),
-      IndexOptions().name("spotify_playlist_spotifyUserId_1"),
-    )
-    playlistMetadataDocumentRepository.mongoCollection().createIndex(
-      Document(AppPlaybackRepositoryAdapter.SPOTIFY_USER_ID_FIELD, 1),
-      IndexOptions().name("spotify_playlist_metadata_spotifyUserId_1"),
-    )
     playlistMetadataDocumentRepository.mongoCollection().createIndex(
       Document(PlaylistRepositoryAdapter.SYNC_STATUS_FIELD, 1),
       IndexOptions().name("spotify_playlist_metadata_syncStatus_1"),

--- a/adapter-out-mongodb/src/main/kotlin/de/chrgroth/spotify/control/adapter/out/mongodb/PlaybackAggregationDocument.kt
+++ b/adapter-out-mongodb/src/main/kotlin/de/chrgroth/spotify/control/adapter/out/mongodb/PlaybackAggregationDocument.kt
@@ -7,11 +7,10 @@ import org.bson.codecs.pojo.annotations.BsonId
 class PlaybackAggregationDocument {
 
   /**
-   * Composite key: "${spotifyUserId}:${type}:${periodStart}"
+   * Composite key: "${type}:${periodStart}"
    */
   @BsonId
   lateinit var id: String
-  lateinit var spotifyUserId: String
   lateinit var type: String
   lateinit var periodStart: String
   var totalPlaybackSeconds: Long = 0L

--- a/adapter-out-mongodb/src/main/kotlin/de/chrgroth/spotify/control/adapter/out/mongodb/PlaybackAggregationRepositoryAdapter.kt
+++ b/adapter-out-mongodb/src/main/kotlin/de/chrgroth/spotify/control/adapter/out/mongodb/PlaybackAggregationRepositoryAdapter.kt
@@ -8,12 +8,10 @@ import de.chrgroth.spotify.control.domain.model.playback.aggregation.Aggregation
 import de.chrgroth.spotify.control.domain.model.playback.aggregation.AggregationRankEntry
 import de.chrgroth.spotify.control.domain.model.playback.aggregation.DailyPlaybackSummary
 import de.chrgroth.spotify.control.domain.model.playback.aggregation.PlaybackAggregation
-import de.chrgroth.spotify.control.domain.model.user.UserId
 import de.chrgroth.spotify.control.domain.port.out.playback.PlaybackAggregationRepositoryPort
 import jakarta.enterprise.context.ApplicationScoped
 import java.time.DayOfWeek
 import kotlinx.datetime.LocalDate
-
 
 @ApplicationScoped
 class PlaybackAggregationRepositoryAdapter(
@@ -34,20 +32,17 @@ class PlaybackAggregationRepositoryAdapter(
     }
   }
 
-  override fun findByUserAndPeriod(userId: UserId, type: AggregationPeriodType, periodStart: LocalDate): PlaybackAggregation? {
-    val id = documentId(userId, type, periodStart)
-    return mongoQueryMetrics.timed("app_playback_aggregation.findByUserAndPeriod") {
+  override fun findByPeriod(type: AggregationPeriodType, periodStart: LocalDate): PlaybackAggregation? {
+    val id = documentId(type, periodStart)
+    return mongoQueryMetrics.timed("app_playback_aggregation.findByPeriod") {
       repository.findById(id)?.toDomain()
     }
   }
 
-  override fun findByUserAndPeriods(
-    userId: UserId,
-    periods: List<Pair<AggregationPeriodType, LocalDate>>,
-  ): Map<Pair<AggregationPeriodType, LocalDate>, PlaybackAggregation> {
+  override fun findByPeriods(periods: List<Pair<AggregationPeriodType, LocalDate>>): Map<Pair<AggregationPeriodType, LocalDate>, PlaybackAggregation> {
     if (periods.isEmpty()) return emptyMap()
-    val keyByDocumentId = periods.associateBy { documentId(userId, it.first, it.second) }
-    return mongoQueryMetrics.timed("app_playback_aggregation.findByUserAndPeriods") {
+    val keyByDocumentId = periods.associateBy { documentId(it.first, it.second) }
+    return mongoQueryMetrics.timed("app_playback_aggregation.findByPeriods") {
       repository.mongoCollection()
         .find(Filters.`in`("_id", keyByDocumentId.keys.toList()))
         .toList()
@@ -56,12 +51,11 @@ class PlaybackAggregationRepositoryAdapter(
     }
   }
 
-  override fun findByUserTypeAndPeriodRange(userId: UserId, type: AggregationPeriodType, from: LocalDate, to: LocalDate): List<PlaybackAggregation> =
-    mongoQueryMetrics.timed("app_playback_aggregation.findByUserTypeAndPeriodRange") {
+  override fun findByTypeAndPeriodRange(type: AggregationPeriodType, from: LocalDate, to: LocalDate): List<PlaybackAggregation> =
+    mongoQueryMetrics.timed("app_playback_aggregation.findByTypeAndPeriodRange") {
       repository.mongoCollection()
         .find(
           Filters.and(
-            Filters.eq(SPOTIFY_USER_ID_FIELD, userId.value),
             Filters.eq(TYPE_FIELD, type.name),
             Filters.gte(PERIOD_START_FIELD, from.toString()),
             Filters.lte(PERIOD_START_FIELD, to.toString()),
@@ -71,12 +65,11 @@ class PlaybackAggregationRepositoryAdapter(
         .map { it.toDomain() }
     }
 
-  override fun findDailySummaryByUserAndPeriodRange(userId: UserId, from: LocalDate, to: LocalDate): List<DailyPlaybackSummary> =
-    mongoQueryMetrics.timed("app_playback_aggregation.findDailySummaryByUserAndPeriodRange") {
+  override fun findDailySummaryByPeriodRange(from: LocalDate, to: LocalDate): List<DailyPlaybackSummary> =
+    mongoQueryMetrics.timed("app_playback_aggregation.findDailySummaryByPeriodRange") {
       repository.mongoCollection()
         .find(
           Filters.and(
-            Filters.eq(SPOTIFY_USER_ID_FIELD, userId.value),
             Filters.eq(TYPE_FIELD, AggregationPeriodType.DAY.name),
             Filters.gte(PERIOD_START_FIELD, from.toString()),
             Filters.lte(PERIOD_START_FIELD, to.toString()),
@@ -87,18 +80,17 @@ class PlaybackAggregationRepositoryAdapter(
         .map { it.toSummary() }
     }
 
-  override fun sumEventCountByUser(userId: UserId): Long =
-    mongoQueryMetrics.timed("app_playback_aggregation.sumEventCountByUser") {
+  override fun sumEventCount(): Long =
+    mongoQueryMetrics.timed("app_playback_aggregation.sumEventCount") {
       repository.mongoCollection()
-        .find(Filters.and(Filters.eq(SPOTIFY_USER_ID_FIELD, userId.value), Filters.eq(TYPE_FIELD, AggregationPeriodType.DAY.name)))
+        .find(Filters.eq(TYPE_FIELD, AggregationPeriodType.DAY.name))
         .projection(Projections.include(EVENT_COUNT_FIELD))
         .toList()
         .sumOf { it.eventCount }
     }
 
   private fun PlaybackAggregation.toDocument(): PlaybackAggregationDocument = PlaybackAggregationDocument().apply {
-    id = documentId(this@toDocument.userId, this@toDocument.type, this@toDocument.periodStart)
-    spotifyUserId = this@toDocument.userId.value
+    id = documentId(this@toDocument.type, this@toDocument.periodStart)
     type = this@toDocument.type.name
     periodStart = this@toDocument.periodStart.toString()
     totalPlaybackSeconds = this@toDocument.totalPlaybackSeconds
@@ -125,7 +117,6 @@ class PlaybackAggregationRepositoryAdapter(
   }
 
   private fun PlaybackAggregationDocument.toDomain(): PlaybackAggregation = PlaybackAggregation(
-    userId = UserId(spotifyUserId),
     type = AggregationPeriodType.valueOf(type),
     periodStart = LocalDate.parse(periodStart),
     totalPlaybackSeconds = totalPlaybackSeconds,
@@ -160,7 +151,6 @@ class PlaybackAggregationRepositoryAdapter(
   )
 
   companion object {
-    internal const val SPOTIFY_USER_ID_FIELD = "spotifyUserId"
     internal const val TYPE_FIELD = "type"
     internal const val PERIOD_START_FIELD = "periodStart"
     internal const val EVENT_COUNT_FIELD = "eventCount"
@@ -168,7 +158,7 @@ class PlaybackAggregationRepositoryAdapter(
     internal const val ARTIST_ENTRIES_FIELD = "artistEntries"
     internal const val TRACK_ENTRIES_FIELD = "trackEntries"
 
-    internal fun documentId(userId: UserId, type: AggregationPeriodType, periodStart: LocalDate): String =
-      "${userId.value}:${type.name}:$periodStart"
+    internal fun documentId(type: AggregationPeriodType, periodStart: LocalDate): String =
+      "${type.name}:$periodStart"
   }
 }

--- a/adapter-out-mongodb/src/main/kotlin/de/chrgroth/spotify/control/adapter/out/mongodb/PlaybackEventViewerRepositoryAdapter.kt
+++ b/adapter-out-mongodb/src/main/kotlin/de/chrgroth/spotify/control/adapter/out/mongodb/PlaybackEventViewerRepositoryAdapter.kt
@@ -5,7 +5,6 @@ import com.mongodb.client.MongoClient
 import com.mongodb.client.model.Filters
 import com.mongodb.client.model.Sorts
 import de.chrgroth.spotify.control.domain.model.playback.RawPlaybackEvent
-import de.chrgroth.spotify.control.domain.model.user.UserId
 import de.chrgroth.spotify.control.domain.port.out.playback.PlaybackEventViewerRepositoryPort
 import jakarta.enterprise.context.ApplicationScoped
 import kotlin.time.Instant
@@ -28,28 +27,26 @@ class PlaybackEventViewerRepositoryAdapter(
   private val databaseName: String,
 ) : PlaybackEventViewerRepositoryPort {
 
-  override fun findRecentlyPlayed(userId: UserId, from: Instant, to: Instant): List<RawPlaybackEvent> =
-    queryCollection(RECENTLY_PLAYED_COLLECTION, PLAYED_AT_FIELD, DURATION_SECONDS_FIELD, 1L, userId, from, to)
+  override fun findRecentlyPlayed(from: Instant, to: Instant): List<RawPlaybackEvent> =
+    queryCollection(RECENTLY_PLAYED_COLLECTION, PLAYED_AT_FIELD, DURATION_SECONDS_FIELD, 1L, from, to)
 
-  override fun findRecentlyPartialPlayed(userId: UserId, from: Instant, to: Instant): List<RawPlaybackEvent> =
-    queryCollection(RECENTLY_PARTIAL_PLAYED_COLLECTION, PLAYED_AT_FIELD, PLAYED_SECONDS_FIELD, 1L, userId, from, to)
+  override fun findRecentlyPartialPlayed(from: Instant, to: Instant): List<RawPlaybackEvent> =
+    queryCollection(RECENTLY_PARTIAL_PLAYED_COLLECTION, PLAYED_AT_FIELD, PLAYED_SECONDS_FIELD, 1L, from, to)
 
-  override fun findCurrentlyPlaying(userId: UserId, from: Instant, to: Instant): List<RawPlaybackEvent> =
-    queryCollection(CURRENTLY_PLAYING_COLLECTION, OBSERVED_AT_FIELD, DURATION_MS_FIELD, MS_PER_SECOND, userId, from, to)
+  override fun findCurrentlyPlaying(from: Instant, to: Instant): List<RawPlaybackEvent> =
+    queryCollection(CURRENTLY_PLAYING_COLLECTION, OBSERVED_AT_FIELD, DURATION_MS_FIELD, MS_PER_SECOND, from, to)
 
   private fun queryCollection(
     collectionName: String,
     timestampField: String,
     durationField: String,
     durationDivisor: Long,
-    userId: UserId,
     from: Instant,
     to: Instant,
   ): List<RawPlaybackEvent> {
     val coll = mongoClient.getDatabase(databaseName).getCollection(collectionName, BsonDocument::class.java)
     return try {
       val filter = Filters.and(
-        Filters.eq(SPOTIFY_USER_ID_FIELD, userId.value),
         Filters.gte(timestampField, from.toJavaInstant()),
         Filters.lt(timestampField, to.toJavaInstant()),
       )
@@ -86,7 +83,6 @@ class PlaybackEventViewerRepositoryAdapter(
     private const val RECENTLY_PLAYED_COLLECTION = "spotify_recently_played"
     private const val RECENTLY_PARTIAL_PLAYED_COLLECTION = "spotify_recently_partial_played"
     private const val CURRENTLY_PLAYING_COLLECTION = "spotify_currently_playing"
-    private const val SPOTIFY_USER_ID_FIELD = "spotifyUserId"
     private const val PLAYED_AT_FIELD = "playedAt"
     private const val OBSERVED_AT_FIELD = "observedAt"
     private const val TRACK_ID_FIELD = "trackId"

--- a/adapter-out-mongodb/src/main/kotlin/de/chrgroth/spotify/control/adapter/out/mongodb/PlaylistDocument.kt
+++ b/adapter-out-mongodb/src/main/kotlin/de/chrgroth/spotify/control/adapter/out/mongodb/PlaylistDocument.kt
@@ -8,7 +8,6 @@ class PlaylistDocument {
 
   @BsonId
   lateinit var id: String
-  lateinit var spotifyUserId: String
   lateinit var spotifyPlaylistId: String
   lateinit var tracks: List<PlaylistTrackSubdocument>
 }

--- a/adapter-out-mongodb/src/main/kotlin/de/chrgroth/spotify/control/adapter/out/mongodb/PlaylistMetadataDocument.kt
+++ b/adapter-out-mongodb/src/main/kotlin/de/chrgroth/spotify/control/adapter/out/mongodb/PlaylistMetadataDocument.kt
@@ -9,7 +9,6 @@ class PlaylistMetadataDocument {
 
   @BsonId
   lateinit var id: String
-  lateinit var spotifyUserId: String
   lateinit var spotifyPlaylistId: String
   lateinit var snapshotId: String
   lateinit var lastSnapshotIdSyncTime: Instant

--- a/adapter-out-mongodb/src/main/kotlin/de/chrgroth/spotify/control/adapter/out/mongodb/PlaylistRepositoryAdapter.kt
+++ b/adapter-out-mongodb/src/main/kotlin/de/chrgroth/spotify/control/adapter/out/mongodb/PlaylistRepositoryAdapter.kt
@@ -12,7 +12,6 @@ import de.chrgroth.spotify.control.domain.model.playlist.PlaylistSyncStatus
 import de.chrgroth.spotify.control.domain.model.playlist.PlaylistTrack
 import de.chrgroth.spotify.control.domain.model.playlist.PlaylistType
 import de.chrgroth.spotify.control.domain.model.catalog.TrackId
-import de.chrgroth.spotify.control.domain.model.user.UserId
 import de.chrgroth.spotify.control.domain.port.out.playlist.PlaylistRepositoryPort
 import jakarta.enterprise.context.ApplicationScoped
 import kotlin.time.toJavaInstant
@@ -28,33 +27,32 @@ class PlaylistRepositoryAdapter(
   private val mongoQueryMetrics: MongoQueryMetrics,
 ) : PlaylistRepositoryPort {
 
-  override fun findByUserId(userId: UserId): List<PlaylistInfo> =
-    mongoQueryMetrics.timed("spotify_playlist_metadata.findByUserId") {
+  override fun findAll(): List<PlaylistInfo> =
+    mongoQueryMetrics.timed("spotify_playlist_metadata.findAll") {
       playlistMetadataDocumentRepository
-        .list("spotifyUserId = ?1", userId.value)
+        .listAll()
         .map { it.toDomain() }
     }
 
-  override fun replaceAll(userId: UserId, playlists: List<PlaylistInfo>) {
-    mongoQueryMetrics.timed("spotify_playlist_metadata.deleteByUserId") {
-      playlistMetadataDocumentRepository.delete("spotifyUserId = ?1", userId.value)
+  override fun replaceAll(playlists: List<PlaylistInfo>) {
+    mongoQueryMetrics.timed("spotify_playlist_metadata.deleteAll") {
+      playlistMetadataDocumentRepository.deleteAll()
     }
     if (playlists.isNotEmpty()) {
-      val documents = playlists.map { it.toDocument(userId) }
+      val documents = playlists.map { it.toDocument() }
       mongoQueryMetrics.timed("spotify_playlist_metadata.saveAll") {
         playlistMetadataDocumentRepository.persist(documents)
       }
     }
   }
 
-  override fun findByUserIdAndPlaylistId(userId: UserId, playlistId: String): Playlist? =
-    mongoQueryMetrics.timed("spotify_playlist.findByUserIdAndPlaylistId") {
-      playlistDocumentRepository.findById("${userId.value}:$playlistId")?.toDomain()
+  override fun findByPlaylistId(playlistId: String): Playlist? =
+    mongoQueryMetrics.timed("spotify_playlist.findByPlaylistId") {
+      playlistDocumentRepository.findById(playlistId)?.toDomain()
     }
 
-  override fun findTrackCountsByUserId(userId: UserId): Map<String, Int> {
+  override fun findTrackCounts(): Map<String, Int> {
     val pipeline = listOf(
-      Aggregates.match(Filters.eq("spotifyUserId", userId.value)),
       Aggregates.project(
         Projections.fields(
           Projections.include("spotifyPlaylistId"),
@@ -62,23 +60,22 @@ class PlaylistRepositoryAdapter(
         ),
       ),
     )
-    return mongoQueryMetrics.timed("spotify_playlist.findTrackCountsByUserId") {
+    return mongoQueryMetrics.timed("spotify_playlist.findTrackCounts") {
       playlistDocumentRepository.mongoCollection()
         .aggregate(pipeline, Document::class.java)
         .associate { it.getString("spotifyPlaylistId") to it.getInteger("trackCount") }
     }
   }
 
-  override fun save(userId: UserId, playlist: Playlist) {
-    val document = playlist.toDocument(userId)
+  override fun save(playlist: Playlist) {
+    val document = playlist.toDocument()
     mongoQueryMetrics.timed("spotify_playlist.save") {
       playlistDocumentRepository.persistOrUpdate(document)
     }
   }
 
-  override fun appendTracks(userId: UserId, playlistId: String, tracks: List<PlaylistTrack>) {
+  override fun appendTracks(playlistId: String, tracks: List<PlaylistTrack>) {
     if (tracks.isEmpty()) return
-    val docId = "${userId.value}:$playlistId"
     mongoQueryMetrics.timed("spotify_playlist.appendTracks") {
       val trackDocuments = tracks.map { track ->
         Document("trackId", track.trackId.value)
@@ -86,19 +83,18 @@ class PlaylistRepositoryAdapter(
           .append("albumId", track.albumId?.value)
       }
       val result = playlistDocumentRepository.mongoCollection().updateOne(
-        Filters.eq("_id", docId),
+        Filters.eq("_id", playlistId),
         Updates.pushEach("tracks", trackDocuments),
       )
       if (result.matchedCount == 0L) {
-        logger.warn { "Playlist document not found for appending tracks: $playlistId (user ${userId.value})" }
+        logger.warn { "Playlist document not found for appending tracks: $playlistId" }
       }
     }
   }
 
-  override fun updateLastSyncTime(userId: UserId, playlistId: String, time: kotlin.time.Instant) {
-    val id = "${userId.value}:$playlistId"
+  override fun updateLastSyncTime(playlistId: String, time: kotlin.time.Instant) {
     mongoQueryMetrics.timed("spotify_playlist_metadata.updateLastSyncTime") {
-      playlistMetadataDocumentRepository.findById(id)?.let { doc ->
+      playlistMetadataDocumentRepository.findById(playlistId)?.let { doc ->
         doc.lastSyncTime = time.toJavaInstant()
         playlistMetadataDocumentRepository.persistOrUpdate(doc)
       }
@@ -115,9 +111,8 @@ class PlaylistRepositoryAdapter(
     lastSyncTime = lastSyncTime?.toKotlinInstant(),
   )
 
-  private fun PlaylistInfo.toDocument(userId: UserId) = PlaylistMetadataDocument().apply {
-    id = "${userId.value}:${this@toDocument.spotifyPlaylistId}"
-    spotifyUserId = userId.value
+  private fun PlaylistInfo.toDocument() = PlaylistMetadataDocument().apply {
+    id = this@toDocument.spotifyPlaylistId
     spotifyPlaylistId = this@toDocument.spotifyPlaylistId
     snapshotId = this@toDocument.snapshotId
     lastSnapshotIdSyncTime = this@toDocument.lastSnapshotIdSyncTime.toJavaInstant()
@@ -138,9 +133,8 @@ class PlaylistRepositoryAdapter(
     albumId = albumId?.let { AlbumId(it) },
   )
 
-  private fun Playlist.toDocument(userId: UserId) = PlaylistDocument().apply {
-    id = "${userId.value}:${this@toDocument.spotifyPlaylistId}"
-    spotifyUserId = userId.value
+  private fun Playlist.toDocument() = PlaylistDocument().apply {
+    id = this@toDocument.spotifyPlaylistId
     spotifyPlaylistId = this@toDocument.spotifyPlaylistId
     tracks = this@toDocument.tracks.map { it.toSubdocument() }
   }
@@ -164,4 +158,3 @@ class PlaylistRepositoryAdapter(
     internal const val SYNC_STATUS_FIELD = "syncStatus"
   }
 }
-

--- a/adapter-out-mongodb/src/main/kotlin/de/chrgroth/spotify/control/adapter/out/mongodb/RecentlyPartialPlayedDocument.kt
+++ b/adapter-out-mongodb/src/main/kotlin/de/chrgroth/spotify/control/adapter/out/mongodb/RecentlyPartialPlayedDocument.kt
@@ -10,7 +10,6 @@ class RecentlyPartialPlayedDocument {
 
   @BsonId
   var id: ObjectId = ObjectId()
-  lateinit var spotifyUserId: String
   lateinit var trackId: String
   lateinit var trackName: String
   lateinit var artistIds: List<String>

--- a/adapter-out-mongodb/src/main/kotlin/de/chrgroth/spotify/control/adapter/out/mongodb/RecentlyPartialPlayedRepositoryAdapter.kt
+++ b/adapter-out-mongodb/src/main/kotlin/de/chrgroth/spotify/control/adapter/out/mongodb/RecentlyPartialPlayedRepositoryAdapter.kt
@@ -4,7 +4,6 @@ import de.chrgroth.spotify.control.domain.model.catalog.AlbumId
 import de.chrgroth.spotify.control.domain.model.catalog.ArtistId
 import de.chrgroth.spotify.control.domain.model.catalog.TrackId
 import de.chrgroth.spotify.control.domain.model.playback.RecentlyPartialPlayedItem
-import de.chrgroth.spotify.control.domain.model.user.UserId
 import de.chrgroth.spotify.control.domain.port.out.playback.RecentlyPartialPlayedRepositoryPort
 import jakarta.enterprise.context.ApplicationScoped
 import kotlin.time.Instant
@@ -17,37 +16,33 @@ class RecentlyPartialPlayedRepositoryAdapter(
   private val mongoQueryMetrics: MongoQueryMetrics,
 ) : RecentlyPartialPlayedRepositoryPort {
 
-  override fun findExistingPlayedAts(userId: UserId, playedAts: Set<Instant>): Set<Instant> {
+  override fun findExistingPlayedAts(playedAts: Set<Instant>): Set<Instant> {
     if (playedAts.isEmpty()) return emptySet()
     val javaPlayedAts = playedAts.map { it.toJavaInstant() }
     return mongoQueryMetrics.timed("recently_partial_played.findExistingPlayedAts") {
       recentlyPartialPlayedDocumentRepository
-        .list("spotifyUserId = ?1 and playedAt in ?2", userId.value, javaPlayedAts)
+        .list("playedAt in ?1", javaPlayedAts)
         .map { it.playedAt.toKotlinInstant() }
         .toSet()
     }
   }
 
-  override fun findSince(userId: UserId, since: Instant?): List<RecentlyPartialPlayedItem> =
+  override fun findSince(since: Instant?): List<RecentlyPartialPlayedItem> =
     mongoQueryMetrics.timed("recently_partial_played.findSince") {
       val query = if (since != null) {
-        recentlyPartialPlayedDocumentRepository.list(
-          "spotifyUserId = ?1 and playedAt > ?2",
-          userId.value,
-          since.toJavaInstant(),
-        )
+        recentlyPartialPlayedDocumentRepository.list("playedAt > ?1", since.toJavaInstant())
       } else {
-        recentlyPartialPlayedDocumentRepository.list("spotifyUserId = ?1", userId.value)
+        recentlyPartialPlayedDocumentRepository.listAll()
       }
       query.map { doc -> doc.toItem() }
     }
 
-  override fun findByUserIdAndTrackIds(userId: UserId, trackIds: Set<TrackId>): List<RecentlyPartialPlayedItem> {
+  override fun findByTrackIds(trackIds: Set<TrackId>): List<RecentlyPartialPlayedItem> {
     if (trackIds.isEmpty()) return emptyList()
     val trackIdValues = trackIds.map { it.value }
-    return mongoQueryMetrics.timed("recently_partial_played.findByUserIdAndTrackIds") {
+    return mongoQueryMetrics.timed("recently_partial_played.findByTrackIds") {
       recentlyPartialPlayedDocumentRepository
-        .list("spotifyUserId = ?1 and trackId in ?2", userId.value, trackIdValues)
+        .list("trackId in ?1", trackIdValues)
         .map { doc -> doc.toItem() }
     }
   }
@@ -56,7 +51,6 @@ class RecentlyPartialPlayedRepositoryAdapter(
     if (items.isEmpty()) return
     val documents = items.map { item ->
       RecentlyPartialPlayedDocument().apply {
-        spotifyUserId = item.spotifyUserId.value
         trackId = item.trackId.value
         trackName = item.trackName
         artistIds = item.artistIds.map { it.value }
@@ -72,16 +66,15 @@ class RecentlyPartialPlayedRepositoryAdapter(
     }
   }
 
-  override fun deleteByPlayedAts(userId: UserId, playedAts: Set<Instant>) {
+  override fun deleteByPlayedAts(playedAts: Set<Instant>) {
     if (playedAts.isEmpty()) return
     val javaPlayedAts = playedAts.map { it.toJavaInstant() }
     mongoQueryMetrics.timed("recently_partial_played.deleteByPlayedAts") {
-      recentlyPartialPlayedDocumentRepository.delete("spotifyUserId = ?1 and playedAt in ?2", userId.value, javaPlayedAts)
+      recentlyPartialPlayedDocumentRepository.delete("playedAt in ?1", javaPlayedAts)
     }
   }
 
   private fun RecentlyPartialPlayedDocument.toItem() = RecentlyPartialPlayedItem(
-    spotifyUserId = UserId(spotifyUserId),
     trackId = TrackId(trackId),
     trackName = trackName,
     artistIds = artistIds.map { ArtistId(it) },

--- a/adapter-out-mongodb/src/main/kotlin/de/chrgroth/spotify/control/adapter/out/mongodb/RecentlyPlayedDocument.kt
+++ b/adapter-out-mongodb/src/main/kotlin/de/chrgroth/spotify/control/adapter/out/mongodb/RecentlyPlayedDocument.kt
@@ -10,7 +10,6 @@ class RecentlyPlayedDocument {
 
   @BsonId
   var id: ObjectId = ObjectId()
-  lateinit var spotifyUserId: String
   lateinit var trackId: String
   lateinit var trackName: String
   lateinit var artistIds: List<String>

--- a/adapter-out-mongodb/src/main/kotlin/de/chrgroth/spotify/control/adapter/out/mongodb/RecentlyPlayedRepositoryAdapter.kt
+++ b/adapter-out-mongodb/src/main/kotlin/de/chrgroth/spotify/control/adapter/out/mongodb/RecentlyPlayedRepositoryAdapter.kt
@@ -4,7 +4,6 @@ import de.chrgroth.spotify.control.domain.model.catalog.AlbumId
 import de.chrgroth.spotify.control.domain.model.catalog.ArtistId
 import de.chrgroth.spotify.control.domain.model.playback.RecentlyPlayedItem
 import de.chrgroth.spotify.control.domain.model.catalog.TrackId
-import de.chrgroth.spotify.control.domain.model.user.UserId
 import de.chrgroth.spotify.control.domain.port.out.playback.RecentlyPlayedRepositoryPort
 import io.quarkus.panache.common.Sort
 import jakarta.enterprise.context.ApplicationScoped
@@ -18,39 +17,34 @@ class RecentlyPlayedRepositoryAdapter(
   private val mongoQueryMetrics: MongoQueryMetrics,
 ) : RecentlyPlayedRepositoryPort {
 
-  override fun findExistingPlayedAts(spotifyUserId: UserId, playedAts: Set<Instant>): Set<Instant> {
+  override fun findExistingPlayedAts(playedAts: Set<Instant>): Set<Instant> {
     if (playedAts.isEmpty()) return emptySet()
     val javaPlayedAts = playedAts.map { it.toJavaInstant() }
     return mongoQueryMetrics.timed("spotify_recently_played.findExistingPlayedAts") {
       recentlyPlayedDocumentRepository
-        .list("spotifyUserId = ?1 and playedAt in ?2", spotifyUserId.value, javaPlayedAts)
+        .list("playedAt in ?1", javaPlayedAts)
         .map { it.playedAt.toKotlinInstant() }
         .toSet()
     }
   }
 
-  override fun findMostRecentPlayedAt(spotifyUserId: UserId): Instant? =
+  override fun findMostRecentPlayedAt(): Instant? =
     mongoQueryMetrics.timed("spotify_recently_played.findMostRecentPlayedAt") {
       recentlyPlayedDocumentRepository
-        .find("spotifyUserId = ?1", Sort.by("playedAt").descending(), spotifyUserId.value)
+        .findAll(Sort.by("playedAt").descending())
         .firstResult()
         ?.playedAt?.toKotlinInstant()
     }
 
-  override fun findSince(spotifyUserId: UserId, since: Instant?): List<RecentlyPlayedItem> =
+  override fun findSince(since: Instant?): List<RecentlyPlayedItem> =
     mongoQueryMetrics.timed("spotify_recently_played.findSince") {
       val query = if (since != null) {
-        recentlyPlayedDocumentRepository.list(
-          "spotifyUserId = ?1 and playedAt > ?2",
-          spotifyUserId.value,
-          since.toJavaInstant(),
-        )
+        recentlyPlayedDocumentRepository.list("playedAt > ?1", since.toJavaInstant())
       } else {
-        recentlyPlayedDocumentRepository.list("spotifyUserId = ?1", spotifyUserId.value)
+        recentlyPlayedDocumentRepository.listAll()
       }
       query.map { doc ->
         RecentlyPlayedItem(
-          spotifyUserId = UserId(doc.spotifyUserId),
           trackId = TrackId(doc.trackId),
           trackName = doc.trackName,
           artistIds = doc.artistIds.map { ArtistId(it) },
@@ -67,7 +61,6 @@ class RecentlyPlayedRepositoryAdapter(
     if (items.isEmpty()) return
     val documents = items.map { item ->
       RecentlyPlayedDocument().apply {
-        spotifyUserId = item.spotifyUserId.value
         trackId = item.trackId.value
         trackName = item.trackName
         artistIds = item.artistIds.map { it.value }
@@ -89,4 +82,3 @@ class RecentlyPlayedRepositoryAdapter(
     }
 
 }
-

--- a/adapter-out-spotify/src/main/kotlin/de/chrgroth/spotify/control/adapter/out/spotify/SpotifyPlaybackAdapter.kt
+++ b/adapter-out-spotify/src/main/kotlin/de/chrgroth/spotify/control/adapter/out/spotify/SpotifyPlaybackAdapter.kt
@@ -15,7 +15,6 @@ import de.chrgroth.spotify.control.domain.model.catalog.TrackId
 import de.chrgroth.spotify.control.domain.model.playback.CurrentlyPlayingItem
 import de.chrgroth.spotify.control.domain.model.playback.RecentlyPlayedItem
 import de.chrgroth.spotify.control.domain.model.user.AccessToken
-import de.chrgroth.spotify.control.domain.model.user.UserId
 import de.chrgroth.spotify.control.domain.port.out.playback.SpotifyPlaybackPort
 import jakarta.enterprise.context.ApplicationScoped
 import kotlinx.serialization.json.JsonElement
@@ -65,8 +64,6 @@ class SpotifyPlaybackAdapter(
     val progressMs = response.progressMs ?: 0L
     val observedAt = Clock.System.now()
     return CurrentlyPlayingItem(
-      // stamped with the real user by PlaybackService, which resolves "the" current user
-      spotifyUserId = PLACEHOLDER_USER_ID,
       trackId = TrackId(trackId),
       trackName = track.name ?: "",
       artistIds = track.artists?.mapNotNull { it.id?.let { id -> ArtistId(id) } } ?: emptyList(),
@@ -126,8 +123,6 @@ class SpotifyPlaybackAdapter(
     val durationSeconds = track.durationMs?.let { it.toLong() / MS_PER_SECOND }
     val playedAtInstant = Instant.parse(playedAt)
     return RecentlyPlayedItem(
-      // stamped with the real user by PlaybackService, which resolves "the" current user
-      spotifyUserId = PLACEHOLDER_USER_ID,
       trackId = TrackId(track.id),
       trackName = track.name ?: "",
       artistIds = track.artists?.mapNotNull { it.id?.let { id -> ArtistId(id) } } ?: emptyList(),
@@ -145,6 +140,5 @@ class SpotifyPlaybackAdapter(
   companion object : KLogging() {
     private const val MS_PER_SECOND = 1_000L
     private const val RECENTLY_PLAYED_LIMIT = 50
-    private val PLACEHOLDER_USER_ID = UserId("")
   }
 }

--- a/application-quarkus/build.gradle.kts
+++ b/application-quarkus/build.gradle.kts
@@ -37,6 +37,7 @@ dependencies {
   testImplementation("io.quarkus:quarkus-junit5")
   testImplementation("io.quarkus:quarkus-junit5-mockito")
   testImplementation("io.quarkus:quarkus-test-security")
+  testImplementation("io.quarkus:quarkus-mongodb-panache-kotlin")
   testImplementation("io.rest-assured:rest-assured")
 }
 

--- a/application-quarkus/src/test/kotlin/de/chrgroth/spotify/control/adapter/out/mongodb/AppPlaybackRepositoryTests.kt
+++ b/application-quarkus/src/test/kotlin/de/chrgroth/spotify/control/adapter/out/mongodb/AppPlaybackRepositoryTests.kt
@@ -1,7 +1,6 @@
 package de.chrgroth.spotify.control.adapter.out.mongodb
 
 import de.chrgroth.spotify.control.domain.model.playback.AppPlaybackItem
-import de.chrgroth.spotify.control.domain.model.user.UserId
 import de.chrgroth.spotify.control.domain.port.out.playback.AppPlaybackRepositoryPort
 import io.quarkus.test.junit.QuarkusTest
 import jakarta.inject.Inject
@@ -9,8 +8,8 @@ import kotlin.time.Clock
 import kotlin.time.Duration.Companion.hours
 import kotlin.time.Instant
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import java.util.UUID
 
 @QuarkusTest
 class AppPlaybackRepositoryTests {
@@ -18,38 +17,41 @@ class AppPlaybackRepositoryTests {
   @Inject
   lateinit var appPlaybackRepository: AppPlaybackRepositoryPort
 
-  private val userId = UserId("test-${UUID.randomUUID()}")
   private val now = Clock.System.now().let { Instant.fromEpochMilliseconds(it.toEpochMilliseconds()) }
 
   private fun item(index: Int) = AppPlaybackItem(
-    userId = userId,
     playedAt = now - index.hours,
     trackId = "track-$index",
     secondsPlayed = (index * 30).toLong(),
   )
 
+  @BeforeEach
+  fun cleanUp() {
+    // single-user application: the collection is no longer scoped per user, so tests reset it explicitly for isolation
+    appPlaybackRepository.deleteAll()
+  }
+
   @Test
   fun `saveAll persists items and countAll returns correct count`() {
     appPlaybackRepository.saveAll(listOf(item(1), item(2), item(3)))
 
-    val count = appPlaybackRepository.countAll(userId)
+    val count = appPlaybackRepository.countAll()
 
-    assertThat(count).isGreaterThanOrEqualTo(3)
+    assertThat(count).isEqualTo(3)
   }
 
   @Test
   fun `findMostRecentPlayedAt returns most recent playedAt`() {
     appPlaybackRepository.saveAll(listOf(item(1), item(2), item(3)))
 
-    val mostRecent = appPlaybackRepository.findMostRecentPlayedAt(userId)
+    val mostRecent = appPlaybackRepository.findMostRecentPlayedAt()
 
     assertThat(mostRecent).isEqualTo(item(1).playedAt)
   }
 
   @Test
   fun `findMostRecentPlayedAt returns null when no items exist`() {
-    val emptyUserId = UserId("empty-${UUID.randomUUID()}")
-    val result = appPlaybackRepository.findMostRecentPlayedAt(emptyUserId)
+    val result = appPlaybackRepository.findMostRecentPlayedAt()
     assertThat(result).isNull()
   }
 
@@ -59,14 +61,14 @@ class AppPlaybackRepositoryTests {
     appPlaybackRepository.saveAll(items)
 
     val playedAts = items.map { it.playedAt }.toSet()
-    val existing = appPlaybackRepository.findExistingPlayedAts(userId, playedAts)
+    val existing = appPlaybackRepository.findExistingPlayedAts(playedAts)
 
     assertThat(existing).containsExactlyInAnyOrderElementsOf(playedAts)
   }
 
   @Test
   fun `findExistingPlayedAts returns empty set for empty input`() {
-    val existing = appPlaybackRepository.findExistingPlayedAts(userId, emptySet())
+    val existing = appPlaybackRepository.findExistingPlayedAts(emptySet())
     assertThat(existing).isEmpty()
   }
 
@@ -77,90 +79,60 @@ class AppPlaybackRepositoryTests {
     appPlaybackRepository.deleteAllByTrackIds(setOf("track-1", "track-2"))
 
     val existing = appPlaybackRepository.findExistingPlayedAts(
-      userId,
       setOf(item(1).playedAt, item(2).playedAt, item(3).playedAt),
     )
     assertThat(existing).containsOnly(item(3).playedAt)
   }
 
   @Test
-  fun `deleteByUserAndPlayedAts removes only matching items for that user`() {
-    val otherUserId = UserId("other-${UUID.randomUUID()}")
-    val myItem1 = item(1)
-    val myItem2 = item(2)
-    val otherItem = AppPlaybackItem(userId = otherUserId, playedAt = now - 1.hours, trackId = "t", secondsPlayed = 0)
-    appPlaybackRepository.saveAll(listOf(myItem1, myItem2))
-    appPlaybackRepository.saveAll(listOf(otherItem))
+  fun `deleteByPlayedAts removes only matching items`() {
+    val item1 = item(1)
+    val item2 = item(2)
+    appPlaybackRepository.saveAll(listOf(item1, item2))
 
-    appPlaybackRepository.deleteByUserAndPlayedAts(userId, setOf(myItem1.playedAt))
+    appPlaybackRepository.deleteByPlayedAts(setOf(item1.playedAt))
 
-    val remaining = appPlaybackRepository.findExistingPlayedAts(userId, setOf(myItem1.playedAt, myItem2.playedAt))
-    assertThat(remaining).containsOnly(myItem2.playedAt)
-    assertThat(appPlaybackRepository.countAll(otherUserId)).isGreaterThanOrEqualTo(1)
+    val remaining = appPlaybackRepository.findExistingPlayedAts(setOf(item1.playedAt, item2.playedAt))
+    assertThat(remaining).containsOnly(item2.playedAt)
   }
 
   @Test
-  fun `deleteByUserAndPlayedAts is a no-op for empty input`() {
+  fun `deleteByPlayedAts is a no-op for empty input`() {
     appPlaybackRepository.saveAll(listOf(item(1)))
 
-    appPlaybackRepository.deleteByUserAndPlayedAts(userId, emptySet())
+    appPlaybackRepository.deleteByPlayedAts(emptySet())
 
-    assertThat(appPlaybackRepository.countAll(userId)).isGreaterThanOrEqualTo(1)
+    assertThat(appPlaybackRepository.countAll()).isEqualTo(1)
   }
 
   @Test
-  fun `deleteAllByUserId removes only items for that user`() {
-    val otherUserId = UserId("other-${UUID.randomUUID()}")
+  fun `deleteAll removes all items`() {
     appPlaybackRepository.saveAll(listOf(item(1), item(2)))
-    appPlaybackRepository.saveAll(listOf(
-      AppPlaybackItem(userId = otherUserId, playedAt = now - 1.hours, trackId = "t", secondsPlayed = 0),
-    ))
 
-    appPlaybackRepository.deleteAllByUserId(userId)
+    appPlaybackRepository.deleteAll()
 
-    assertThat(appPlaybackRepository.countAll(userId)).isZero()
-    assertThat(appPlaybackRepository.countAll(otherUserId)).isGreaterThanOrEqualTo(1)
+    assertThat(appPlaybackRepository.countAll()).isZero()
   }
 
   @Test
   fun `findRecentlyPlayed returns limited results sorted by playedAt descending`() {
     appPlaybackRepository.saveAll(listOf(item(1), item(2), item(3)))
 
-    val result = appPlaybackRepository.findRecentlyPlayed(userId, 2)
+    val result = appPlaybackRepository.findRecentlyPlayed(2)
 
-    assertThat(result).hasSizeLessThanOrEqualTo(2)
+    assertThat(result.map { it.trackId }).containsExactly("track-1", "track-2")
   }
 
   @Test
   fun `sumSecondsPlayedByTrackIdSince aggregates seconds per track excluding zero values`() {
-    val itemWithSeconds = AppPlaybackItem(
-      userId = userId,
-      playedAt = now - 1.hours,
-      trackId = "track-a",
-      secondsPlayed = 120L,
-    )
-    val anotherItemSameTrack = AppPlaybackItem(
-      userId = userId,
-      playedAt = now - 2.hours,
-      trackId = "track-a",
-      secondsPlayed = 60L,
-    )
-    val itemOtherTrack = AppPlaybackItem(
-      userId = userId,
-      playedAt = now - 3.hours,
-      trackId = "track-b",
-      secondsPlayed = 90L,
-    )
-    val itemNoSeconds = AppPlaybackItem(
-      userId = userId,
-      playedAt = now - 4.hours,
-      trackId = "track-c",
-      secondsPlayed = 0L,
-    )
+    val itemWithSeconds = AppPlaybackItem(playedAt = now - 1.hours, trackId = "track-a", secondsPlayed = 120L)
+    val anotherItemSameTrack = AppPlaybackItem(playedAt = now - 2.hours, trackId = "track-a", secondsPlayed = 60L)
+    val itemOtherTrack = AppPlaybackItem(playedAt = now - 3.hours, trackId = "track-b", secondsPlayed = 90L)
+    val itemNoSeconds = AppPlaybackItem(playedAt = now - 4.hours, trackId = "track-c", secondsPlayed = 0L)
     appPlaybackRepository.saveAll(listOf(itemWithSeconds, anotherItemSameTrack, itemOtherTrack, itemNoSeconds))
 
     val since = now - 24.hours
-    val result = appPlaybackRepository.sumSecondsPlayedByTrackIdSince(userId, since)
+    val result = appPlaybackRepository.sumSecondsPlayedByTrackIdSince(since)
 
     assertThat(result["track-a"]).isEqualTo(180L)
     assertThat(result["track-b"]).isEqualTo(90L)
@@ -169,17 +141,16 @@ class AppPlaybackRepositoryTests {
 
   @Test
   fun `findAllBetween returns only items within the given time window`() {
-    val inside1 = AppPlaybackItem(userId = userId, playedAt = now - 2.hours, trackId = "inside-1", secondsPlayed = 60L)
-    val inside2 = AppPlaybackItem(userId = userId, playedAt = now - 3.hours, trackId = "inside-2", secondsPlayed = 90L)
-    val tooEarly = AppPlaybackItem(userId = userId, playedAt = now - 6.hours, trackId = "too-early", secondsPlayed = 30L)
-    val tooLate = AppPlaybackItem(userId = userId, playedAt = now, trackId = "too-late", secondsPlayed = 30L)
+    val inside1 = AppPlaybackItem(playedAt = now - 2.hours, trackId = "inside-1", secondsPlayed = 60L)
+    val inside2 = AppPlaybackItem(playedAt = now - 3.hours, trackId = "inside-2", secondsPlayed = 90L)
+    val tooEarly = AppPlaybackItem(playedAt = now - 6.hours, trackId = "too-early", secondsPlayed = 30L)
+    val tooLate = AppPlaybackItem(playedAt = now, trackId = "too-late", secondsPlayed = 30L)
     appPlaybackRepository.saveAll(listOf(inside1, inside2, tooEarly, tooLate))
 
     val from = now - 4.hours
     val to = now - 1.hours
-    val result = appPlaybackRepository.findAllBetween(userId, from, to)
+    val result = appPlaybackRepository.findAllBetween(from, to)
 
     assertThat(result.map { it.trackId }).containsExactlyInAnyOrder("inside-1", "inside-2")
   }
 }
-

--- a/application-quarkus/src/test/kotlin/de/chrgroth/spotify/control/adapter/out/mongodb/CurrentlyPlayingRepositoryTests.kt
+++ b/application-quarkus/src/test/kotlin/de/chrgroth/spotify/control/adapter/out/mongodb/CurrentlyPlayingRepositoryTests.kt
@@ -2,7 +2,6 @@ package de.chrgroth.spotify.control.adapter.out.mongodb
 
 import de.chrgroth.spotify.control.domain.model.catalog.TrackId
 import de.chrgroth.spotify.control.domain.model.playback.CurrentlyPlayingItem
-import de.chrgroth.spotify.control.domain.model.user.UserId
 import de.chrgroth.spotify.control.domain.port.out.playback.CurrentlyPlayingRepositoryPort
 import io.quarkus.test.junit.QuarkusTest
 import jakarta.inject.Inject
@@ -10,7 +9,6 @@ import kotlin.time.Duration.Companion.seconds
 import kotlin.time.Instant
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import java.util.UUID
 
 @QuarkusTest
 class CurrentlyPlayingRepositoryTests {
@@ -18,8 +16,7 @@ class CurrentlyPlayingRepositoryTests {
   @Inject
   lateinit var currentlyPlayingRepository: CurrentlyPlayingRepositoryPort
 
-  private fun item(userId: UserId, trackId: TrackId, observedAt: Instant) = CurrentlyPlayingItem(
-    spotifyUserId = userId,
+  private fun item(trackId: TrackId, observedAt: Instant) = CurrentlyPlayingItem(
     trackId = trackId,
     trackName = "Track",
     artistIds = emptyList(),
@@ -32,23 +29,22 @@ class CurrentlyPlayingRepositoryTests {
   )
 
   @Test
-  fun `findMostRecentByUserAndTrack returns the item with the latest observedAt`() {
-    val userId = UserId("test-${UUID.randomUUID()}")
+  fun `findMostRecentByTrack returns the item with the latest observedAt`() {
     val trackId = TrackId("track-1")
     val now = Instant.fromEpochSeconds(1_000_000)
-    currentlyPlayingRepository.save(item(userId, trackId, now))
-    currentlyPlayingRepository.save(item(userId, trackId, now + 30.seconds))
-    currentlyPlayingRepository.save(item(userId, trackId, now + 10.seconds))
+    currentlyPlayingRepository.save(item(trackId, now))
+    currentlyPlayingRepository.save(item(trackId, now + 30.seconds))
+    currentlyPlayingRepository.save(item(trackId, now + 10.seconds))
 
-    val result = currentlyPlayingRepository.findMostRecentByUserAndTrack(userId, trackId)
+    val result = currentlyPlayingRepository.findMostRecentByTrack(trackId)
 
     assertThat(result).isNotNull
     assertThat(result!!.observedAt).isEqualTo(now + 30.seconds)
   }
 
   @Test
-  fun `findMostRecentByUserAndTrack returns null when no items match`() {
-    val result = currentlyPlayingRepository.findMostRecentByUserAndTrack(UserId("test-${UUID.randomUUID()}"), TrackId("unknown-track"))
+  fun `findMostRecentByTrack returns null when no items match`() {
+    val result = currentlyPlayingRepository.findMostRecentByTrack(TrackId("unknown-track"))
     assertThat(result).isNull()
   }
 }

--- a/application-quarkus/src/test/kotlin/de/chrgroth/spotify/control/adapter/out/mongodb/PlaybackAggregationRepositoryTests.kt
+++ b/application-quarkus/src/test/kotlin/de/chrgroth/spotify/control/adapter/out/mongodb/PlaybackAggregationRepositoryTests.kt
@@ -3,14 +3,13 @@ package de.chrgroth.spotify.control.adapter.out.mongodb
 import de.chrgroth.spotify.control.domain.model.playback.aggregation.AggregationPeriodType
 import de.chrgroth.spotify.control.domain.model.playback.aggregation.AggregationRankEntry
 import de.chrgroth.spotify.control.domain.model.playback.aggregation.PlaybackAggregation
-import de.chrgroth.spotify.control.domain.model.user.UserId
 import de.chrgroth.spotify.control.domain.port.out.playback.PlaybackAggregationRepositoryPort
 import io.quarkus.test.junit.QuarkusTest
 import jakarta.inject.Inject
 import kotlinx.datetime.LocalDate
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import java.util.UUID
 
 @QuarkusTest
 class PlaybackAggregationRepositoryTests {
@@ -18,8 +17,7 @@ class PlaybackAggregationRepositoryTests {
   @Inject
   lateinit var aggregationRepository: PlaybackAggregationRepositoryPort
 
-  private fun aggregation(userId: UserId, type: AggregationPeriodType, periodStart: LocalDate, eventCount: Long = 1L) = PlaybackAggregation(
-    userId = userId,
+  private fun aggregation(type: AggregationPeriodType, periodStart: LocalDate, eventCount: Long = 1L) = PlaybackAggregation(
     type = type,
     periodStart = periodStart,
     totalPlaybackSeconds = eventCount * SECONDS_PER_EVENT,
@@ -33,34 +31,35 @@ class PlaybackAggregationRepositoryTests {
     activityEntries = emptyList(),
   )
 
-  @Test
-  fun `save persists aggregation and findByUserAndPeriod returns it`() {
-    val userId = UserId("user-${UUID.randomUUID()}")
-    val periodStart = LocalDate(2024, 1, 10)
-    aggregationRepository.save(aggregation(userId, AggregationPeriodType.DAY, periodStart, eventCount = 5L))
+  @BeforeEach
+  fun cleanUp() {
+    // single-user application: the collection is no longer scoped per user, so tests reset it explicitly for isolation
+    aggregationRepository.deleteAll()
+  }
 
-    val result = aggregationRepository.findByUserAndPeriod(userId, AggregationPeriodType.DAY, periodStart)
+  @Test
+  fun `save persists aggregation and findByPeriod returns it`() {
+    val periodStart = LocalDate(2024, 1, 10)
+    aggregationRepository.save(aggregation(AggregationPeriodType.DAY, periodStart, eventCount = 5L))
+
+    val result = aggregationRepository.findByPeriod(AggregationPeriodType.DAY, periodStart)
 
     assertThat(result).isNotNull()
     assertThat(result!!.eventCount).isEqualTo(5L)
   }
 
   @Test
-  fun `findByUserAndPeriod returns null when no aggregation exists`() {
-    val result = aggregationRepository.findByUserAndPeriod(UserId("user-${UUID.randomUUID()}"), AggregationPeriodType.DAY, LocalDate(2024, 1, 1))
+  fun `findByPeriod returns null when no aggregation exists`() {
+    val result = aggregationRepository.findByPeriod(AggregationPeriodType.DAY, LocalDate(2024, 1, 1))
     assertThat(result).isNull()
   }
 
   @Test
-  fun `findByUserAndPeriods resolves multiple type period-start pairs in a single batch`() {
-    val userId = UserId("user-${UUID.randomUUID()}")
-    val otherUserId = UserId("user-${UUID.randomUUID()}")
-    aggregationRepository.save(aggregation(userId, AggregationPeriodType.DAY, LocalDate(2024, 1, 10), eventCount = 3L))
-    aggregationRepository.save(aggregation(userId, AggregationPeriodType.WEEK, LocalDate(2024, 1, 8), eventCount = 5L))
-    aggregationRepository.save(aggregation(otherUserId, AggregationPeriodType.DAY, LocalDate(2024, 1, 10), eventCount = 99L))
+  fun `findByPeriods resolves multiple type period-start pairs in a single batch`() {
+    aggregationRepository.save(aggregation(AggregationPeriodType.DAY, LocalDate(2024, 1, 10), eventCount = 3L))
+    aggregationRepository.save(aggregation(AggregationPeriodType.WEEK, LocalDate(2024, 1, 8), eventCount = 5L))
 
-    val result = aggregationRepository.findByUserAndPeriods(
-      userId,
+    val result = aggregationRepository.findByPeriods(
       listOf(
         AggregationPeriodType.DAY to LocalDate(2024, 1, 10),
         AggregationPeriodType.WEEK to LocalDate(2024, 1, 8),
@@ -75,55 +74,46 @@ class PlaybackAggregationRepositoryTests {
   }
 
   @Test
-  fun `findByUserAndPeriods returns empty map for empty input`() {
-    val result = aggregationRepository.findByUserAndPeriods(UserId("user-${UUID.randomUUID()}"), emptyList())
+  fun `findByPeriods returns empty map for empty input`() {
+    val result = aggregationRepository.findByPeriods(emptyList())
     assertThat(result).isEmpty()
   }
 
   @Test
-  fun `findByUserTypeAndPeriodRange returns only aggregations within range for the given user and type`() {
-    val userId = UserId("user-${UUID.randomUUID()}")
-    val otherUserId = UserId("user-${UUID.randomUUID()}")
-    aggregationRepository.save(aggregation(userId, AggregationPeriodType.DAY, LocalDate(2024, 1, 10)))
-    aggregationRepository.save(aggregation(userId, AggregationPeriodType.DAY, LocalDate(2024, 1, 15)))
-    aggregationRepository.save(aggregation(userId, AggregationPeriodType.DAY, LocalDate(2024, 2, 1)))
-    aggregationRepository.save(aggregation(userId, AggregationPeriodType.WEEK, LocalDate(2024, 1, 15)))
-    aggregationRepository.save(aggregation(otherUserId, AggregationPeriodType.DAY, LocalDate(2024, 1, 15)))
+  fun `findByTypeAndPeriodRange returns only aggregations within range for the given type`() {
+    aggregationRepository.save(aggregation(AggregationPeriodType.DAY, LocalDate(2024, 1, 10)))
+    aggregationRepository.save(aggregation(AggregationPeriodType.DAY, LocalDate(2024, 1, 15)))
+    aggregationRepository.save(aggregation(AggregationPeriodType.DAY, LocalDate(2024, 2, 1)))
+    aggregationRepository.save(aggregation(AggregationPeriodType.WEEK, LocalDate(2024, 1, 15)))
 
-    val result = aggregationRepository.findByUserTypeAndPeriodRange(userId, AggregationPeriodType.DAY, LocalDate(2024, 1, 1), LocalDate(2024, 1, 31))
+    val result = aggregationRepository.findByTypeAndPeriodRange(AggregationPeriodType.DAY, LocalDate(2024, 1, 1), LocalDate(2024, 1, 31))
 
     assertThat(result.map { it.periodStart }).containsExactlyInAnyOrder(LocalDate(2024, 1, 10), LocalDate(2024, 1, 15))
   }
 
   @Test
-  fun `findByUserTypeAndPeriodRange returns empty list when nothing matches`() {
-    val result = aggregationRepository.findByUserTypeAndPeriodRange(
-      UserId("user-${UUID.randomUUID()}"), AggregationPeriodType.DAY, LocalDate(2024, 1, 1), LocalDate(2024, 1, 31),
-    )
+  fun `findByTypeAndPeriodRange returns empty list when nothing matches`() {
+    val result = aggregationRepository.findByTypeAndPeriodRange(AggregationPeriodType.DAY, LocalDate(2024, 1, 1), LocalDate(2024, 1, 31))
     assertThat(result).isEmpty()
   }
 
   @Test
-  fun `findDailySummaryByUserAndPeriodRange returns only DAY aggregations within range for the given user`() {
-    val userId = UserId("user-${UUID.randomUUID()}")
-    val otherUserId = UserId("user-${UUID.randomUUID()}")
-    aggregationRepository.save(aggregation(userId, AggregationPeriodType.DAY, LocalDate(2024, 1, 10)))
-    aggregationRepository.save(aggregation(userId, AggregationPeriodType.DAY, LocalDate(2024, 1, 15)))
-    aggregationRepository.save(aggregation(userId, AggregationPeriodType.DAY, LocalDate(2024, 2, 1)))
-    aggregationRepository.save(aggregation(userId, AggregationPeriodType.WEEK, LocalDate(2024, 1, 15)))
-    aggregationRepository.save(aggregation(otherUserId, AggregationPeriodType.DAY, LocalDate(2024, 1, 15)))
+  fun `findDailySummaryByPeriodRange returns only DAY aggregations within range`() {
+    aggregationRepository.save(aggregation(AggregationPeriodType.DAY, LocalDate(2024, 1, 10)))
+    aggregationRepository.save(aggregation(AggregationPeriodType.DAY, LocalDate(2024, 1, 15)))
+    aggregationRepository.save(aggregation(AggregationPeriodType.DAY, LocalDate(2024, 2, 1)))
+    aggregationRepository.save(aggregation(AggregationPeriodType.WEEK, LocalDate(2024, 1, 15)))
 
-    val result = aggregationRepository.findDailySummaryByUserAndPeriodRange(userId, LocalDate(2024, 1, 1), LocalDate(2024, 1, 31))
+    val result = aggregationRepository.findDailySummaryByPeriodRange(LocalDate(2024, 1, 1), LocalDate(2024, 1, 31))
 
     assertThat(result.map { it.periodStart }).containsExactlyInAnyOrder(LocalDate(2024, 1, 10), LocalDate(2024, 1, 15))
   }
 
   @Test
-  fun `findDailySummaryByUserAndPeriodRange maps event count, playback seconds, track and artist entries`() {
-    val userId = UserId("user-${UUID.randomUUID()}")
-    aggregationRepository.save(aggregation(userId, AggregationPeriodType.DAY, LocalDate(2024, 1, 10), eventCount = 5L))
+  fun `findDailySummaryByPeriodRange maps event count, playback seconds, track and artist entries`() {
+    aggregationRepository.save(aggregation(AggregationPeriodType.DAY, LocalDate(2024, 1, 10), eventCount = 5L))
 
-    val result = aggregationRepository.findDailySummaryByUserAndPeriodRange(userId, LocalDate(2024, 1, 1), LocalDate(2024, 1, 31))
+    val result = aggregationRepository.findDailySummaryByPeriodRange(LocalDate(2024, 1, 1), LocalDate(2024, 1, 31))
 
     assertThat(result).hasSize(1)
     val summary = result.single()
@@ -134,28 +124,25 @@ class PlaybackAggregationRepositoryTests {
   }
 
   @Test
-  fun `findDailySummaryByUserAndPeriodRange returns empty list when nothing matches`() {
-    val result = aggregationRepository.findDailySummaryByUserAndPeriodRange(
-      UserId("user-${UUID.randomUUID()}"), LocalDate(2024, 1, 1), LocalDate(2024, 1, 31),
-    )
+  fun `findDailySummaryByPeriodRange returns empty list when nothing matches`() {
+    val result = aggregationRepository.findDailySummaryByPeriodRange(LocalDate(2024, 1, 1), LocalDate(2024, 1, 31))
     assertThat(result).isEmpty()
   }
 
   @Test
-  fun `sumEventCountByUser sums event counts across all DAY aggregations for the user`() {
-    val userId = UserId("user-${UUID.randomUUID()}")
-    aggregationRepository.save(aggregation(userId, AggregationPeriodType.DAY, LocalDate(2024, 1, 10), eventCount = 3L))
-    aggregationRepository.save(aggregation(userId, AggregationPeriodType.DAY, LocalDate(2024, 1, 11), eventCount = 4L))
-    aggregationRepository.save(aggregation(userId, AggregationPeriodType.WEEK, LocalDate(2024, 1, 8), eventCount = 100L))
+  fun `sumEventCount sums event counts across all DAY aggregations`() {
+    aggregationRepository.save(aggregation(AggregationPeriodType.DAY, LocalDate(2024, 1, 10), eventCount = 3L))
+    aggregationRepository.save(aggregation(AggregationPeriodType.DAY, LocalDate(2024, 1, 11), eventCount = 4L))
+    aggregationRepository.save(aggregation(AggregationPeriodType.WEEK, LocalDate(2024, 1, 8), eventCount = 100L))
 
-    val result = aggregationRepository.sumEventCountByUser(userId)
+    val result = aggregationRepository.sumEventCount()
 
     assertThat(result).isEqualTo(7L)
   }
 
   @Test
-  fun `sumEventCountByUser returns zero when user has no aggregations`() {
-    val result = aggregationRepository.sumEventCountByUser(UserId("user-${UUID.randomUUID()}"))
+  fun `sumEventCount returns zero when no aggregations exist`() {
+    val result = aggregationRepository.sumEventCount()
     assertThat(result).isEqualTo(0L)
   }
 

--- a/application-quarkus/src/test/kotlin/de/chrgroth/spotify/control/adapter/out/mongodb/PlaylistDataRepositoryTests.kt
+++ b/application-quarkus/src/test/kotlin/de/chrgroth/spotify/control/adapter/out/mongodb/PlaylistDataRepositoryTests.kt
@@ -3,17 +3,11 @@ package de.chrgroth.spotify.control.adapter.out.mongodb
 import de.chrgroth.spotify.control.domain.model.catalog.AlbumId
 import de.chrgroth.spotify.control.domain.model.catalog.ArtistId
 import de.chrgroth.spotify.control.domain.model.playlist.Playlist
-import de.chrgroth.spotify.control.domain.model.playlist.PlaylistInfo
-import de.chrgroth.spotify.control.domain.model.playlist.PlaylistSyncStatus
 import de.chrgroth.spotify.control.domain.model.playlist.PlaylistTrack
 import de.chrgroth.spotify.control.domain.model.catalog.TrackId
-import de.chrgroth.spotify.control.domain.model.user.UserId
 import de.chrgroth.spotify.control.domain.port.out.playlist.PlaylistRepositoryPort
 import io.quarkus.test.junit.QuarkusTest
 import jakarta.inject.Inject
-import kotlin.time.Clock
-import kotlin.time.Duration.Companion.hours
-import kotlin.time.Instant
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import java.util.UUID
@@ -35,34 +29,21 @@ class PlaylistDataRepositoryTests {
     ),
   )
 
-  private fun buildPlaylistInfo(playlistId: String, syncStatus: PlaylistSyncStatus = PlaylistSyncStatus.PASSIVE): PlaylistInfo {
-    val now = Clock.System.now().let { Instant.fromEpochMilliseconds(it.toEpochMilliseconds()) }
-    return PlaylistInfo(
-      spotifyPlaylistId = playlistId,
-      snapshotId = "snap-1",
-      lastSnapshotIdSyncTime = now - 1.hours,
-      name = "Playlist $playlistId",
-      syncStatus = syncStatus,
-    )
+  @Test
+  fun `findByPlaylistId returns null when no playlist exists`() {
+    assertThat(playlistRepository.findByPlaylistId("unknown-playlist-${UUID.randomUUID()}")).isNull()
   }
 
   @Test
-  fun `findByUserIdAndPlaylistId returns null when no playlist exists`() {
-    val userId = UserId("no-playlist-${UUID.randomUUID()}")
+  fun `save and findByPlaylistId round-trips playlist correctly`() {
+    val playlistId = "playlist-${UUID.randomUUID()}"
+    val playlist = buildPlaylist(playlistId)
 
-    assertThat(playlistRepository.findByUserIdAndPlaylistId(userId, "unknown-playlist")).isNull()
-  }
+    playlistRepository.save(playlist)
 
-  @Test
-  fun `save and findByUserIdAndPlaylistId round-trips playlist correctly`() {
-    val userId = UserId("test-${UUID.randomUUID()}")
-    val playlist = buildPlaylist("playlist-1")
-
-    playlistRepository.save(userId, playlist)
-
-    val found = playlistRepository.findByUserIdAndPlaylistId(userId, "playlist-1")
+    val found = playlistRepository.findByPlaylistId(playlistId)
     assertThat(found).isNotNull
-    assertThat(found!!.spotifyPlaylistId).isEqualTo("playlist-1")
+    assertThat(found!!.spotifyPlaylistId).isEqualTo(playlistId)
     assertThat(found.tracks).hasSize(1)
     assertThat(found.tracks[0].trackId).isEqualTo(TrackId("track-1"))
     assertThat(found.tracks[0].artistIds).containsExactly(ArtistId("artist-1"))
@@ -70,7 +51,6 @@ class PlaylistDataRepositoryTests {
 
   @Test
   fun `numberOfTracks returns correct size after save`() {
-    val userId = UserId("test-${UUID.randomUUID()}")
     val playlistId = "playlist-ntracks-${UUID.randomUUID()}"
     val playlist = Playlist(
       spotifyPlaylistId = playlistId,
@@ -80,19 +60,17 @@ class PlaylistDataRepositoryTests {
       ),
     )
 
-    playlistRepository.save(userId, playlist)
+    playlistRepository.save(playlist)
 
-    val found = playlistRepository.findByUserIdAndPlaylistId(userId, playlistId)
+    val found = playlistRepository.findByPlaylistId(playlistId)
     assertThat(found).isNotNull
     assertThat(found!!.numberOfTracks).isEqualTo(2)
   }
 
   @Test
   fun `numberOfTracks returns correct size after appendTracks`() {
-    val userId = UserId("test-${UUID.randomUUID()}")
     val playlistId = "playlist-append-${UUID.randomUUID()}"
     playlistRepository.save(
-      userId,
       Playlist(
         spotifyPlaylistId = playlistId,
         tracks = listOf(PlaylistTrack(trackId = TrackId("t1"), artistIds = listOf(ArtistId("a1")), albumId = AlbumId("al1"))),
@@ -100,7 +78,6 @@ class PlaylistDataRepositoryTests {
     )
 
     playlistRepository.appendTracks(
-      userId,
       playlistId,
       listOf(
         PlaylistTrack(trackId = TrackId("t2"), artistIds = listOf(ArtistId("a2")), albumId = AlbumId("al2")),
@@ -108,62 +85,41 @@ class PlaylistDataRepositoryTests {
       ),
     )
 
-    val found = playlistRepository.findByUserIdAndPlaylistId(userId, playlistId)
+    val found = playlistRepository.findByPlaylistId(playlistId)
     assertThat(found).isNotNull
     assertThat(found!!.numberOfTracks).isEqualTo(3)
   }
 
   @Test
   fun `save overwrites previous playlist data`() {
-    val userId = UserId("test-${UUID.randomUUID()}")
-    playlistRepository.save(userId, buildPlaylist("playlist-1"))
+    val playlistId = "playlist-${UUID.randomUUID()}"
+    playlistRepository.save(buildPlaylist(playlistId))
 
-    playlistRepository.save(userId, buildPlaylist("playlist-1"))
+    playlistRepository.save(buildPlaylist(playlistId))
 
-    val found = playlistRepository.findByUserIdAndPlaylistId(userId, "playlist-1")
+    val found = playlistRepository.findByPlaylistId(playlistId)
     assertThat(found).isNotNull
     assertThat(found!!.tracks).hasSize(1)
   }
 
   @Test
-  fun `findTrackCountsByUserId returns track count per playlist for the given user`() {
-    val userId = UserId("test-${UUID.randomUUID()}")
-    val otherUserId = UserId("test-${UUID.randomUUID()}")
+  fun `findTrackCounts returns track count per playlist`() {
+    val playlistId1 = "playlist-${UUID.randomUUID()}"
+    val playlistId2 = "playlist-${UUID.randomUUID()}"
     playlistRepository.save(
-      userId,
       Playlist(
-        spotifyPlaylistId = "playlist-1",
+        spotifyPlaylistId = playlistId1,
         tracks = listOf(
           PlaylistTrack(trackId = TrackId("t1"), artistIds = listOf(ArtistId("a1")), albumId = AlbumId("al1")),
           PlaylistTrack(trackId = TrackId("t2"), artistIds = listOf(ArtistId("a2")), albumId = AlbumId("al2")),
         ),
       ),
     )
-    playlistRepository.save(userId, buildPlaylist("playlist-2"))
-    playlistRepository.save(otherUserId, buildPlaylist("playlist-3"))
+    playlistRepository.save(buildPlaylist(playlistId2))
 
-    val result = playlistRepository.findTrackCountsByUserId(userId)
+    val result = playlistRepository.findTrackCounts()
 
-    assertThat(result).containsExactlyInAnyOrderEntriesOf(mapOf("playlist-1" to 2, "playlist-2" to 1))
-  }
-
-  @Test
-  fun `findTrackCountsByUserId returns empty map when user has no playlists`() {
-    val userId = UserId("no-playlists-${UUID.randomUUID()}")
-
-    assertThat(playlistRepository.findTrackCountsByUserId(userId)).isEmpty()
-  }
-
-  @Test
-  fun `save does not affect playlists of other users`() {
-    val userId1 = UserId("test-${UUID.randomUUID()}")
-    val userId2 = UserId("test-${UUID.randomUUID()}")
-    playlistRepository.save(userId1, buildPlaylist("playlist-1"))
-    playlistRepository.save(userId2, buildPlaylist("playlist-2"))
-
-    assertThat(playlistRepository.findByUserIdAndPlaylistId(userId1, "playlist-1")).isNotNull
-    assertThat(playlistRepository.findByUserIdAndPlaylistId(userId2, "playlist-2")).isNotNull
-    assertThat(playlistRepository.findByUserIdAndPlaylistId(userId1, "playlist-2")).isNull()
-    assertThat(playlistRepository.findByUserIdAndPlaylistId(userId2, "playlist-1")).isNull()
+    assertThat(result).containsEntry(playlistId1, 2)
+    assertThat(result).containsEntry(playlistId2, 1)
   }
 }

--- a/application-quarkus/src/test/kotlin/de/chrgroth/spotify/control/adapter/out/mongodb/PlaylistRepositoryTests.kt
+++ b/application-quarkus/src/test/kotlin/de/chrgroth/spotify/control/adapter/out/mongodb/PlaylistRepositoryTests.kt
@@ -2,7 +2,6 @@ package de.chrgroth.spotify.control.adapter.out.mongodb
 
 import de.chrgroth.spotify.control.domain.model.playlist.PlaylistInfo
 import de.chrgroth.spotify.control.domain.model.playlist.PlaylistSyncStatus
-import de.chrgroth.spotify.control.domain.model.user.UserId
 import de.chrgroth.spotify.control.domain.port.out.playlist.PlaylistRepositoryPort
 import io.quarkus.test.junit.QuarkusTest
 import jakarta.inject.Inject
@@ -31,95 +30,72 @@ class PlaylistRepositoryTests {
   }
 
   @Test
-  fun `findByUserId returns empty list when no playlists exist`() {
-    val userId = UserId("no-playlists-${UUID.randomUUID()}")
+  fun `replaceAll with empty list removes all playlists`() {
+    playlistRepository.replaceAll(emptyList())
 
-    assertThat(playlistRepository.findByUserId(userId)).isEmpty()
+    assertThat(playlistRepository.findAll()).isEmpty()
   }
 
   @Test
-  fun `saveAll and findByUserId round-trips playlists correctly`() {
-    val userId = UserId("test-${UUID.randomUUID()}")
+  fun `replaceAll and findAll round-trips playlists correctly`() {
+    val p1 = "p1-${UUID.randomUUID()}"
+    val p2 = "p2-${UUID.randomUUID()}"
     val playlists = listOf(
-      buildPlaylistInfo("p1", PlaylistSyncStatus.ACTIVE),
-      buildPlaylistInfo("p2", PlaylistSyncStatus.PASSIVE),
+      buildPlaylistInfo(p1, PlaylistSyncStatus.ACTIVE),
+      buildPlaylistInfo(p2, PlaylistSyncStatus.PASSIVE),
     )
 
-    playlistRepository.replaceAll(userId, playlists)
+    playlistRepository.replaceAll(playlists)
 
-    val found = playlistRepository.findByUserId(userId)
+    val found = playlistRepository.findAll()
     assertThat(found).hasSize(2)
     val byId = found.associateBy { it.spotifyPlaylistId }
-    assertThat(byId["p1"]!!.syncStatus).isEqualTo(PlaylistSyncStatus.ACTIVE)
-    assertThat(byId["p2"]!!.syncStatus).isEqualTo(PlaylistSyncStatus.PASSIVE)
+    assertThat(byId[p1]!!.syncStatus).isEqualTo(PlaylistSyncStatus.ACTIVE)
+    assertThat(byId[p2]!!.syncStatus).isEqualTo(PlaylistSyncStatus.PASSIVE)
   }
 
   @Test
-  fun `saveAll replaces previous playlists for the same user`() {
-    val userId = UserId("test-${UUID.randomUUID()}")
-    playlistRepository.replaceAll(userId, listOf(buildPlaylistInfo("p1"), buildPlaylistInfo("p2")))
+  fun `replaceAll replaces all previous playlists`() {
+    playlistRepository.replaceAll(listOf(buildPlaylistInfo("p1-${UUID.randomUUID()}"), buildPlaylistInfo("p2-${UUID.randomUUID()}")))
 
-    playlistRepository.replaceAll(userId, listOf(buildPlaylistInfo("p3")))
+    val p3 = "p3-${UUID.randomUUID()}"
+    playlistRepository.replaceAll(listOf(buildPlaylistInfo(p3)))
 
-    val found = playlistRepository.findByUserId(userId)
+    val found = playlistRepository.findAll()
     assertThat(found).hasSize(1)
-    assertThat(found[0].spotifyPlaylistId).isEqualTo("p3")
-  }
-
-  @Test
-  fun `saveAll with empty list removes all playlists for user`() {
-    val userId = UserId("test-${UUID.randomUUID()}")
-    playlistRepository.replaceAll(userId, listOf(buildPlaylistInfo("p1")))
-
-    playlistRepository.replaceAll(userId, emptyList())
-
-    assertThat(playlistRepository.findByUserId(userId)).isEmpty()
-  }
-
-  @Test
-  fun `saveAll does not affect playlists of other users`() {
-    val userId1 = UserId("test-${UUID.randomUUID()}")
-    val userId2 = UserId("test-${UUID.randomUUID()}")
-    playlistRepository.replaceAll(userId1, listOf(buildPlaylistInfo("p1")))
-    playlistRepository.replaceAll(userId2, listOf(buildPlaylistInfo("p2")))
-
-    playlistRepository.replaceAll(userId1, listOf(buildPlaylistInfo("p3")))
-
-    assertThat(playlistRepository.findByUserId(userId1).map { it.spotifyPlaylistId }).containsExactly("p3")
-    assertThat(playlistRepository.findByUserId(userId2).map { it.spotifyPlaylistId }).containsExactly("p2")
+    assertThat(found[0].spotifyPlaylistId).isEqualTo(p3)
   }
 
   @Test
   fun `updateLastSyncTime sets lastSyncTime on existing playlist metadata`() {
-    val userId = UserId("test-${UUID.randomUUID()}")
-    playlistRepository.replaceAll(userId, listOf(buildPlaylistInfo("p1")))
+    val p1 = "p1-${UUID.randomUUID()}"
+    playlistRepository.replaceAll(listOf(buildPlaylistInfo(p1)))
     val syncTime = Clock.System.now().let { Instant.fromEpochMilliseconds(it.toEpochMilliseconds()) }
 
-    playlistRepository.updateLastSyncTime(userId, "p1", syncTime)
+    playlistRepository.updateLastSyncTime(p1, syncTime)
 
-    val found = playlistRepository.findByUserId(userId)
+    val found = playlistRepository.findAll()
     assertThat(found).hasSize(1)
     assertThat(found[0].lastSyncTime).isEqualTo(syncTime)
   }
 
   @Test
   fun `updateLastSyncTime is a no-op for unknown playlist`() {
-    val userId = UserId("test-${UUID.randomUUID()}")
+    playlistRepository.replaceAll(emptyList())
 
-    playlistRepository.updateLastSyncTime(userId, "unknown", Clock.System.now())
+    playlistRepository.updateLastSyncTime("unknown-${UUID.randomUUID()}", Clock.System.now())
 
-    assertThat(playlistRepository.findByUserId(userId)).isEmpty()
+    assertThat(playlistRepository.findAll()).isEmpty()
   }
 
   @Test
-  fun `saveAll and findByUserId round-trips lastSyncTime correctly`() {
-    val userId = UserId("test-${UUID.randomUUID()}")
+  fun `replaceAll and findAll round-trips lastSyncTime correctly`() {
     val syncTime = Clock.System.now().let { Instant.fromEpochMilliseconds(it.toEpochMilliseconds()) }
-    val playlist = buildPlaylistInfo("p1").copy(lastSyncTime = syncTime)
+    val playlist = buildPlaylistInfo("p1-${UUID.randomUUID()}").copy(lastSyncTime = syncTime)
 
-    playlistRepository.replaceAll(userId, listOf(playlist))
+    playlistRepository.replaceAll(listOf(playlist))
 
-    val found = playlistRepository.findByUserId(userId)
+    val found = playlistRepository.findAll()
     assertThat(found).hasSize(1)
     assertThat(found[0].lastSyncTime).isEqualTo(syncTime)
   }

--- a/application-quarkus/src/test/kotlin/de/chrgroth/spotify/control/adapter/out/mongodb/RecentlyPartialPlayedRepositoryTests.kt
+++ b/application-quarkus/src/test/kotlin/de/chrgroth/spotify/control/adapter/out/mongodb/RecentlyPartialPlayedRepositoryTests.kt
@@ -3,18 +3,15 @@ package de.chrgroth.spotify.control.adapter.out.mongodb
 import de.chrgroth.spotify.control.domain.model.catalog.ArtistId
 import de.chrgroth.spotify.control.domain.model.catalog.TrackId
 import de.chrgroth.spotify.control.domain.model.playback.RecentlyPartialPlayedItem
-import de.chrgroth.spotify.control.domain.model.user.UserId
 import de.chrgroth.spotify.control.domain.port.out.playback.RecentlyPartialPlayedRepositoryPort
 import io.quarkus.test.junit.QuarkusTest
 import jakarta.inject.Inject
 import kotlin.time.Clock
 import kotlin.time.Duration.Companion.hours
-import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.Instant
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import java.util.UUID
 
 @QuarkusTest
 class RecentlyPartialPlayedRepositoryTests {
@@ -22,11 +19,9 @@ class RecentlyPartialPlayedRepositoryTests {
   @Inject
   lateinit var recentlyPartialPlayedRepository: RecentlyPartialPlayedRepositoryPort
 
-  private val userId = UserId("test-${UUID.randomUUID()}")
   private val now = Clock.System.now().let { Instant.fromEpochMilliseconds(it.toEpochMilliseconds()) }
 
   private fun item(index: Int, trackSuffix: String = "$index") = RecentlyPartialPlayedItem(
-    spotifyUserId = userId,
     trackId = TrackId("track-$trackSuffix"),
     trackName = "Track $trackSuffix",
     artistIds = listOf(ArtistId("artist-id-$index")),
@@ -37,14 +32,13 @@ class RecentlyPartialPlayedRepositoryTests {
   )
 
   @Test
-  fun `findByUserIdAndTrackIds returns matching items`() {
+  fun `findByTrackIds returns matching items`() {
     val item1 = item(1, "a")
     val item2 = item(2, "b")
     val item3 = item(3, "c")
     recentlyPartialPlayedRepository.saveAll(listOf(item1, item2, item3))
 
-    val result = recentlyPartialPlayedRepository.findByUserIdAndTrackIds(
-      userId,
+    val result = recentlyPartialPlayedRepository.findByTrackIds(
       setOf(TrackId("track-a"), TrackId("track-b")),
     )
 
@@ -52,19 +46,19 @@ class RecentlyPartialPlayedRepositoryTests {
   }
 
   @Test
-  fun `findByUserIdAndTrackIds returns empty list for empty input`() {
+  fun `findByTrackIds returns empty list for empty input`() {
     recentlyPartialPlayedRepository.saveAll(listOf(item(1)))
 
-    val result = recentlyPartialPlayedRepository.findByUserIdAndTrackIds(userId, emptySet())
+    val result = recentlyPartialPlayedRepository.findByTrackIds(emptySet())
 
     assertThat(result).isEmpty()
   }
 
   @Test
-  fun `findByUserIdAndTrackIds returns empty list when no match`() {
+  fun `findByTrackIds returns empty list when no match`() {
     recentlyPartialPlayedRepository.saveAll(listOf(item(1, "x")))
 
-    val result = recentlyPartialPlayedRepository.findByUserIdAndTrackIds(userId, setOf(TrackId("track-unknown")))
+    val result = recentlyPartialPlayedRepository.findByTrackIds(setOf(TrackId("track-unknown")))
 
     assertThat(result).isEmpty()
   }
@@ -76,10 +70,9 @@ class RecentlyPartialPlayedRepositoryTests {
     val item3 = item(3, "del-c")
     recentlyPartialPlayedRepository.saveAll(listOf(item1, item2, item3))
 
-    recentlyPartialPlayedRepository.deleteByPlayedAts(userId, setOf(item1.playedAt, item2.playedAt))
+    recentlyPartialPlayedRepository.deleteByPlayedAts(setOf(item1.playedAt, item2.playedAt))
 
     val remaining = recentlyPartialPlayedRepository.findExistingPlayedAts(
-      userId,
       setOf(item1.playedAt, item2.playedAt, item3.playedAt),
     )
     assertThat(remaining).containsOnly(item3.playedAt)
@@ -90,42 +83,9 @@ class RecentlyPartialPlayedRepositoryTests {
     val item1 = item(1, "noop-a")
     recentlyPartialPlayedRepository.saveAll(listOf(item1))
 
-    recentlyPartialPlayedRepository.deleteByPlayedAts(userId, emptySet())
+    recentlyPartialPlayedRepository.deleteByPlayedAts(emptySet())
 
-    val remaining = recentlyPartialPlayedRepository.findExistingPlayedAts(userId, setOf(item1.playedAt))
+    val remaining = recentlyPartialPlayedRepository.findExistingPlayedAts(setOf(item1.playedAt))
     assertThat(remaining).containsOnly(item1.playedAt)
-  }
-
-  @Test
-  fun `deleteByPlayedAts does not affect other users`() {
-    val otherUserId = UserId("other-${UUID.randomUUID()}")
-    val myItem = RecentlyPartialPlayedItem(
-      spotifyUserId = userId,
-      trackId = TrackId("track-shared"),
-      trackName = "Track Shared",
-      artistIds = listOf(ArtistId("artist-1")),
-      artistNames = listOf("Artist 1"),
-      playedAt = now - 1.hours,
-      startTime = now - 1.hours - 60.seconds,
-      playedSeconds = 60L,
-    )
-    val otherItem = RecentlyPartialPlayedItem(
-      spotifyUserId = otherUserId,
-      trackId = TrackId("track-shared"),
-      trackName = "Track Shared",
-      artistIds = listOf(ArtistId("artist-1")),
-      artistNames = listOf("Artist 1"),
-      playedAt = now - 1.hours - 5.minutes,
-      startTime = now - 1.hours - 5.minutes - 60.seconds,
-      playedSeconds = 60L,
-    )
-    recentlyPartialPlayedRepository.saveAll(listOf(myItem, otherItem))
-
-    recentlyPartialPlayedRepository.deleteByPlayedAts(userId, setOf(myItem.playedAt))
-
-    val myRemaining = recentlyPartialPlayedRepository.findExistingPlayedAts(userId, setOf(myItem.playedAt))
-    assertThat(myRemaining).isEmpty()
-    val otherRemaining = recentlyPartialPlayedRepository.findExistingPlayedAts(otherUserId, setOf(otherItem.playedAt))
-    assertThat(otherRemaining).containsOnly(otherItem.playedAt)
   }
 }

--- a/application-quarkus/src/test/kotlin/de/chrgroth/spotify/control/adapter/out/mongodb/RecentlyPlayedRepositoryTests.kt
+++ b/application-quarkus/src/test/kotlin/de/chrgroth/spotify/control/adapter/out/mongodb/RecentlyPlayedRepositoryTests.kt
@@ -3,7 +3,6 @@ package de.chrgroth.spotify.control.adapter.out.mongodb
 import de.chrgroth.spotify.control.domain.model.catalog.ArtistId
 import de.chrgroth.spotify.control.domain.model.playback.RecentlyPlayedItem
 import de.chrgroth.spotify.control.domain.model.catalog.TrackId
-import de.chrgroth.spotify.control.domain.model.user.UserId
 import de.chrgroth.spotify.control.domain.port.out.playback.RecentlyPlayedRepositoryPort
 import io.quarkus.test.junit.QuarkusTest
 import jakarta.inject.Inject
@@ -11,8 +10,8 @@ import kotlin.time.Clock
 import kotlin.time.Duration.Companion.hours
 import kotlin.time.Instant
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import java.util.UUID
 
 @QuarkusTest
 class RecentlyPlayedRepositoryTests {
@@ -20,11 +19,17 @@ class RecentlyPlayedRepositoryTests {
   @Inject
   lateinit var recentlyPlayedRepository: RecentlyPlayedRepositoryPort
 
-  private val userId = UserId("test-${UUID.randomUUID()}")
+  @Inject
+  lateinit var recentlyPlayedDocumentRepository: RecentlyPlayedDocumentRepository
+
   private val now = Clock.System.now().let { Instant.fromEpochMilliseconds(it.toEpochMilliseconds()) }
 
+  @BeforeEach
+  fun cleanUp() {
+    recentlyPlayedDocumentRepository.deleteAll()
+  }
+
   private fun item(index: Int) = RecentlyPlayedItem(
-    spotifyUserId = userId,
     trackId = TrackId("track-$index"),
     trackName = "Track $index",
     artistIds = listOf(ArtistId("artist-id-$index")),
@@ -37,14 +42,14 @@ class RecentlyPlayedRepositoryTests {
   fun `findMostRecentPlayedAt returns most recent playedAt`() {
     recentlyPlayedRepository.saveAll(listOf(item(1), item(2), item(3)))
 
-    val mostRecent = recentlyPlayedRepository.findMostRecentPlayedAt(userId)
+    val mostRecent = recentlyPlayedRepository.findMostRecentPlayedAt()
 
     assertThat(mostRecent).isEqualTo(item(1).playedAt)
   }
 
   @Test
   fun `findMostRecentPlayedAt returns null when no items exist`() {
-    val result = recentlyPlayedRepository.findMostRecentPlayedAt(userId)
+    val result = recentlyPlayedRepository.findMostRecentPlayedAt()
     assertThat(result).isNull()
   }
 
@@ -54,7 +59,7 @@ class RecentlyPlayedRepositoryTests {
     recentlyPlayedRepository.saveAll(items)
 
     val playedAts = items.map { it.playedAt }.toSet()
-    val existing = recentlyPlayedRepository.findExistingPlayedAts(userId, playedAts)
+    val existing = recentlyPlayedRepository.findExistingPlayedAts(playedAts)
 
     assertThat(existing).containsExactlyInAnyOrderElementsOf(playedAts)
   }
@@ -62,13 +67,13 @@ class RecentlyPlayedRepositoryTests {
   @Test
   fun `findExistingPlayedAts returns empty set when no items exist`() {
     val playedAts = setOf(now - 10.hours)
-    val existing = recentlyPlayedRepository.findExistingPlayedAts(userId, playedAts)
+    val existing = recentlyPlayedRepository.findExistingPlayedAts(playedAts)
     assertThat(existing).isEmpty()
   }
 
   @Test
   fun `findExistingPlayedAts returns empty set for empty input`() {
-    val existing = recentlyPlayedRepository.findExistingPlayedAts(userId, emptySet())
+    val existing = recentlyPlayedRepository.findExistingPlayedAts(emptySet())
     assertThat(existing).isEmpty()
   }
 
@@ -78,14 +83,13 @@ class RecentlyPlayedRepositoryTests {
     recentlyPlayedRepository.saveAll(listOf(savedItem))
 
     val newPlayedAt = now - 5.hours
-    val result = recentlyPlayedRepository.findExistingPlayedAts(userId, setOf(savedItem.playedAt, newPlayedAt))
+    val result = recentlyPlayedRepository.findExistingPlayedAts(setOf(savedItem.playedAt, newPlayedAt))
 
     assertThat(result).containsOnly(savedItem.playedAt)
     assertThat(result).doesNotContain(newPlayedAt)
   }
 
   private fun nonTrackItem(index: Int) = RecentlyPlayedItem(
-    spotifyUserId = userId,
     trackId = TrackId("episode-$index"),
     trackName = "Episode $index",
     artistIds = emptyList(),
@@ -100,7 +104,7 @@ class RecentlyPlayedRepositoryTests {
     val deleted = recentlyPlayedRepository.deleteNonTracks()
 
     assertThat(deleted).isEqualTo(2L)
-    val remaining = recentlyPlayedRepository.findExistingPlayedAts(userId, setOf(item(1).playedAt, nonTrackItem(2).playedAt, nonTrackItem(3).playedAt))
+    val remaining = recentlyPlayedRepository.findExistingPlayedAts(setOf(item(1).playedAt, nonTrackItem(2).playedAt, nonTrackItem(3).playedAt))
     assertThat(remaining).containsOnly(item(1).playedAt)
   }
 
@@ -118,7 +122,7 @@ class RecentlyPlayedRepositoryTests {
     val itemWithDuration = item(1)
     recentlyPlayedRepository.saveAll(listOf(itemWithDuration))
 
-    val result = recentlyPlayedRepository.findSince(userId, null)
+    val result = recentlyPlayedRepository.findSince(null)
 
     assertThat(result).hasSize(1)
     assertThat(result[0].durationSeconds).isEqualTo(itemWithDuration.durationSeconds)
@@ -127,7 +131,6 @@ class RecentlyPlayedRepositoryTests {
   @Test
   fun `findSince returns zero durationSeconds when not set`() {
     val itemWithoutDuration = RecentlyPlayedItem(
-      spotifyUserId = userId,
       trackId = TrackId("track-noduration"),
       trackName = "Track No Duration",
       artistIds = listOf(ArtistId("artist-id-1")),
@@ -137,7 +140,7 @@ class RecentlyPlayedRepositoryTests {
     )
     recentlyPlayedRepository.saveAll(listOf(itemWithoutDuration))
 
-    val result = recentlyPlayedRepository.findSince(userId, null)
+    val result = recentlyPlayedRepository.findSince(null)
 
     val found = result.first { it.trackId == TrackId("track-noduration") }
     assertThat(found.durationSeconds).isEqualTo(0L)

--- a/docs/arc42/arc42.md
+++ b/docs/arc42/arc42.md
@@ -375,7 +375,7 @@ Layer 5 applies to adapter modules where the logic is pure (e.g. `adapter-in-sta
 
 - Spotify OAuth 2.0 Authorization Code Flow.
 - A `User` document is upserted in the `app_user` MongoDB collection on every successful login. Both access and refresh tokens are stored encrypted (AES-256-GCM) using `APP_TOKEN_ENCRYPTION_KEY`.
-- The application is built for a single user (see [ADR-0008](../adr/0008-single-user-architecture.md)); login no longer checks an allow-list — any Spotify account that completes the OAuth flow is upserted as the application's user. Phases 1 and 2 of the [migration plan](../plans/single-user-simplification.md) are complete: scheduled jobs (playback fetch, playback aggregation, playlist sync, profile update) and catalog sync now act directly on the one stored user instead of fanning out over a user list. Phase 3 (dropping `UserId` from ports and outbox events) is in progress; the user-profile, `SpotifyAccessTokenPort`, and SSE/dashboard slices are done — `UserProfilePort`, `SpotifyAccessTokenPort`, `DashboardPort`, and `DashboardRefreshPort` no longer carry a `UserId`, and the `UpdateUserProfile` outbox event no longer carries one either.
+- The application is built for a single user (see [ADR-0008](../adr/0008-single-user-architecture.md)); login no longer checks an allow-list — any Spotify account that completes the OAuth flow is upserted as the application's user. Phases 1–4 of the [migration plan](../plans/single-user-simplification.md) are complete: scheduled jobs, catalog sync, and every repository port act directly on the one stored user instead of fanning out over or filtering by a user list, and the MongoDB collections that used to carry a `spotifyUserId` field or key (`app_playback`, `app_playback_aggregation`, `spotify_currently_playing`, `spotify_recently_played`, `spotify_recently_partial_played`, `spotify_playlist`, `spotify_playlist_metadata`) no longer do. Only Phase 5 (config/tests/deploy cleanup) remains.
 - Session-based authentication for all endpoints. The session stores only the Spotify user ID – never tokens.
 - `return_to` parameter stored in the session for redirect after login.
 - A CSRF `state` parameter is generated per authorization request and validated in the callback.
@@ -514,7 +514,7 @@ SLACK_WEBHOOK_URL
 | Enrichment completeness | `app_artist`, `app_track`, and `app_album` entries that existed before enrichment was introduced may lack imageLink or albumTitle until re-enriched. |
 | Partial-play detection accuracy | Partial play detection relies on polling frequency; very short plays near the end of a track may be missed or misclassified. |
 | Test coverage for domain adapters | Domain adapter integration (e.g. `PlaybackDataAdapter`, `PlaylistSyncAdapter`) is not yet covered by `@QuarkusTest` boundary tests. |
-| Multi-user plumbing | `UserId` is no longer part of any port's public signature (Phase 3 of the [single-user simplification plan](../plans/single-user-simplification.md) is complete), but repository out-ports and MongoDB document keys still carry `spotifyUserId` internally until Phase 4 migrates the schema. Tracked by [ADR-0008](../adr/0008-single-user-architecture.md). |
+| Config/test/deploy cleanup | Phase 5 of the [single-user simplification plan](../plans/single-user-simplification.md) (removing now-dead config, test fixtures, and documentation references) is still open. Tracked by [ADR-0008](../adr/0008-single-user-architecture.md). |
 
 # Glossary
 

--- a/docs/plans/single-user-simplification.md
+++ b/docs/plans/single-user-simplification.md
@@ -121,31 +121,44 @@ still resolves and threads `UserId` down to those calls, just no longer as a pub
 
 ---
 
-## Phase 4: MongoDB schema and index cleanup
+## Phase 4: MongoDB schema and index cleanup — done
 
 **Goal:** Simplify collections and indexes that currently exist to disambiguate between users.
 
-| Collection | Current key | Proposed change |
+| Collection | Old key | New key |
 |---|---|---|
-| `app_user` | `_id = spotifyUserId` | Keep as-is; still the single source of truth for "who is the user," now guaranteed to have at most one document. |
-| `app_playback` | `_id = "${spotifyUserId}:${playedAt.epochMilli}"` | Drop `spotifyUserId` from the key; `_id = playedAt.epochMilli` (or keep the compound key — see risk note below). |
-| `app_playback_aggregation` | `_id = "${spotifyUserId}:${type}:${periodStart}"` | Drop `spotifyUserId` from the key: `_id = "${type}:${periodStart}"`. |
-| `spotify_currently_playing` | `spotifyUserId` field + compound index `(spotifyUserId, trackId, observedAt)` | Drop `spotifyUserId` field and shrink index to `(trackId, observedAt)`. |
-| `spotify_recently_played` | `spotifyUserId` field + index `(spotifyUserId, playedAt)` | Drop field, shrink index to `(playedAt)`. |
-| `spotify_recently_partial_played` | same pattern | Drop field, shrink index to `(playedAt)`. |
-| `spotify_playlist` | `spotifyUserId` field + index `spotify_playlist_spotifyUserId_1` | Drop field and index. |
-| `spotify_playlist_metadata` | `spotifyUserId` field + index | Drop field and index. |
+| `app_user` | `_id = spotifyUserId` | Unchanged; still the single source of truth for "who is the user," now guaranteed to have at most one document. |
+| `app_playback` | `_id = "${spotifyUserId}:${playedAt.epochMilli}"` | `_id = playedAt.epochMilli` |
+| `app_playback_aggregation` | `_id = "${spotifyUserId}:${type}:${periodStart}"` | `_id = "${type}:${periodStart}"` |
+| `spotify_currently_playing` | `spotifyUserId` field + compound index `(spotifyUserId, trackId, observedAt)` | Field dropped; index shrunk to `(trackId, observedAt)`. |
+| `spotify_recently_played` | `spotifyUserId` field + index `(spotifyUserId, playedAt)` | Field dropped; index shrunk to `(playedAt)`. |
+| `spotify_recently_partial_played` | same pattern | Field dropped; index shrunk to `(playedAt)`. |
+| `spotify_playlist` | `_id = "${spotifyUserId}:${playlistId}"` + index `spotify_playlist_spotifyUserId_1` | `_id = spotifyPlaylistId`; index dropped. |
+| `spotify_playlist_metadata` | `_id = "${spotifyUserId}:${playlistId}"` + index | `_id = spotifyPlaylistId`; index dropped. |
 
-`app_artist`, `app_album`, `app_track` already have no `userId` and are unaffected.
+`app_artist`, `app_album`, `app_track` already had no `userId` and were unaffected.
 
-**Migration approach:** use a one-time `Starter` (per the existing pattern in
-`adapter-in-starter`, see arc42 "Starters" section) to strip `spotifyUserId` from existing
-documents and rebuild indexes, rather than a manual migration script — this matches how the
-project already handles one-time schema changes. Because there has only ever been one real user,
-this is a low-risk, single-pass rewrite, not a multi-tenant data migration.
+**Migration approach:** a one-time `SimplifySingleUserSchemaStarter` (per the existing pattern in
+`adapter-in-starter`, see arc42 "Starters" section) strips `spotifyUserId` from existing
+`spotify_currently_playing`/`spotify_recently_played`/`spotify_recently_partial_played` documents,
+and rewrites the composite `_id`s (insert-then-delete, since MongoDB can't change an existing
+`_id` in place) for `app_playback`, `app_playback_aggregation`, `spotify_playlist`, and
+`spotify_playlist_metadata`.
 
-**Risk:** Medium. Requires careful index rebuild sequencing (`MongoIndexInitializer.kt`) to avoid
-downtime, and must run after Phase 3 so no code still reads/writes the dropped field.
+Beyond the schema/index/migration work, this phase also went further than originally scoped and
+removed the now-dead `UserId`/`spotifyUserId` parameters and fields from the repository out-ports
+themselves (`AppPlaybackRepositoryPort`, `PlaybackAggregationRepositoryPort`,
+`CurrentlyPlayingRepositoryPort`, `RecentlyPlayedRepositoryPort`,
+`RecentlyPartialPlayedRepositoryPort`, `PlaylistRepositoryPort`, `PlaybackEventViewerRepositoryPort`)
+and from the in-memory domain models (`AppPlaybackItem`, `CurrentlyPlayingItem`,
+`RecentlyPlayedItem`, `RecentlyPartialPlayedItem`, `PlaybackAggregation`), since those fields were
+never read once Phase 3 moved user resolution to `CurrentUserResolver` — leaving them in place
+would just have been dead weight passed around for no reason. All call sites in `domain-impl` and
+`adapter-in-web`, and the `PlaylistCheckRunner` interface (which took a `UserId` purely to forward
+into playlist lookups), were updated accordingly.
+
+**Risk:** Medium. Required careful index rebuild sequencing (`MongoIndexInitializer.kt`) and ran
+only after Phase 3 confirmed no code still reads/writes the dropped fields.
 
 ---
 
@@ -174,7 +187,7 @@ downtime, and must run after Phase 3 so no code still reads/writes the dropped f
 | 1 – Login/allow-list removal | Low | Permissive change; single real operator already unaffected. |
 | 2 – Scheduler fan-out & catalog-sync shortcut | Medium | Done — "zero users" and "one user" cases covered by tests. |
 | 3 – `UserId` threading removal | High | Done — split per bounded context (user-profile, `SpotifyAccessTokenPort`, SSE/dashboard, then playback/playlist/catalog); in-flight outbox payloads with stale `userId` fields are tolerated by `fromKey`/`fromPayload`. |
-| 4 – MongoDB schema/index cleanup | Medium | Use a one-time `Starter`; sequence after Phase 3; rebuild indexes without downtime. |
+| 4 – MongoDB schema/index cleanup | Medium | Done — one-time `SimplifySingleUserSchemaStarter`; sequenced after Phase 3; also removed the now-dead `UserId` parameters from repository ports and domain models. |
 | 5 – Config/tests/deploy cleanup | Low | Cleanup only. |
 
 ## Out of scope

--- a/docs/releasenotes/snippets/issue-737-20260709-1826-bugfix.md
+++ b/docs/releasenotes/snippets/issue-737-20260709-1826-bugfix.md
@@ -1,0 +1,1 @@
+* Simplified the playback, playback-aggregation, currently-playing, recently-played, and playlist database collections to no longer be scoped by user, since the app only ever supports one.

--- a/domain-api/src/main/kotlin/de/chrgroth/spotify/control/domain/model/playback/AppPlaybackItem.kt
+++ b/domain-api/src/main/kotlin/de/chrgroth/spotify/control/domain/model/playback/AppPlaybackItem.kt
@@ -1,10 +1,8 @@
 package de.chrgroth.spotify.control.domain.model.playback
 
-import de.chrgroth.spotify.control.domain.model.user.UserId
 import kotlin.time.Instant
 
 data class AppPlaybackItem(
-  val userId: UserId,
   val playedAt: Instant,
   val trackId: String,
   val secondsPlayed: Long,

--- a/domain-api/src/main/kotlin/de/chrgroth/spotify/control/domain/model/playback/CurrentlyPlayingItem.kt
+++ b/domain-api/src/main/kotlin/de/chrgroth/spotify/control/domain/model/playback/CurrentlyPlayingItem.kt
@@ -3,11 +3,9 @@ package de.chrgroth.spotify.control.domain.model.playback
 import de.chrgroth.spotify.control.domain.model.catalog.AlbumId
 import de.chrgroth.spotify.control.domain.model.catalog.ArtistId
 import de.chrgroth.spotify.control.domain.model.catalog.TrackId
-import de.chrgroth.spotify.control.domain.model.user.UserId
 import kotlin.time.Instant
 
 data class CurrentlyPlayingItem(
-  val spotifyUserId: UserId,
   val trackId: TrackId,
   val trackName: String,
   val artistIds: List<ArtistId>,

--- a/domain-api/src/main/kotlin/de/chrgroth/spotify/control/domain/model/playback/RecentlyPartialPlayedItem.kt
+++ b/domain-api/src/main/kotlin/de/chrgroth/spotify/control/domain/model/playback/RecentlyPartialPlayedItem.kt
@@ -3,11 +3,9 @@ package de.chrgroth.spotify.control.domain.model.playback
 import de.chrgroth.spotify.control.domain.model.catalog.AlbumId
 import de.chrgroth.spotify.control.domain.model.catalog.ArtistId
 import de.chrgroth.spotify.control.domain.model.catalog.TrackId
-import de.chrgroth.spotify.control.domain.model.user.UserId
 import kotlin.time.Instant
 
 data class RecentlyPartialPlayedItem(
-  val spotifyUserId: UserId,
   val trackId: TrackId,
   val trackName: String,
   val artistIds: List<ArtistId>,

--- a/domain-api/src/main/kotlin/de/chrgroth/spotify/control/domain/model/playback/RecentlyPlayedItem.kt
+++ b/domain-api/src/main/kotlin/de/chrgroth/spotify/control/domain/model/playback/RecentlyPlayedItem.kt
@@ -3,11 +3,9 @@ package de.chrgroth.spotify.control.domain.model.playback
 import de.chrgroth.spotify.control.domain.model.catalog.AlbumId
 import de.chrgroth.spotify.control.domain.model.catalog.ArtistId
 import de.chrgroth.spotify.control.domain.model.catalog.TrackId
-import de.chrgroth.spotify.control.domain.model.user.UserId
 import kotlin.time.Instant
 
 data class RecentlyPlayedItem(
-  val spotifyUserId: UserId,
   val trackId: TrackId,
   val trackName: String,
   val artistIds: List<ArtistId>,

--- a/domain-api/src/main/kotlin/de/chrgroth/spotify/control/domain/model/playback/aggregation/PlaybackAggregation.kt
+++ b/domain-api/src/main/kotlin/de/chrgroth/spotify/control/domain/model/playback/aggregation/PlaybackAggregation.kt
@@ -1,10 +1,8 @@
 package de.chrgroth.spotify.control.domain.model.playback.aggregation
 
-import de.chrgroth.spotify.control.domain.model.user.UserId
 import kotlinx.datetime.LocalDate
 
 data class PlaybackAggregation(
-  val userId: UserId,
   val type: AggregationPeriodType,
   val periodStart: LocalDate,
   val totalPlaybackSeconds: Long,

--- a/domain-api/src/main/kotlin/de/chrgroth/spotify/control/domain/port/out/playback/AppPlaybackRepositoryPort.kt
+++ b/domain-api/src/main/kotlin/de/chrgroth/spotify/control/domain/port/out/playback/AppPlaybackRepositoryPort.kt
@@ -1,24 +1,23 @@
 package de.chrgroth.spotify.control.domain.port.out.playback
 
 import de.chrgroth.spotify.control.domain.model.playback.AppPlaybackItem
-import de.chrgroth.spotify.control.domain.model.user.UserId
 import kotlin.time.Instant
 import kotlinx.datetime.LocalDate
 
 interface AppPlaybackRepositoryPort {
   fun saveAll(items: List<AppPlaybackItem>)
-  fun deleteAllByUserId(userId: UserId)
+  fun deleteAll()
   fun deleteAllByTrackIds(trackIds: Set<String>)
-  fun deleteByUserAndPlayedAts(userId: UserId, playedAts: Set<Instant>)
-  fun findMostRecentPlayedAt(userId: UserId): Instant?
+  fun deleteByPlayedAts(playedAts: Set<Instant>)
+  fun findMostRecentPlayedAt(): Instant?
   fun findOldestPlayedAt(): Instant?
-  fun findExistingPlayedAts(userId: UserId, playedAts: Set<Instant>): Set<Instant>
-  fun countAll(userId: UserId): Long
-  fun countSince(userId: UserId, since: Instant): Long
-  fun countPerDaySince(userId: UserId, since: Instant): List<Pair<LocalDate, Long>>
-  fun findRecentlyPlayed(userId: UserId, limit: Int): List<AppPlaybackItem>
-  fun findAllSince(userId: UserId, since: Instant): List<AppPlaybackItem>
-  fun findAllBetween(userId: UserId, from: Instant, to: Instant): List<AppPlaybackItem>
-  fun sumSecondsPlayedByTrackIdSince(userId: UserId, since: Instant): Map<String, Long>
+  fun findExistingPlayedAts(playedAts: Set<Instant>): Set<Instant>
+  fun countAll(): Long
+  fun countSince(since: Instant): Long
+  fun countPerDaySince(since: Instant): List<Pair<LocalDate, Long>>
+  fun findRecentlyPlayed(limit: Int): List<AppPlaybackItem>
+  fun findAllSince(since: Instant): List<AppPlaybackItem>
+  fun findAllBetween(from: Instant, to: Instant): List<AppPlaybackItem>
+  fun sumSecondsPlayedByTrackIdSince(since: Instant): Map<String, Long>
   fun findAllDistinctTrackIds(): Set<String>
 }

--- a/domain-api/src/main/kotlin/de/chrgroth/spotify/control/domain/port/out/playback/CurrentlyPlayingRepositoryPort.kt
+++ b/domain-api/src/main/kotlin/de/chrgroth/spotify/control/domain/port/out/playback/CurrentlyPlayingRepositoryPort.kt
@@ -2,12 +2,11 @@ package de.chrgroth.spotify.control.domain.port.out.playback
 
 import de.chrgroth.spotify.control.domain.model.catalog.TrackId
 import de.chrgroth.spotify.control.domain.model.playback.CurrentlyPlayingItem
-import de.chrgroth.spotify.control.domain.model.user.UserId
 
 interface CurrentlyPlayingRepositoryPort {
   fun save(item: CurrentlyPlayingItem)
-  fun findMostRecentByUserAndTrack(userId: UserId, trackId: TrackId): CurrentlyPlayingItem?
+  fun findMostRecentByTrack(trackId: TrackId): CurrentlyPlayingItem?
   fun updateProgress(item: CurrentlyPlayingItem)
-  fun findByUserId(userId: UserId): List<CurrentlyPlayingItem>
-  fun deleteByUserIdAndTrackIds(userId: UserId, trackIds: Set<String>)
+  fun findAll(): List<CurrentlyPlayingItem>
+  fun deleteByTrackIds(trackIds: Set<String>)
 }

--- a/domain-api/src/main/kotlin/de/chrgroth/spotify/control/domain/port/out/playback/PlaybackAggregationRepositoryPort.kt
+++ b/domain-api/src/main/kotlin/de/chrgroth/spotify/control/domain/port/out/playback/PlaybackAggregationRepositoryPort.kt
@@ -3,15 +3,14 @@ package de.chrgroth.spotify.control.domain.port.out.playback
 import de.chrgroth.spotify.control.domain.model.playback.aggregation.AggregationPeriodType
 import de.chrgroth.spotify.control.domain.model.playback.aggregation.DailyPlaybackSummary
 import de.chrgroth.spotify.control.domain.model.playback.aggregation.PlaybackAggregation
-import de.chrgroth.spotify.control.domain.model.user.UserId
 import kotlinx.datetime.LocalDate
 
 interface PlaybackAggregationRepositoryPort {
   fun save(aggregation: PlaybackAggregation)
   fun deleteAll()
-  fun findByUserAndPeriod(userId: UserId, type: AggregationPeriodType, periodStart: LocalDate): PlaybackAggregation?
-  fun findByUserAndPeriods(userId: UserId, periods: List<Pair<AggregationPeriodType, LocalDate>>): Map<Pair<AggregationPeriodType, LocalDate>, PlaybackAggregation>
-  fun findByUserTypeAndPeriodRange(userId: UserId, type: AggregationPeriodType, from: LocalDate, to: LocalDate): List<PlaybackAggregation>
-  fun findDailySummaryByUserAndPeriodRange(userId: UserId, from: LocalDate, to: LocalDate): List<DailyPlaybackSummary>
-  fun sumEventCountByUser(userId: UserId): Long
+  fun findByPeriod(type: AggregationPeriodType, periodStart: LocalDate): PlaybackAggregation?
+  fun findByPeriods(periods: List<Pair<AggregationPeriodType, LocalDate>>): Map<Pair<AggregationPeriodType, LocalDate>, PlaybackAggregation>
+  fun findByTypeAndPeriodRange(type: AggregationPeriodType, from: LocalDate, to: LocalDate): List<PlaybackAggregation>
+  fun findDailySummaryByPeriodRange(from: LocalDate, to: LocalDate): List<DailyPlaybackSummary>
+  fun sumEventCount(): Long
 }

--- a/domain-api/src/main/kotlin/de/chrgroth/spotify/control/domain/port/out/playback/PlaybackEventViewerRepositoryPort.kt
+++ b/domain-api/src/main/kotlin/de/chrgroth/spotify/control/domain/port/out/playback/PlaybackEventViewerRepositoryPort.kt
@@ -1,11 +1,10 @@
 package de.chrgroth.spotify.control.domain.port.out.playback
 
 import de.chrgroth.spotify.control.domain.model.playback.RawPlaybackEvent
-import de.chrgroth.spotify.control.domain.model.user.UserId
 import kotlin.time.Instant
 
 interface PlaybackEventViewerRepositoryPort {
-  fun findRecentlyPlayed(userId: UserId, from: Instant, to: Instant): List<RawPlaybackEvent>
-  fun findRecentlyPartialPlayed(userId: UserId, from: Instant, to: Instant): List<RawPlaybackEvent>
-  fun findCurrentlyPlaying(userId: UserId, from: Instant, to: Instant): List<RawPlaybackEvent>
+  fun findRecentlyPlayed(from: Instant, to: Instant): List<RawPlaybackEvent>
+  fun findRecentlyPartialPlayed(from: Instant, to: Instant): List<RawPlaybackEvent>
+  fun findCurrentlyPlaying(from: Instant, to: Instant): List<RawPlaybackEvent>
 }

--- a/domain-api/src/main/kotlin/de/chrgroth/spotify/control/domain/port/out/playback/RecentlyPartialPlayedRepositoryPort.kt
+++ b/domain-api/src/main/kotlin/de/chrgroth/spotify/control/domain/port/out/playback/RecentlyPartialPlayedRepositoryPort.kt
@@ -2,13 +2,12 @@ package de.chrgroth.spotify.control.domain.port.out.playback
 
 import de.chrgroth.spotify.control.domain.model.catalog.TrackId
 import de.chrgroth.spotify.control.domain.model.playback.RecentlyPartialPlayedItem
-import de.chrgroth.spotify.control.domain.model.user.UserId
 import kotlin.time.Instant
 
 interface RecentlyPartialPlayedRepositoryPort {
-  fun findExistingPlayedAts(userId: UserId, playedAts: Set<Instant>): Set<Instant>
-  fun findSince(userId: UserId, since: Instant?): List<RecentlyPartialPlayedItem>
-  fun findByUserIdAndTrackIds(userId: UserId, trackIds: Set<TrackId>): List<RecentlyPartialPlayedItem>
+  fun findExistingPlayedAts(playedAts: Set<Instant>): Set<Instant>
+  fun findSince(since: Instant?): List<RecentlyPartialPlayedItem>
+  fun findByTrackIds(trackIds: Set<TrackId>): List<RecentlyPartialPlayedItem>
   fun saveAll(items: List<RecentlyPartialPlayedItem>)
-  fun deleteByPlayedAts(userId: UserId, playedAts: Set<Instant>)
+  fun deleteByPlayedAts(playedAts: Set<Instant>)
 }

--- a/domain-api/src/main/kotlin/de/chrgroth/spotify/control/domain/port/out/playback/RecentlyPlayedRepositoryPort.kt
+++ b/domain-api/src/main/kotlin/de/chrgroth/spotify/control/domain/port/out/playback/RecentlyPlayedRepositoryPort.kt
@@ -1,13 +1,12 @@
 package de.chrgroth.spotify.control.domain.port.out.playback
 
 import de.chrgroth.spotify.control.domain.model.playback.RecentlyPlayedItem
-import de.chrgroth.spotify.control.domain.model.user.UserId
 import kotlin.time.Instant
 
 interface RecentlyPlayedRepositoryPort {
-  fun findExistingPlayedAts(spotifyUserId: UserId, playedAts: Set<Instant>): Set<Instant>
-  fun findMostRecentPlayedAt(spotifyUserId: UserId): Instant?
-  fun findSince(spotifyUserId: UserId, since: Instant?): List<RecentlyPlayedItem>
+  fun findExistingPlayedAts(playedAts: Set<Instant>): Set<Instant>
+  fun findMostRecentPlayedAt(): Instant?
+  fun findSince(since: Instant?): List<RecentlyPlayedItem>
   fun saveAll(items: List<RecentlyPlayedItem>)
   fun deleteNonTracks(): Long
 }

--- a/domain-api/src/main/kotlin/de/chrgroth/spotify/control/domain/port/out/playlist/PlaylistRepositoryPort.kt
+++ b/domain-api/src/main/kotlin/de/chrgroth/spotify/control/domain/port/out/playlist/PlaylistRepositoryPort.kt
@@ -3,15 +3,14 @@ package de.chrgroth.spotify.control.domain.port.out.playlist
 import de.chrgroth.spotify.control.domain.model.playlist.Playlist
 import de.chrgroth.spotify.control.domain.model.playlist.PlaylistInfo
 import de.chrgroth.spotify.control.domain.model.playlist.PlaylistTrack
-import de.chrgroth.spotify.control.domain.model.user.UserId
 
 interface PlaylistRepositoryPort {
-  fun findByUserId(userId: UserId): List<PlaylistInfo>
-  fun replaceAll(userId: UserId, playlists: List<PlaylistInfo>)
-  fun findByUserIdAndPlaylistId(userId: UserId, playlistId: String): Playlist?
-  fun findTrackCountsByUserId(userId: UserId): Map<String, Int>
-  fun save(userId: UserId, playlist: Playlist)
-  fun appendTracks(userId: UserId, playlistId: String, tracks: List<PlaylistTrack>)
-  fun updateLastSyncTime(userId: UserId, playlistId: String, time: kotlin.time.Instant)
+  fun findAll(): List<PlaylistInfo>
+  fun replaceAll(playlists: List<PlaylistInfo>)
+  fun findByPlaylistId(playlistId: String): Playlist?
+  fun findTrackCounts(): Map<String, Int>
+  fun save(playlist: Playlist)
+  fun appendTracks(playlistId: String, tracks: List<PlaylistTrack>)
+  fun updateLastSyncTime(playlistId: String, time: kotlin.time.Instant)
   fun setAllSyncInactive()
 }

--- a/domain-impl/src/main/kotlin/de/chrgroth/spotify/control/domain/catalog/CatalogBrowserService.kt
+++ b/domain-impl/src/main/kotlin/de/chrgroth/spotify/control/domain/catalog/CatalogBrowserService.kt
@@ -206,8 +206,8 @@ class CatalogBrowserService(
     appArtistRepository.findByArtistIds(setOf(ArtistId(artistId))).firstOrNull()?.artistName ?: artistId
 
   private fun playlistName(playlistId: String): String {
-    val userId = currentUserResolver.userId() ?: return playlistId
-    return playlistRepository.findByUserId(userId).firstOrNull { it.spotifyPlaylistId == playlistId }?.name ?: playlistId
+    currentUserResolver.userId() ?: return playlistId
+    return playlistRepository.findAll().firstOrNull { it.spotifyPlaylistId == playlistId }?.name ?: playlistId
   }
 
   companion object {

--- a/domain-impl/src/main/kotlin/de/chrgroth/spotify/control/domain/catalog/CatalogService.kt
+++ b/domain-impl/src/main/kotlin/de/chrgroth/spotify/control/domain/catalog/CatalogService.kt
@@ -13,7 +13,6 @@ import de.chrgroth.spotify.control.domain.model.catalog.ArtistId
 import de.chrgroth.spotify.control.domain.model.catalog.SyncCause
 import de.chrgroth.spotify.control.domain.model.catalog.SyncTrace
 import de.chrgroth.spotify.control.domain.model.catalog.SyncTraceEntityType
-import de.chrgroth.spotify.control.domain.model.user.UserId
 import de.chrgroth.spotify.control.domain.outbox.DomainOutboxEvent
 import de.chrgroth.spotify.control.domain.port.`in`.catalog.CatalogPort
 import de.chrgroth.spotify.control.domain.port.out.catalog.AppAlbumRepositoryPort
@@ -104,8 +103,8 @@ class CatalogService(
 
   override fun resyncCatalog(): Either<DomainError, Unit> {
     val allArtistIds = appArtistRepository.findAll().map { it.id.value }
-    val userId = currentUserResolver.userId() ?: return Unit.right()
-    val playbackCatalogRequests = buildPlaybackCatalogRequests(userId)
+    currentUserResolver.userId() ?: return Unit.right()
+    val playbackCatalogRequests = buildPlaybackCatalogRequests()
     logger.info { "Re-syncing catalog: ${allArtistIds.size} catalog artist(s), ${playbackCatalogRequests.size} playback track(s)" }
     allArtistIds.forEach { outboxPort.enqueue(DomainOutboxEvent.SyncArtistAlbums(it)) }
     syncController.syncForTracks(playbackCatalogRequests)
@@ -196,20 +195,19 @@ class CatalogService(
   }
 
   override fun enqueuePlaybackArtistsForSync() {
-    val userId = currentUserResolver.userId()
-    if (userId == null) {
+    if (currentUserResolver.userId() == null) {
       logger.warn { "No users available for playback artists sync, skipping" }
       return
     }
-    val playbackCatalogRequests = buildPlaybackCatalogRequests(userId)
+    val playbackCatalogRequests = buildPlaybackCatalogRequests()
     val artistCount = playbackCatalogRequests.flatMap { it.artistIds }.filter { it.isNotBlank() }.distinct().size
     logger.info { "Enqueuing artist sync for $artistCount artist(s) found in playback data" }
     syncController.syncForTracks(playbackCatalogRequests)
   }
 
-  private fun buildPlaybackCatalogRequests(userId: UserId): List<CatalogSyncRequest> {
-    val recentlyPlayed = recentlyPlayedRepository.findSince(userId, null)
-    val partialPlayed = recentlyPartialPlayedRepository.findSince(userId, null)
+  private fun buildPlaybackCatalogRequests(): List<CatalogSyncRequest> {
+    val recentlyPlayed = recentlyPlayedRepository.findSince(null)
+    val partialPlayed = recentlyPartialPlayedRepository.findSince(null)
     return (
       recentlyPlayed.map { buildCatalogSyncRequest(it.trackId.value, it.artistIds) } +
         partialPlayed.map { buildCatalogSyncRequest(it.trackId.value, it.artistIds) }

--- a/domain-impl/src/main/kotlin/de/chrgroth/spotify/control/domain/infra/DashboardService.kt
+++ b/domain-impl/src/main/kotlin/de/chrgroth/spotify/control/domain/infra/DashboardService.kt
@@ -13,7 +13,6 @@ import de.chrgroth.spotify.control.domain.model.playlist.PlaylistSyncStatus
 import de.chrgroth.spotify.control.domain.model.playback.RecentlyPlayedItem
 import de.chrgroth.spotify.control.domain.model.playback.TopEntry
 import de.chrgroth.spotify.control.domain.model.catalog.TrackId
-import de.chrgroth.spotify.control.domain.model.user.UserId
 import de.chrgroth.spotify.control.domain.port.`in`.catalog.CatalogBrowserPort
 import de.chrgroth.spotify.control.domain.port.`in`.infra.DashboardPort
 import de.chrgroth.spotify.control.domain.port.out.catalog.AppAlbumRepositoryPort
@@ -54,12 +53,12 @@ class DashboardService(
 ) : DashboardPort {
 
   override fun getStats(): DashboardStats {
-    val userId = currentUserResolver.userId() ?: return DashboardStats.EMPTY
-    val dailyAggsFuture = managedExecutor.supplyAsync { fetchDailyAggregations(userId) }
-    val totalPlaybackEventsFuture = managedExecutor.supplyAsync { aggregationRepository.sumEventCountByUser(userId) }
-    val playlistMetadataFuture = managedExecutor.supplyAsync { computePlaylistMetadata(userId) }
+    currentUserResolver.userId() ?: return DashboardStats.EMPTY
+    val dailyAggsFuture = managedExecutor.supplyAsync { fetchDailyAggregations() }
+    val totalPlaybackEventsFuture = managedExecutor.supplyAsync { aggregationRepository.sumEventCount() }
+    val playlistMetadataFuture = managedExecutor.supplyAsync { computePlaylistMetadata() }
     val playlistCheckStatsFuture = managedExecutor.supplyAsync { computePlaylistCheckStats() }
-    val recentlyPlayedFuture = managedExecutor.supplyAsync { buildRecentlyPlayedTracks(userId) }
+    val recentlyPlayedFuture = managedExecutor.supplyAsync { buildRecentlyPlayedTracks() }
     val catalogStatsFuture = managedExecutor.supplyAsync { catalogBrowser.getCatalogStats() }
 
     val dailyAggs = dailyAggsFuture.join()
@@ -80,23 +79,23 @@ class DashboardService(
   }
 
   override fun getPlaybackStats(): DashboardStats {
-    val userId = currentUserResolver.userId() ?: return DashboardStats.EMPTY
-    return buildPlaybackStats(fetchDailyAggregations(userId), aggregationRepository.sumEventCountByUser(userId))
+    currentUserResolver.userId() ?: return DashboardStats.EMPTY
+    return buildPlaybackStats(fetchDailyAggregations(), aggregationRepository.sumEventCount())
   }
 
   override fun getPlaylistMetadata(): DashboardStats {
-    val userId = currentUserResolver.userId() ?: return DashboardStats.EMPTY
-    return computePlaylistMetadata(userId)
+    currentUserResolver.userId() ?: return DashboardStats.EMPTY
+    return computePlaylistMetadata()
   }
 
   override fun getRecentlyPlayed(): DashboardStats {
-    val userId = currentUserResolver.userId() ?: return DashboardStats.EMPTY
-    return DashboardStats.EMPTY.copy(recentlyPlayedTracks = buildRecentlyPlayedTracks(userId))
+    currentUserResolver.userId() ?: return DashboardStats.EMPTY
+    return DashboardStats.EMPTY.copy(recentlyPlayedTracks = buildRecentlyPlayedTracks())
   }
 
   override fun getListeningStats(): DashboardStats {
-    val userId = currentUserResolver.userId() ?: return DashboardStats.EMPTY
-    return DashboardStats.EMPTY.copy(listeningStats = buildListeningStats(fetchDailyAggregations(userId)))
+    currentUserResolver.userId() ?: return DashboardStats.EMPTY
+    return DashboardStats.EMPTY.copy(listeningStats = buildListeningStats(fetchDailyAggregations()))
   }
 
   override fun getPlaylistCheckStats(): DashboardStats =
@@ -110,9 +109,9 @@ class DashboardService(
     return (today - DatePeriod(days = STATS_DAYS - 1)) to today
   }
 
-  private fun fetchDailyAggregations(userId: UserId): List<DailyPlaybackSummary> {
+  private fun fetchDailyAggregations(): List<DailyPlaybackSummary> {
     val (from, to) = statsDateRange()
-    return aggregationRepository.findDailySummaryByUserAndPeriodRange(userId, from, to)
+    return aggregationRepository.findDailySummaryByPeriodRange(from, to)
   }
 
   private fun buildPlaybackStats(dailyAggs: List<DailyPlaybackSummary>, total: Long): DashboardStats {
@@ -138,8 +137,8 @@ class DashboardService(
     )
   }
 
-  private fun computePlaylistMetadata(userId: UserId): DashboardStats {
-    val playlists = playlistRepository.findByUserId(userId)
+  private fun computePlaylistMetadata(): DashboardStats {
+    val playlists = playlistRepository.findAll()
     val totalPlaylists = playlists.size.toLong()
     val syncedPlaylists = playlists.count { it.syncStatus == PlaylistSyncStatus.ACTIVE }.toLong()
     return DashboardStats.EMPTY.copy(
@@ -160,8 +159,8 @@ class DashboardService(
     )
   }
 
-  private fun buildRecentlyPlayedTracks(userId: UserId): List<RecentlyPlayedItem> {
-    val recentPlaybackItems = appPlaybackRepository.findRecentlyPlayed(userId, recentlyPlayedLimit)
+  private fun buildRecentlyPlayedTracks(): List<RecentlyPlayedItem> {
+    val recentPlaybackItems = appPlaybackRepository.findRecentlyPlayed(recentlyPlayedLimit)
     val trackIds = recentPlaybackItems.map { it.trackId }.toSet()
     val trackMap = appTrackRepository.findByTrackIds(trackIds.map { TrackId(it) }.toSet()).associateBy { it.id.value }
     val albumIds = trackMap.values.mapNotNull { it.albumId }.toSet()
@@ -177,7 +176,6 @@ class DashboardService(
       val trackArtistIds = track?.allArtistIds() ?: emptyList()
       val album = track?.albumId?.let { albumMap[it.value] }
       RecentlyPlayedItem(
-        spotifyUserId = playback.userId,
         trackId = TrackId(playback.trackId),
         trackName = track?.title ?: playback.trackId,
         artistIds = trackArtistIds.map { ArtistId(it) },

--- a/domain-impl/src/main/kotlin/de/chrgroth/spotify/control/domain/infra/DomainMetrics.kt
+++ b/domain-impl/src/main/kotlin/de/chrgroth/spotify/control/domain/infra/DomainMetrics.kt
@@ -5,7 +5,6 @@ import de.chrgroth.spotify.control.domain.port.out.catalog.AppAlbumRepositoryPor
 import de.chrgroth.spotify.control.domain.port.out.catalog.AppArtistRepositoryPort
 import de.chrgroth.spotify.control.domain.port.out.catalog.AppTrackRepositoryPort
 import de.chrgroth.spotify.control.domain.port.out.playlist.PlaylistRepositoryPort
-import de.chrgroth.spotify.control.domain.port.out.user.UserRepositoryPort
 import io.micrometer.core.instrument.Gauge
 import io.micrometer.core.instrument.MeterRegistry
 import io.quarkus.runtime.StartupEvent
@@ -20,7 +19,6 @@ import mu.KLogging
 @ApplicationScoped
 @Suppress("Unused", "UnusedParameter")
 class DomainMetrics(
-  private val userRepository: UserRepositoryPort,
   private val playlistRepository: PlaylistRepositoryPort,
   private val appArtistRepository: AppArtistRepositoryPort,
   private val appTrackRepository: AppTrackRepositoryPort,
@@ -69,11 +67,9 @@ class DomainMetrics(
   }
 
   private fun outOfSyncPlaylistCount(): Int =
-    userRepository.findAll().sumOf { user ->
-      playlistRepository.findByUserId(user.spotifyUserId).count { playlist ->
-        val lastSyncTime = playlist.lastSyncTime
-        playlist.syncStatus == PlaylistSyncStatus.ACTIVE && (lastSyncTime == null || lastSyncTime < playlist.lastSnapshotIdSyncTime)
-      }
+    playlistRepository.findAll().count { playlist ->
+      val lastSyncTime = playlist.lastSyncTime
+      playlist.syncStatus == PlaylistSyncStatus.ACTIVE && (lastSyncTime == null || lastSyncTime < playlist.lastSnapshotIdSyncTime)
     }
 
   companion object : KLogging()

--- a/domain-impl/src/main/kotlin/de/chrgroth/spotify/control/domain/infra/OverviewMetrics.kt
+++ b/domain-impl/src/main/kotlin/de/chrgroth/spotify/control/domain/infra/OverviewMetrics.kt
@@ -37,9 +37,7 @@ class OverviewMetrics(
   private fun activeUserCount(): Int = userRepository.findAll().size
 
   private fun trackedPlaylistCount(): Int =
-    userRepository.findAll().sumOf { user ->
-      playlistRepository.findByUserId(user.spotifyUserId).count { it.syncStatus == PlaylistSyncStatus.ACTIVE }
-    }
+    playlistRepository.findAll().count { it.syncStatus == PlaylistSyncStatus.ACTIVE }
 
   private fun pendingAlbumUpgradeCount(): Int =
     playlistCheckRepository.findAll().count { !it.succeeded && it.checkId.endsWith(":$ALBUM_UPGRADE_CHECK_ID") }

--- a/domain-impl/src/main/kotlin/de/chrgroth/spotify/control/domain/playback/PlaybackAggregationService.kt
+++ b/domain-impl/src/main/kotlin/de/chrgroth/spotify/control/domain/playback/PlaybackAggregationService.kt
@@ -10,7 +10,6 @@ import de.chrgroth.spotify.control.domain.model.playback.aggregation.ActivityTim
 import de.chrgroth.spotify.control.domain.model.playback.aggregation.AggregationPeriodType
 import de.chrgroth.spotify.control.domain.model.playback.aggregation.AggregationRankEntry
 import de.chrgroth.spotify.control.domain.model.playback.aggregation.PlaybackAggregation
-import de.chrgroth.spotify.control.domain.model.user.UserId
 import de.chrgroth.spotify.control.domain.outbox.DomainOutboxEvent
 import de.chrgroth.spotify.control.domain.port.`in`.playback.PlaybackAggregationPort
 import de.chrgroth.spotify.control.domain.port.out.catalog.AppArtistRepositoryPort
@@ -167,20 +166,20 @@ class PlaybackAggregationService(
   // --- Outbox handler ---
 
   override fun handle(event: DomainOutboxEvent.AggregatePlaybackData): Either<DomainError, Unit> {
-    val userId = currentUserResolver.userId() ?: return Unit.right()
+    currentUserResolver.userId() ?: return Unit.right()
     when (event.type) {
-      AggregationPeriodType.DAY -> aggregateDay(userId, event.periodStart)
+      AggregationPeriodType.DAY -> aggregateDay(event.periodStart)
       AggregationPeriodType.WEEK -> aggregateFromDailyAggregations(
-        userId, AggregationPeriodType.WEEK, event.periodStart, event.periodStart.plusKDays(DAYS_IN_WEEK),
+        AggregationPeriodType.WEEK, event.periodStart, event.periodStart.plusKDays(DAYS_IN_WEEK),
       )
       AggregationPeriodType.MONTH -> aggregateFromDailyAggregations(
-        userId, AggregationPeriodType.MONTH, event.periodStart, event.periodStart.endOfMonth(),
+        AggregationPeriodType.MONTH, event.periodStart, event.periodStart.endOfMonth(),
       )
       AggregationPeriodType.QUARTER -> aggregateFromDailyAggregations(
-        userId, AggregationPeriodType.QUARTER, event.periodStart, event.periodStart.plusKMonths(MONTHS_PER_QUARTER).minusKDays(1),
+        AggregationPeriodType.QUARTER, event.periodStart, event.periodStart.plusKMonths(MONTHS_PER_QUARTER).minusKDays(1),
       )
       AggregationPeriodType.YEAR -> aggregateFromDailyAggregations(
-        userId, AggregationPeriodType.YEAR, event.periodStart, event.periodStart.plusKMonths(MONTHS_PER_YEAR).minusKDays(1),
+        AggregationPeriodType.YEAR, event.periodStart, event.periodStart.plusKMonths(MONTHS_PER_YEAR).minusKDays(1),
       )
     }
     recordAggregationSuccess(event.type)
@@ -201,14 +200,14 @@ class PlaybackAggregationService(
 
   // --- Aggregation logic ---
 
-  private fun aggregateDay(userId: UserId, date: LocalDate) {
+  private fun aggregateDay(date: LocalDate) {
     val javaDate = date.toJavaLocalDate()
     val from = Instant.fromEpochMilliseconds(javaDate.atStartOfDay(ZoneOffset.UTC).toInstant().toEpochMilli())
     val to = Instant.fromEpochMilliseconds(javaDate.plusDays(1).atStartOfDay(ZoneOffset.UTC).toInstant().toEpochMilli())
 
-    val items = appPlaybackRepository.findAllBetween(userId, from, to)
+    val items = appPlaybackRepository.findAllBetween(from, to)
     if (items.isEmpty()) {
-      aggregationRepository.save(emptyAggregation(userId, AggregationPeriodType.DAY, date))
+      aggregationRepository.save(emptyAggregation(AggregationPeriodType.DAY, date))
       return
     }
 
@@ -225,7 +224,7 @@ class PlaybackAggregationService(
     }
 
     if (filteredItems.isEmpty()) {
-      aggregationRepository.save(emptyAggregation(userId, AggregationPeriodType.DAY, date))
+      aggregationRepository.save(emptyAggregation(AggregationPeriodType.DAY, date))
       return
     }
 
@@ -233,7 +232,6 @@ class PlaybackAggregationService(
     val activityEntries = buildActivityEntries(filteredItems)
 
     val aggregation = PlaybackAggregation(
-      userId = userId,
       type = AggregationPeriodType.DAY,
       periodStart = date,
       totalPlaybackSeconds = filteredItems.sumOf { it.secondsPlayed },
@@ -249,10 +247,10 @@ class PlaybackAggregationService(
     aggregationRepository.save(aggregation)
   }
 
-  private fun aggregateFromDailyAggregations(userId: UserId, type: AggregationPeriodType, from: LocalDate, to: LocalDate) {
-    val dailyAggregations = aggregationRepository.findByUserTypeAndPeriodRange(userId, AggregationPeriodType.DAY, from, to)
+  private fun aggregateFromDailyAggregations(type: AggregationPeriodType, from: LocalDate, to: LocalDate) {
+    val dailyAggregations = aggregationRepository.findByTypeAndPeriodRange(AggregationPeriodType.DAY, from, to)
     if (dailyAggregations.isEmpty()) {
-      aggregationRepository.save(emptyAggregation(userId, type, from))
+      aggregationRepository.save(emptyAggregation(type, from))
       return
     }
 
@@ -280,7 +278,6 @@ class PlaybackAggregationService(
     // a full year of daily entries can produce documents with one rank entry per distinct track/artist/album ever
     // played in that period, which made a single findByUserAndPeriod lookup of such a document slow.
     val aggregation = PlaybackAggregation(
-      userId = userId,
       type = type,
       periodStart = from,
       totalPlaybackSeconds = dailyAggregations.sumOf { it.totalPlaybackSeconds },
@@ -334,8 +331,7 @@ class PlaybackAggregationService(
       ActivityEntry(dayOfWeek = key.first, timeWindow = key.second, totalSeconds = entries.sumOf { it.secondsPlayed })
     }
 
-  private fun emptyAggregation(userId: UserId, type: AggregationPeriodType, periodStart: LocalDate): PlaybackAggregation = PlaybackAggregation(
-    userId = userId,
+  private fun emptyAggregation(type: AggregationPeriodType, periodStart: LocalDate): PlaybackAggregation = PlaybackAggregation(
     type = type,
     periodStart = periodStart,
     totalPlaybackSeconds = 0L,

--- a/domain-impl/src/main/kotlin/de/chrgroth/spotify/control/domain/playback/PlaybackEventViewerService.kt
+++ b/domain-impl/src/main/kotlin/de/chrgroth/spotify/control/domain/playback/PlaybackEventViewerService.kt
@@ -29,16 +29,16 @@ class PlaybackEventViewerService(
   override fun getEvents(date: LocalDate): PlaybackEventViewerResult {
     val tz = TimeZone.currentSystemDefault()
     val isToday = date == Clock.System.now().toLocalDateTime(tz).date
-    val userId = currentUserResolver.userId() ?: return PlaybackEventViewerResult(date = date, isToday = isToday, events = emptyList())
+    currentUserResolver.userId() ?: return PlaybackEventViewerResult(date = date, isToday = isToday, events = emptyList())
     val from = date.atStartOfDayIn(tz)
     val to = date.plus(DatePeriod(days = 1)).atStartOfDayIn(tz)
 
-    val rawCurrentlyPlaying = repository.findCurrentlyPlaying(userId, from, to)
+    val rawCurrentlyPlaying = repository.findCurrentlyPlaying(from, to)
     val latestCurrentlyPlayingTimestamp = if (isToday) rawCurrentlyPlaying.maxByOrNull { it.timestamp }?.timestamp else null
 
     val allEvents = (
-      repository.findRecentlyPlayed(userId, from, to).map { it.toEntry(PlaybackEventType.RECENTLY_PLAYED, false) } +
-        repository.findRecentlyPartialPlayed(userId, from, to).map { it.toEntry(PlaybackEventType.RECENTLY_PARTIAL_PLAYED, false) } +
+      repository.findRecentlyPlayed(from, to).map { it.toEntry(PlaybackEventType.RECENTLY_PLAYED, false) } +
+        repository.findRecentlyPartialPlayed(from, to).map { it.toEntry(PlaybackEventType.RECENTLY_PARTIAL_PLAYED, false) } +
         rawCurrentlyPlaying.map { it.toEntry(PlaybackEventType.CURRENTLY_PLAYING, it.timestamp != latestCurrentlyPlayingTimestamp) }
       ).sortedByDescending { it.timestamp }
 

--- a/domain-impl/src/main/kotlin/de/chrgroth/spotify/control/domain/playback/PlaybackService.kt
+++ b/domain-impl/src/main/kotlin/de/chrgroth/spotify/control/domain/playback/PlaybackService.kt
@@ -83,18 +83,17 @@ class PlaybackService(
 
   internal fun fetchCurrentlyPlaying(userId: UserId): Either<DomainError, Unit> {
     val accessToken = spotifyAccessToken.getValidAccessToken()
-    return spotifyPlayback.getCurrentlyPlaying(accessToken).flatMap { rawItem ->
-      val item = rawItem?.copy(spotifyUserId = userId)
+    return spotifyPlayback.getCurrentlyPlaying(accessToken).flatMap { item ->
       if (item != null && item.isPlaying) {
         playbackState.onPlaybackDetected()
       }
       val orphanedItemsConverted = if (item != null) {
-        val existing = currentlyPlayingRepository.findMostRecentByUserAndTrack(userId, item.trackId)
+        val existing = currentlyPlayingRepository.findMostRecentByTrack(item.trackId)
         if (existing != null && !isTrackRestart(item, existing)) {
           currentlyPlayingRepository.updateProgress(item.copy(startTime = existing.startTime))
         } else {
           if (existing != null) {
-            currentlyPlayingRepository.deleteByUserIdAndTrackIds(userId, setOf(item.trackId.value))
+            currentlyPlayingRepository.deleteByTrackIds(setOf(item.trackId.value))
           }
           currentlyPlayingRepository.save(item)
         }
@@ -114,7 +113,7 @@ class PlaybackService(
     newItem.progressMs < RESTART_THRESHOLD_MS && existingItem.progressMs > minimumProgressMs
 
   private fun convertAndDeleteOrphanedItems(userId: UserId, currentTrackId: TrackId?): Boolean {
-    val orphanedItems = currentlyPlayingRepository.findByUserId(userId)
+    val orphanedItems = currentlyPlayingRepository.findAll()
       .let { items -> if (currentTrackId != null) items.filter { it.trackId != currentTrackId } else items }
     if (orphanedItems.isEmpty()) return false
 
@@ -123,7 +122,6 @@ class PlaybackService(
       val partialItems = convertibleItems.map { item ->
         val playedMs = minOf(item.progressMs, item.durationMs)
         RecentlyPartialPlayedItem(
-          spotifyUserId = userId,
           trackId = item.trackId,
           trackName = item.trackName,
           artistIds = item.artistIds,
@@ -134,7 +132,7 @@ class PlaybackService(
           albumId = item.albumId,
         )
       }
-      val existingPlayedAts = recentlyPartialPlayedRepository.findExistingPlayedAts(userId, partialItems.map { it.playedAt }.toSet())
+      val existingPlayedAts = recentlyPartialPlayedRepository.findExistingPlayedAts(partialItems.map { it.playedAt }.toSet())
       val newPartial = partialItems.filter { it.playedAt !in existingPlayedAts }
       if (newPartial.isNotEmpty()) {
         recentlyPartialPlayedRepository.saveAll(newPartial)
@@ -146,7 +144,7 @@ class PlaybackService(
     }
 
     val orphanedTrackIds = orphanedItems.map { it.trackId.value }.toSet()
-    currentlyPlayingRepository.deleteByUserIdAndTrackIds(userId, orphanedTrackIds)
+    currentlyPlayingRepository.deleteByTrackIds(orphanedTrackIds)
     return newPartialSaved
   }
 
@@ -154,16 +152,15 @@ class PlaybackService(
 
   internal fun fetchRecentlyPlayed(userId: UserId): Either<DomainError, Unit> {
     val accessToken = spotifyAccessToken.getValidAccessToken()
-    val after = recentlyPlayedRepository.findMostRecentPlayedAt(userId)
-    return spotifyPlayback.getRecentlyPlayed(accessToken, after).flatMap { rawTracks ->
-      val tracks = rawTracks.map { it.copy(spotifyUserId = userId) }
+    val after = recentlyPlayedRepository.findMostRecentPlayedAt()
+    return spotifyPlayback.getRecentlyPlayed(accessToken, after).flatMap { tracks ->
       val playedAts = tracks.map { it.playedAt }.toSet()
-      val existingPlayedAts = recentlyPlayedRepository.findExistingPlayedAts(userId, playedAts)
+      val existingPlayedAts = recentlyPlayedRepository.findExistingPlayedAts(playedAts)
       val newItems = tracks.filter { it.playedAt !in existingPlayedAts }
       if (newItems.isNotEmpty()) {
         recentlyPlayedRepository.saveAll(newItems)
         recordEventsIngested(userId, "recently_played", newItems.size)
-        deduplicateWithPartialPlays(userId, newItems)
+        deduplicateWithPartialPlays(newItems)
       }
       val computedCount = convertPartialPlays(userId, tracks.map { it.trackId }.toSet())
       if (newItems.isNotEmpty() || computedCount > 0) {
@@ -193,12 +190,12 @@ class PlaybackService(
     meterRegistry.counter("app.playback.events_ingested", "userId", userId.value, "source", source).increment(count.toDouble())
   }
 
-  private fun deduplicateWithPartialPlays(userId: UserId, newRecentlyPlayedItems: List<RecentlyPlayedItem>) {
+  private fun deduplicateWithPartialPlays(newRecentlyPlayedItems: List<RecentlyPlayedItem>) {
     val recentlyPlayedWithStartTime = newRecentlyPlayedItems.filter { it.startTime != null }
     if (recentlyPlayedWithStartTime.isEmpty()) return
 
     val trackIds = recentlyPlayedWithStartTime.map { it.trackId }.toSet()
-    val partialPlays = recentlyPartialPlayedRepository.findByUserIdAndTrackIds(userId, trackIds)
+    val partialPlays = recentlyPartialPlayedRepository.findByTrackIds(trackIds)
     if (partialPlays.isEmpty()) return
 
     val duplicatePlayedAts = mutableSetOf<Instant>()
@@ -213,8 +210,8 @@ class PlaybackService(
     }
 
     if (duplicatePlayedAts.isNotEmpty()) {
-      recentlyPartialPlayedRepository.deleteByPlayedAts(userId, duplicatePlayedAts)
-      appPlaybackRepository.deleteByUserAndPlayedAts(userId, duplicatePlayedAts)
+      recentlyPartialPlayedRepository.deleteByPlayedAts(duplicatePlayedAts)
+      appPlaybackRepository.deleteByPlayedAts(duplicatePlayedAts)
       duplicatePlayedAts
         .map { instant -> JLocalDate.ofInstant(instant.toJavaInstant(), ZoneOffset.UTC).toKotlinLocalDate() }
         .toSet()
@@ -225,7 +222,7 @@ class PlaybackService(
   }
 
   private fun convertPartialPlays(userId: UserId, completedTrackIds: Set<TrackId>): Int {
-    val sortedItems = currentlyPlayingRepository.findByUserId(userId).sortedBy { it.observedAt }
+    val sortedItems = currentlyPlayingRepository.findAll().sortedBy { it.observedAt }
 
     // The single latest item is protected — it may still be active
     val latestItem = sortedItems.lastOrNull()
@@ -239,7 +236,6 @@ class PlaybackService(
       val partialItems = convertibleItems.map { item ->
         val playedMs = minOf(item.progressMs, item.durationMs)
         RecentlyPartialPlayedItem(
-          spotifyUserId = userId,
           trackId = item.trackId,
           trackName = item.trackName,
           artistIds = item.artistIds,
@@ -250,7 +246,7 @@ class PlaybackService(
           albumId = item.albumId,
         )
       }
-      val existingPlayedAts = recentlyPartialPlayedRepository.findExistingPlayedAts(userId, partialItems.map { it.playedAt }.toSet())
+      val existingPlayedAts = recentlyPartialPlayedRepository.findExistingPlayedAts(partialItems.map { it.playedAt }.toSet())
       val newPartial = partialItems.filter { it.playedAt !in existingPlayedAts }
       if (newPartial.isNotEmpty()) {
         recentlyPartialPlayedRepository.saveAll(newPartial)
@@ -264,7 +260,7 @@ class PlaybackService(
     // Delete completed tracks and all processed items (converted or skipped below threshold),
     // but don't delete the latest item's trackId as it may still be active
     val allProcessedTrackIds = itemsToProcess.map { it.trackId }.filter { it != latestItem?.trackId }.toSet()
-    currentlyPlayingRepository.deleteByUserIdAndTrackIds(userId, (completedTrackIds + allProcessedTrackIds).map { it.value }.toSet())
+    currentlyPlayingRepository.deleteByTrackIds((completedTrackIds + allProcessedTrackIds).map { it.value }.toSet())
     return newComputedCount
   }
 
@@ -279,27 +275,24 @@ class PlaybackService(
   override fun rebuildPlaybackData() {
     val userId = currentUserResolver.userId() ?: return
     logger.info { "Rebuilding playback data for user: ${userDisplayName(userId)}" }
-    appPlaybackRepository.deleteAllByUserId(userId)
-    appendPlaybackDataForUser(userId)
+    appPlaybackRepository.deleteAll()
+    appendPlaybackDataForUser()
   }
 
   override fun appendPlaybackData() {
-    val userId = currentUserResolver.userId() ?: return
-    appendPlaybackDataForUser(userId)
+    currentUserResolver.userId() ?: return
+    appendPlaybackDataForUser()
   }
 
-  private fun appendPlaybackDataForUser(userId: UserId) {
-    val since = appPlaybackRepository.findMostRecentPlayedAt(userId)
-    val recentlyPlayed = recentlyPlayedRepository.findSince(userId, since)
-    val partialPlayed = recentlyPartialPlayedRepository.findSince(userId, since)
+  private fun appendPlaybackDataForUser() {
+    val since = appPlaybackRepository.findMostRecentPlayedAt()
+    val recentlyPlayed = recentlyPlayedRepository.findSince(since)
+    val partialPlayed = recentlyPartialPlayedRepository.findSince(since)
 
     val allPlaybackItems = buildPlaybackItems(recentlyPlayed, partialPlayed)
     if (allPlaybackItems.isEmpty()) return
 
-    val existingPlayedAts = appPlaybackRepository.findExistingPlayedAts(
-      userId = userId,
-      playedAts = allPlaybackItems.map { it.playedAt }.toSet(),
-    )
+    val existingPlayedAts = appPlaybackRepository.findExistingPlayedAts(allPlaybackItems.map { it.playedAt }.toSet())
     val newPlaybackItems = allPlaybackItems.filter { it.playedAt !in existingPlayedAts }
     if (newPlaybackItems.isEmpty()) return
 
@@ -324,14 +317,12 @@ class PlaybackService(
     partialPlayed: List<RecentlyPartialPlayedItem>,
   ) = recentlyPlayed.map { item ->
     AppPlaybackItem(
-      userId = item.spotifyUserId,
       playedAt = item.playedAt,
       trackId = item.trackId.value,
       secondsPlayed = item.durationSeconds ?: 0L,
     )
   } + partialPlayed.map { item ->
     AppPlaybackItem(
-      userId = item.spotifyUserId,
       playedAt = item.playedAt,
       trackId = item.trackId.value,
       secondsPlayed = item.playedSeconds,

--- a/domain-impl/src/main/kotlin/de/chrgroth/spotify/control/domain/playlist/PlaylistCheckService.kt
+++ b/domain-impl/src/main/kotlin/de/chrgroth/spotify/control/domain/playlist/PlaylistCheckService.kt
@@ -43,14 +43,14 @@ class PlaylistCheckService(
 ) : PlaylistCheckPort {
 
   override fun handle(event: DomainOutboxEvent.RunPlaylistChecks): Either<DomainError, Unit> {
-    val userId = currentUserResolver.userId() ?: return Unit.right()
-    val playlist = playlistRepository.findByUserIdAndPlaylistId(userId, event.playlistId)
+    currentUserResolver.userId() ?: return Unit.right()
+    val playlist = playlistRepository.findByPlaylistId(event.playlistId)
     if (playlist == null) {
-      logger.warn { "Playlist ${event.playlistId} not found for user ${userId.value}, skipping checks" }
+      logger.warn { "Playlist ${event.playlistId} not found, skipping checks" }
       return Unit.right()
     }
 
-    val allPlaylistInfos = playlistRepository.findByUserId(userId)
+    val allPlaylistInfos = playlistRepository.findAll()
     val currentPlaylistInfo = allPlaylistInfos.find { it.spotifyPlaylistId == event.playlistId }
 
     val applicableRunners = checkRunners.filter { it.isApplicable(currentPlaylistInfo) }
@@ -58,7 +58,7 @@ class PlaylistCheckService(
       .map { runner ->
         managedExecutor.supplyAsync {
           timedCheck(runner.checkId, event.playlistId) {
-            runner.run(userId, event.playlistId, playlist, currentPlaylistInfo, allPlaylistInfos)
+            runner.run(event.playlistId, playlist, currentPlaylistInfo, allPlaylistInfos)
           }
         }
       }
@@ -72,7 +72,7 @@ class PlaylistCheckService(
 
     val totalViolations = results.sumOf { it.violations.size }
     val status = if (totalViolations == 0) "all passed" else "$totalViolations violation(s)"
-    logger.info { "Ran playlist checks for playlist ${event.playlistId} (user ${userId.value}): $status" }
+    logger.info { "Ran playlist checks for playlist ${event.playlistId}: $status" }
     dashboardRefresh.notifyUserPlaylistChecks()
     return Unit.right()
   }
@@ -87,7 +87,7 @@ class PlaylistCheckService(
     )
     val displayNameFuture = managedExecutor.supplyAsync { userRepository.findById(userId)?.displayName ?: userId.value }
     val playlistNamesFuture = managedExecutor.supplyAsync {
-      playlistRepository.findByUserId(userId).associateBy({ it.spotifyPlaylistId }, { it.name })
+      playlistRepository.findAll().associateBy({ it.spotifyPlaylistId }, { it.name })
     }
     val checksFuture = managedExecutor.supplyAsync { playlistCheckRepository.findAll() }
     val displayName = displayNameFuture.join()
@@ -109,20 +109,20 @@ class PlaylistCheckService(
     checkRunners.filter { it.canFix() }.map { it.checkId }.toSet()
 
   override fun runFix(playlistId: String, checkType: String): Either<DomainError, Unit> {
-    val userId = currentUserResolver.userId() ?: return PlaylistFixError.PLAYLIST_NOT_FOUND.left()
+    currentUserResolver.userId() ?: return PlaylistFixError.PLAYLIST_NOT_FOUND.left()
     val runner = checkRunners.find { it.checkId == checkType && it.canFix() } ?: run {
       logger.warn { "No fix runner found for checkType $checkType" }
       return PlaylistFixError.FIX_NOT_FOUND.left()
     }
-    val playlist = playlistRepository.findByUserIdAndPlaylistId(userId, playlistId) ?: run {
-      logger.warn { "Playlist $playlistId not found for user ${userId.value}" }
+    val playlist = playlistRepository.findByPlaylistId(playlistId) ?: run {
+      logger.warn { "Playlist $playlistId not found" }
       return PlaylistFixError.PLAYLIST_NOT_FOUND.left()
     }
-    val allPlaylistInfos = playlistRepository.findByUserId(userId)
+    val allPlaylistInfos = playlistRepository.findAll()
     val currentPlaylistInfo = allPlaylistInfos.find { it.spotifyPlaylistId == playlistId }
     val accessToken = spotifyAccessToken.getValidAccessToken()
-    logger.info { "Running fix '$checkType' for playlist $playlistId (user ${userId.value})" }
-    return runner.fix(userId, accessToken, playlistId, playlist, currentPlaylistInfo, allPlaylistInfos).also { result ->
+    logger.info { "Running fix '$checkType' for playlist $playlistId" }
+    return runner.fix(accessToken, playlistId, playlist, currentPlaylistInfo, allPlaylistInfos).also { result ->
       if (result.isRight()) {
         logger.info { "Fix '$checkType' for playlist $playlistId completed, enqueueing re-check" }
         outboxPort.enqueue(DomainOutboxEvent.SyncPlaylistData(playlistId))

--- a/domain-impl/src/main/kotlin/de/chrgroth/spotify/control/domain/playlist/PlaylistService.kt
+++ b/domain-impl/src/main/kotlin/de/chrgroth/spotify/control/domain/playlist/PlaylistService.kt
@@ -58,13 +58,13 @@ class PlaylistService(
   }
 
   override fun getPlaylists(): List<PlaylistInfo> {
-    val userId = currentUserResolver.userId() ?: return emptyList()
-    return playlistRepository.findByUserId(userId)
+    currentUserResolver.userId() ?: return emptyList()
+    return playlistRepository.findAll()
   }
 
   override fun getTrackCounts(): Map<String, Int> {
-    val userId = currentUserResolver.userId() ?: return emptyMap()
-    return playlistRepository.findTrackCountsByUserId(userId)
+    currentUserResolver.userId() ?: return emptyMap()
+    return playlistRepository.findTrackCounts()
   }
 
   override fun enqueueUpdates() {
@@ -78,7 +78,7 @@ class PlaylistService(
     val accessToken = spotifyAccessToken.getValidAccessToken()
     return spotifyPlaylist.getPlaylists(accessToken).map { spotifyPlaylists ->
       val now = Clock.System.now()
-      val existingById = playlistRepository.findByUserId(userId).associateBy { it.spotifyPlaylistId }
+      val existingById = playlistRepository.findAll().associateBy { it.spotifyPlaylistId }
       val updatedPlaylists = spotifyPlaylists.filter { it.ownerId == userId.value }.map { item ->
         val existing = existingById[item.id]
         PlaylistInfo(
@@ -90,7 +90,7 @@ class PlaylistService(
           type = existing?.type,
         )
       }
-      playlistRepository.replaceAll(userId, updatedPlaylists)
+      playlistRepository.replaceAll(updatedPlaylists)
       if (updatedPlaylists.size != existingById.size) {
         dashboardRefresh.notifyUserPlaylistMetadata()
       }
@@ -100,7 +100,7 @@ class PlaylistService(
           val existing = existingById[playlist.spotifyPlaylistId]
           existing == null ||
             existing.snapshotId != playlist.snapshotId ||
-            playlistRepository.findByUserIdAndPlaylistId(userId, playlist.spotifyPlaylistId) == null
+            playlistRepository.findByPlaylistId(playlist.spotifyPlaylistId) == null
         }
         .forEach { playlist ->
           outboxPort.enqueue(DomainOutboxEvent.SyncPlaylistData(playlist.spotifyPlaylistId))
@@ -119,9 +119,9 @@ class PlaylistService(
         return@map
       }
       if (isFirstPage) {
-        playlistRepository.save(userId, Playlist(playlistId, page.tracks))
+        playlistRepository.save(Playlist(playlistId, page.tracks))
       } else {
-        playlistRepository.appendTracks(userId, playlistId, page.tracks)
+        playlistRepository.appendTracks(playlistId, page.tracks)
       }
 
       val catalogRequests = page.tracks.map {
@@ -133,7 +133,7 @@ class PlaylistService(
         outboxPort.enqueue(DomainOutboxEvent.SyncPlaylistData(playlistId, page.nextUrl, page.snapshotId))
       } else {
         logger.info { "Completed all pages for playlist $playlistId (user ${userDisplayName(userId)})" }
-        playlistRepository.updateLastSyncTime(userId, playlistId, Clock.System.now())
+        playlistRepository.updateLastSyncTime(playlistId, Clock.System.now())
         outboxPort.enqueue(DomainOutboxEvent.RunPlaylistChecks(playlistId))
       }
     }
@@ -141,7 +141,7 @@ class PlaylistService(
 
   override fun updateSyncStatus(playlistId: String, syncStatus: PlaylistSyncStatus): Either<DomainError, Unit> {
     val userId = currentUserResolver.userId() ?: return PlaylistSyncError.PLAYLIST_NOT_FOUND.left()
-    val playlists = playlistRepository.findByUserId(userId)
+    val playlists = playlistRepository.findAll()
     val playlist = playlists.find { it.spotifyPlaylistId == playlistId }
       ?: return PlaylistSyncError.PLAYLIST_NOT_FOUND.left()
     val updatedPlaylists = playlists.map {
@@ -160,7 +160,7 @@ class PlaylistService(
       }
     }
     logger.info { "Updated sync status for playlist '${playlist.name}' ($playlistId, user ${userDisplayName(userId)}) to $syncStatus" }
-    playlistRepository.replaceAll(userId, updatedPlaylists)
+    playlistRepository.replaceAll(updatedPlaylists)
     dashboardRefresh.notifyUserPlaylistMetadata()
     if (syncStatus == PlaylistSyncStatus.PASSIVE) {
       logger.info { "Deleting checks for deactivated playlist '${playlist.name}' ($playlistId, user ${userDisplayName(userId)})" }
@@ -174,21 +174,21 @@ class PlaylistService(
 
   override fun updatePlaylistType(playlistId: String, type: PlaylistType): Either<DomainError, Unit> {
     val userId = currentUserResolver.userId() ?: return PlaylistSyncError.PLAYLIST_NOT_FOUND.left()
-    val validationError = validatePlaylistTypeUpdate(userId, playlistId, type)
+    val validationError = validatePlaylistTypeUpdate(playlistId, type)
     if (validationError != null) return validationError.left()
-    val playlists = playlistRepository.findByUserId(userId)
+    val playlists = playlistRepository.findAll()
     val updatedPlaylists = playlists.map {
       if (it.spotifyPlaylistId == playlistId) it.copy(type = type) else it
     }
     val playlistName = playlists.find { it.spotifyPlaylistId == playlistId }?.name ?: playlistId
     logger.info { "Updated type for playlist '$playlistName' ($playlistId, user ${userDisplayName(userId)}) to $type" }
-    playlistRepository.replaceAll(userId, updatedPlaylists)
+    playlistRepository.replaceAll(updatedPlaylists)
     dashboardRefresh.notifyUserPlaylistMetadata()
     return Unit.right()
   }
 
-  private fun validatePlaylistTypeUpdate(userId: UserId, playlistId: String, type: PlaylistType): PlaylistSyncError? {
-    val playlists = playlistRepository.findByUserId(userId)
+  private fun validatePlaylistTypeUpdate(playlistId: String, type: PlaylistType): PlaylistSyncError? {
+    val playlists = playlistRepository.findAll()
     val playlist = playlists.find { it.spotifyPlaylistId == playlistId }
     return when {
       playlist == null -> PlaylistSyncError.PLAYLIST_NOT_FOUND
@@ -202,14 +202,14 @@ class PlaylistService(
   }
 
   override fun enqueueSyncPlaylistData(playlistId: String): Either<DomainError, Unit> {
-    val userId = currentUserResolver.userId() ?: return PlaylistSyncError.PLAYLIST_NOT_FOUND.left()
-    val playlists = playlistRepository.findByUserId(userId)
+    currentUserResolver.userId() ?: return PlaylistSyncError.PLAYLIST_NOT_FOUND.left()
+    val playlists = playlistRepository.findAll()
     val playlist = playlists.find { it.spotifyPlaylistId == playlistId }
       ?: return PlaylistSyncError.PLAYLIST_NOT_FOUND.left()
     return if (playlist.syncStatus != PlaylistSyncStatus.ACTIVE) {
       PlaylistSyncError.PLAYLIST_SYNC_INACTIVE.left()
     } else {
-      logger.info { "Enqueueing SyncPlaylistData for playlist '${playlist.name}' ($playlistId, user ${userDisplayName(userId)})" }
+      logger.info { "Enqueueing SyncPlaylistData for playlist '${playlist.name}' ($playlistId)" }
       outboxPort.enqueue(DomainOutboxEvent.SyncPlaylistData(playlistId))
       Unit.right()
     }

--- a/domain-impl/src/main/kotlin/de/chrgroth/spotify/control/domain/playlist/check/DuplicateTrackIdsCheckRunner.kt
+++ b/domain-impl/src/main/kotlin/de/chrgroth/spotify/control/domain/playlist/check/DuplicateTrackIdsCheckRunner.kt
@@ -9,7 +9,6 @@ import de.chrgroth.spotify.control.domain.model.playlist.Playlist
 import de.chrgroth.spotify.control.domain.model.playlist.PlaylistId
 import de.chrgroth.spotify.control.domain.model.playlist.PlaylistInfo
 import de.chrgroth.spotify.control.domain.model.user.AccessToken
-import de.chrgroth.spotify.control.domain.model.user.UserId
 import de.chrgroth.spotify.control.domain.port.out.catalog.AppTrackRepositoryPort
 import de.chrgroth.spotify.control.domain.port.out.playlist.SpotifyPlaylistPort
 import io.micrometer.core.instrument.MeterRegistry
@@ -28,7 +27,7 @@ class DuplicateTrackIdsCheckRunner(
   override val checkId = "duplicate-track-ids"
   override val displayName = "Duplicate Track IDs"
 
-  override fun run(userId: UserId, playlistId: String, playlist: Playlist, currentPlaylistInfo: PlaylistInfo?, allPlaylistInfos: List<PlaylistInfo>): AppPlaylistCheck {
+  override fun run(playlistId: String, playlist: Playlist, currentPlaylistInfo: PlaylistInfo?, allPlaylistInfos: List<PlaylistInfo>): AppPlaylistCheck {
     val countByTrackId = playlist.tracks.groupingBy { it.trackId }.eachCount()
     val duplicateTrackIds = playlist.tracks
       .distinctBy { it.trackId }
@@ -56,7 +55,6 @@ class DuplicateTrackIdsCheckRunner(
   override fun canFix(): Boolean = true
 
   override fun fix(
-    userId: UserId,
     accessToken: AccessToken,
     playlistId: String,
     playlist: Playlist,
@@ -68,7 +66,7 @@ class DuplicateTrackIdsCheckRunner(
     if (duplicateTrackIds.isEmpty()) {
       return Unit.right()
     }
-    logger.info { "Removing all occurrences of ${duplicateTrackIds.size} duplicate track(s) from playlist $playlistId (user ${userId.value}), then re-adding once each" }
+    logger.info { "Removing all occurrences of ${duplicateTrackIds.size} duplicate track(s) from playlist $playlistId, then re-adding once each" }
     return spotifyPlaylist.removePlaylistTracks(accessToken, playlistId, duplicateTrackIds)
       .flatMap { spotifyPlaylist.addPlaylistTracks(accessToken, playlistId, duplicateTrackIds) }
       .onRight { meterRegistry.counter("app.playlist.duplicates_removed", "playlistId", playlistId).increment(duplicateTrackIds.size.toDouble()) }

--- a/domain-impl/src/main/kotlin/de/chrgroth/spotify/control/domain/playlist/check/PlaylistCheckRunner.kt
+++ b/domain-impl/src/main/kotlin/de/chrgroth/spotify/control/domain/playlist/check/PlaylistCheckRunner.kt
@@ -8,16 +8,14 @@ import de.chrgroth.spotify.control.domain.model.playlist.AppPlaylistCheck
 import de.chrgroth.spotify.control.domain.model.playlist.Playlist
 import de.chrgroth.spotify.control.domain.model.playlist.PlaylistInfo
 import de.chrgroth.spotify.control.domain.model.user.AccessToken
-import de.chrgroth.spotify.control.domain.model.user.UserId
 
 interface PlaylistCheckRunner {
   val checkId: String
   val displayName: String
   fun isApplicable(playlistInfo: PlaylistInfo?): Boolean = true
-  fun run(userId: UserId, playlistId: String, playlist: Playlist, currentPlaylistInfo: PlaylistInfo?, allPlaylistInfos: List<PlaylistInfo>): AppPlaylistCheck
+  fun run(playlistId: String, playlist: Playlist, currentPlaylistInfo: PlaylistInfo?, allPlaylistInfos: List<PlaylistInfo>): AppPlaylistCheck
   fun canFix(): Boolean = false
   fun fix(
-    userId: UserId,
     accessToken: AccessToken,
     playlistId: String,
     playlist: Playlist,

--- a/domain-impl/src/main/kotlin/de/chrgroth/spotify/control/domain/playlist/check/SingleArtistTrackCheckRunner.kt
+++ b/domain-impl/src/main/kotlin/de/chrgroth/spotify/control/domain/playlist/check/SingleArtistTrackCheckRunner.kt
@@ -5,7 +5,6 @@ import de.chrgroth.spotify.control.domain.model.playlist.Playlist
 import de.chrgroth.spotify.control.domain.model.playlist.PlaylistId
 import de.chrgroth.spotify.control.domain.model.playlist.PlaylistInfo
 import de.chrgroth.spotify.control.domain.model.playlist.PlaylistType
-import de.chrgroth.spotify.control.domain.model.user.UserId
 import de.chrgroth.spotify.control.domain.port.out.catalog.AppTrackRepositoryPort
 import jakarta.enterprise.context.ApplicationScoped
 import kotlin.time.Clock
@@ -22,7 +21,6 @@ class SingleArtistTrackCheckRunner(
   override fun isApplicable(playlistInfo: PlaylistInfo?): Boolean = playlistInfo?.type == PlaylistType.SINGULARITY
 
   override fun run(
-    userId: UserId,
     playlistId: String,
     playlist: Playlist,
     currentPlaylistInfo: PlaylistInfo?,

--- a/domain-impl/src/main/kotlin/de/chrgroth/spotify/control/domain/playlist/check/TrackFromLatestReleaseCheckRunner.kt
+++ b/domain-impl/src/main/kotlin/de/chrgroth/spotify/control/domain/playlist/check/TrackFromLatestReleaseCheckRunner.kt
@@ -13,7 +13,6 @@ import de.chrgroth.spotify.control.domain.model.playlist.Playlist
 import de.chrgroth.spotify.control.domain.model.playlist.PlaylistId
 import de.chrgroth.spotify.control.domain.model.playlist.PlaylistInfo
 import de.chrgroth.spotify.control.domain.model.user.AccessToken
-import de.chrgroth.spotify.control.domain.model.user.UserId
 import de.chrgroth.spotify.control.domain.port.out.catalog.AppAlbumRepositoryPort
 import de.chrgroth.spotify.control.domain.port.out.catalog.AppTrackRepositoryPort
 import de.chrgroth.spotify.control.domain.port.out.playlist.SpotifyPlaylistPort
@@ -35,7 +34,6 @@ class TrackFromLatestReleaseCheckRunner(
   override val displayName = "Track From Latest Release"
 
   override fun run(
-    userId: UserId,
     playlistId: String,
     playlist: Playlist,
     currentPlaylistInfo: PlaylistInfo?,
@@ -54,7 +52,6 @@ class TrackFromLatestReleaseCheckRunner(
   override fun canFix(): Boolean = true
 
   override fun fix(
-    userId: UserId,
     accessToken: AccessToken,
     playlistId: String,
     playlist: Playlist,
@@ -65,7 +62,7 @@ class TrackFromLatestReleaseCheckRunner(
     if (violations.isEmpty()) {
       return Unit.right()
     }
-    logger.info { "Replacing ${violations.size} outdated track(s) in playlist $playlistId (user ${userId.value})" }
+    logger.info { "Replacing ${violations.size} outdated track(s) in playlist $playlistId" }
     // Process in reverse position order so earlier positions are unaffected by later replacements
     violations.sortedByDescending { it.position }.forEach { violation ->
       val result = spotifyPlaylist.replacePlaylistTrack(

--- a/domain-impl/src/main/kotlin/de/chrgroth/spotify/control/domain/playlist/check/YearSongsInAllCheckRunner.kt
+++ b/domain-impl/src/main/kotlin/de/chrgroth/spotify/control/domain/playlist/check/YearSongsInAllCheckRunner.kt
@@ -13,7 +13,6 @@ import de.chrgroth.spotify.control.domain.model.playlist.PlaylistInfo
 import de.chrgroth.spotify.control.domain.model.playlist.PlaylistType
 import de.chrgroth.spotify.control.domain.model.catalog.TrackId
 import de.chrgroth.spotify.control.domain.model.user.AccessToken
-import de.chrgroth.spotify.control.domain.model.user.UserId
 import de.chrgroth.spotify.control.domain.port.out.catalog.AppTrackRepositoryPort
 import de.chrgroth.spotify.control.domain.port.out.playlist.PlaylistRepositoryPort
 import de.chrgroth.spotify.control.domain.port.out.playlist.SpotifyPlaylistPort
@@ -34,9 +33,9 @@ class YearSongsInAllCheckRunner(
 
   override fun isApplicable(playlistInfo: PlaylistInfo?): Boolean = playlistInfo?.type == PlaylistType.YEAR
 
-  override fun run(userId: UserId, playlistId: String, playlist: Playlist, currentPlaylistInfo: PlaylistInfo?, allPlaylistInfos: List<PlaylistInfo>): AppPlaylistCheck {
+  override fun run(playlistId: String, playlist: Playlist, currentPlaylistInfo: PlaylistInfo?, allPlaylistInfos: List<PlaylistInfo>): AppPlaylistCheck {
     val allPlaylistInfo = allPlaylistInfos.find { it.type == PlaylistType.ALL }
-    val allPlaylist = allPlaylistInfo?.let { playlistRepository.findByUserIdAndPlaylistId(userId, it.spotifyPlaylistId) }
+    val allPlaylist = allPlaylistInfo?.let { playlistRepository.findByPlaylistId(it.spotifyPlaylistId) }
     val violations = if (allPlaylist == null) {
       emptyList()
     } else {
@@ -68,14 +67,13 @@ class YearSongsInAllCheckRunner(
   override fun canFix(): Boolean = true
 
   override fun fix(
-    userId: UserId,
     accessToken: AccessToken,
     playlistId: String,
     playlist: Playlist,
     currentPlaylistInfo: PlaylistInfo?,
     allPlaylistInfos: List<PlaylistInfo>,
   ): Either<DomainError, Unit> =
-    resolveAllPlaylist(userId, playlistId, allPlaylistInfos).flatMap { (allPlaylistInfo, allPlaylist) ->
+    resolveAllPlaylist(playlistId, allPlaylistInfos).flatMap { (allPlaylistInfo, allPlaylist) ->
       val allTrackIds = allPlaylist.tracks.map { it.trackId.value }.toSet()
       val missingTrackIds = playlist.tracks
         .filter { it.trackId.value !in allTrackIds }
@@ -84,18 +82,18 @@ class YearSongsInAllCheckRunner(
       if (missingTrackIds.isEmpty()) {
         Unit.right()
       } else {
-        logger.info { "Adding ${missingTrackIds.size} track(s) to all playlist ${allPlaylistInfo.spotifyPlaylistId} (user ${userId.value})" }
+        logger.info { "Adding ${missingTrackIds.size} track(s) to all playlist ${allPlaylistInfo.spotifyPlaylistId}" }
         spotifyPlaylist.addPlaylistTracks(accessToken, allPlaylistInfo.spotifyPlaylistId, missingTrackIds)
       }
     }
 
-  private fun resolveAllPlaylist(userId: UserId, playlistId: String, allPlaylistInfos: List<PlaylistInfo>): Either<DomainError, Pair<PlaylistInfo, Playlist>> {
+  private fun resolveAllPlaylist(playlistId: String, allPlaylistInfos: List<PlaylistInfo>): Either<DomainError, Pair<PlaylistInfo, Playlist>> {
     val allPlaylistInfo = allPlaylistInfos.find { it.type == PlaylistType.ALL } ?: run {
-      logger.warn { "No all playlist found for user ${userId.value}, cannot fix $checkId for playlist $playlistId" }
+      logger.warn { "No all playlist found, cannot fix $checkId for playlist $playlistId" }
       return PlaylistFixError.FIX_NOT_FOUND.left()
     }
-    val allPlaylist = playlistRepository.findByUserIdAndPlaylistId(userId, allPlaylistInfo.spotifyPlaylistId) ?: run {
-      logger.warn { "All playlist ${allPlaylistInfo.spotifyPlaylistId} not yet synced for user ${userId.value}, cannot fix $checkId" }
+    val allPlaylist = playlistRepository.findByPlaylistId(allPlaylistInfo.spotifyPlaylistId) ?: run {
+      logger.warn { "All playlist ${allPlaylistInfo.spotifyPlaylistId} not yet synced, cannot fix $checkId" }
       return PlaylistFixError.PLAYLIST_NOT_FOUND.left()
     }
     return (allPlaylistInfo to allPlaylist).right()

--- a/domain-impl/src/test/kotlin/de/chrgroth/spotify/control/domain/catalog/CatalogBrowserServiceTests.kt
+++ b/domain-impl/src/test/kotlin/de/chrgroth/spotify/control/domain/catalog/CatalogBrowserServiceTests.kt
@@ -109,7 +109,7 @@ class CatalogBrowserServiceTests {
     every { appTrackRepository.findByTrackIds(setOf(TrackId("track-1"))) } returns
       listOf(AppTrack(id = TrackId("track-1"), title = "Some Song", artistId = ArtistId("artist-1"), lastSync = triggeredAt))
     every { currentUserResolver.userId() } returns userId
-    every { playlistRepository.findByUserId(userId) } returns listOf(
+    every { playlistRepository.findAll() } returns listOf(
       PlaylistInfo(
         spotifyPlaylistId = "playlist-1",
         snapshotId = "snap-1",

--- a/domain-impl/src/test/kotlin/de/chrgroth/spotify/control/domain/catalog/CatalogServiceTests.kt
+++ b/domain-impl/src/test/kotlin/de/chrgroth/spotify/control/domain/catalog/CatalogServiceTests.kt
@@ -100,7 +100,6 @@ class CatalogServiceTests {
   private val albumSyncResult = AlbumSyncResult(album = album1, tracks = listOf(trackWithAlbum1, trackWithAlbum2))
 
   private fun recentlyPlayedItem(trackId: String, vararg artistIds: String) = RecentlyPlayedItem(
-    spotifyUserId = userId,
     trackId = TrackId(trackId),
     trackName = "Track $trackId",
     artistIds = artistIds.map { ArtistId(it) },
@@ -109,7 +108,6 @@ class CatalogServiceTests {
   )
 
   private fun recentlyPartialPlayedItem(trackId: String, vararg artistIds: String) = RecentlyPartialPlayedItem(
-    spotifyUserId = userId,
     trackId = TrackId(trackId),
     trackName = "Track $trackId",
     artistIds = artistIds.map { ArtistId(it) },
@@ -161,8 +159,8 @@ class CatalogServiceTests {
   fun `resyncCatalog enqueues playback-based sync when catalog is empty`() {
     every { appArtistRepository.findAll() } returns emptyList()
     every { currentUserResolver.userId() } returns userId
-    every { recentlyPlayedRepository.findSince(userId, null) } returns listOf(recentlyPlayedItem("track-1", "artist-1", "artist-1b"))
-    every { recentlyPartialPlayedRepository.findSince(userId, null) } returns listOf(recentlyPartialPlayedItem("track-2", "artist-2"))
+    every { recentlyPlayedRepository.findSince(null) } returns listOf(recentlyPlayedItem("track-1", "artist-1", "artist-1b"))
+    every { recentlyPartialPlayedRepository.findSince(null) } returns listOf(recentlyPartialPlayedItem("track-2", "artist-2"))
 
     val result = adapter.resyncCatalog()
 
@@ -184,8 +182,8 @@ class CatalogServiceTests {
     every { appArtistRepository.findAll() } returns listOf(artist1, artist2)
     every { currentUserResolver.userId() } returns userId
     every { outboxPort.enqueue(any()) } just runs
-    every { recentlyPlayedRepository.findSince(userId, null) } returns emptyList()
-    every { recentlyPartialPlayedRepository.findSince(userId, null) } returns emptyList()
+    every { recentlyPlayedRepository.findSince(null) } returns emptyList()
+    every { recentlyPartialPlayedRepository.findSince(null) } returns emptyList()
 
     val result = adapter.resyncCatalog()
 
@@ -212,8 +210,8 @@ class CatalogServiceTests {
     every { appArtistRepository.findAll() } returns listOf(artist1)
     every { currentUserResolver.userId() } returns userId
     every { outboxPort.enqueue(any()) } just runs
-    every { recentlyPlayedRepository.findSince(userId, null) } returns emptyList()
-    every { recentlyPartialPlayedRepository.findSince(userId, null) } returns emptyList()
+    every { recentlyPlayedRepository.findSince(null) } returns emptyList()
+    every { recentlyPartialPlayedRepository.findSince(null) } returns emptyList()
 
     val result = adapter.handle(DomainOutboxEvent.ResyncCatalog())
 
@@ -458,8 +456,8 @@ class CatalogServiceTests {
   @Test
   fun `enqueuePlaybackArtistsForSync delegates playback tracks to syncController using only primary artist per track`() {
     every { currentUserResolver.userId() } returns userId
-    every { recentlyPlayedRepository.findSince(userId, null) } returns listOf(recentlyPlayedItem("track-1", "artist-1", "artist-1b"))
-    every { recentlyPartialPlayedRepository.findSince(userId, null) } returns listOf(recentlyPartialPlayedItem("track-2", "artist-2"))
+    every { recentlyPlayedRepository.findSince(null) } returns listOf(recentlyPlayedItem("track-1", "artist-1", "artist-1b"))
+    every { recentlyPartialPlayedRepository.findSince(null) } returns listOf(recentlyPartialPlayedItem("track-2", "artist-2"))
 
     adapter.enqueuePlaybackArtistsForSync()
 

--- a/domain-impl/src/test/kotlin/de/chrgroth/spotify/control/domain/infra/DashboardServiceTests.kt
+++ b/domain-impl/src/test/kotlin/de/chrgroth/spotify/control/domain/infra/DashboardServiceTests.kt
@@ -83,10 +83,10 @@ class DashboardServiceTests {
 
   private fun setupCommonMocks() {
     every { currentUserResolver.userId() } returns userId
-    every { aggregationRepository.findDailySummaryByUserAndPeriodRange(userId, any(), any()) } returns emptyList()
-    every { aggregationRepository.sumEventCountByUser(userId) } returns 0L
-    every { appPlaybackRepository.findRecentlyPlayed(userId, any()) } returns emptyList()
-    every { playlistRepository.findByUserId(userId) } returns emptyList()
+    every { aggregationRepository.findDailySummaryByPeriodRange(any(), any()) } returns emptyList()
+    every { aggregationRepository.sumEventCount() } returns 0L
+    every { appPlaybackRepository.findRecentlyPlayed(any()) } returns emptyList()
+    every { playlistRepository.findAll() } returns emptyList()
     every { playlistCheckRepository.countAll() } returns 0L
     every { playlistCheckRepository.countSucceeded() } returns 0L
     every { catalogBrowser.getCatalogStats() } returns CatalogStats(0, 0, 0)
@@ -105,7 +105,7 @@ class DashboardServiceTests {
       trackEntries = listOf(AggregationRankEntry(id = "track-1", name = "Track One", totalSeconds = 180L)),
       artistEntries = listOf(AggregationRankEntry(id = "artist-1", name = "Artist One", totalSeconds = 180L)),
     )
-    every { aggregationRepository.findDailySummaryByUserAndPeriodRange(userId, any(), any()) } returns listOf(summary)
+    every { aggregationRepository.findDailySummaryByPeriodRange(any(), any()) } returns listOf(summary)
     every { appTrackRepository.findAlbumIdsByTrackIds(setOf(TrackId("track-1"))) } returns mapOf(TrackId("track-1") to AlbumId("album-1"))
     every { appTrackRepository.findByTrackIds(setOf(TrackId("track-1"))) } returns listOf(track1)
     every { appArtistRepository.findByArtistIds(setOf(ArtistId("artist-1"))) } returns listOf(artist1)
@@ -148,7 +148,7 @@ class DashboardServiceTests {
       trackEntries = listOf(AggregationRankEntry(id = "track-2", name = "Track Two", totalSeconds = 180L)),
       artistEntries = listOf(AggregationRankEntry(id = "artist-1", name = "Artist One", totalSeconds = 180L)),
     )
-    every { aggregationRepository.findDailySummaryByUserAndPeriodRange(userId, any(), any()) } returns listOf(summary1, summary2)
+    every { aggregationRepository.findDailySummaryByPeriodRange(any(), any()) } returns listOf(summary1, summary2)
     every { appTrackRepository.findAlbumIdsByTrackIds(setOf(TrackId("track-1"), TrackId("track-2"))) } returns
       mapOf(TrackId("track-1") to AlbumId("album-1"), TrackId("track-2") to null)
     every { appTrackRepository.findByTrackIds(setOf(TrackId("track-1"), TrackId("track-2"))) } returns listOf(track1, track2)
@@ -183,7 +183,7 @@ class DashboardServiceTests {
       ),
       artistEntries = listOf(AggregationRankEntry(id = "artist-1", name = "Artist One", totalSeconds = 480L)),
     )
-    every { aggregationRepository.findDailySummaryByUserAndPeriodRange(userId, any(), any()) } returns listOf(summary)
+    every { aggregationRepository.findDailySummaryByPeriodRange(any(), any()) } returns listOf(summary)
     every { appTrackRepository.findAlbumIdsByTrackIds(any()) } returns
       mapOf(TrackId("track-1") to AlbumId("album-1"), TrackId("track-2") to AlbumId("album-2"))
     every { appTrackRepository.findByTrackIds(any()) } returns listOf(track1, track2)
@@ -230,7 +230,7 @@ class DashboardServiceTests {
         AggregationRankEntry(id = "track-4", name = "Track Four", totalSeconds = 50L),
       ),
     )
-    every { aggregationRepository.findDailySummaryByUserAndPeriodRange(userId, any(), any()) } returns listOf(summary)
+    every { aggregationRepository.findDailySummaryByPeriodRange(any(), any()) } returns listOf(summary)
     val allTrackIds = setOf(TrackId("track-1"), TrackId("track-2"), TrackId("track-3"), TrackId("track-4"))
     every { appTrackRepository.findAlbumIdsByTrackIds(allTrackIds) } returns emptyMap()
     val topTrackIds = setOf(TrackId("track-1"), TrackId("track-2"), TrackId("track-3"))
@@ -247,9 +247,9 @@ class DashboardServiceTests {
   @Test
   fun `recently played tracks include duration from secondsPlayed`() {
     every { currentUserResolver.userId() } returns userId
-    every { aggregationRepository.findDailySummaryByUserAndPeriodRange(userId, any(), any()) } returns emptyList()
-    every { aggregationRepository.sumEventCountByUser(userId) } returns 1L
-    every { playlistRepository.findByUserId(userId) } returns emptyList()
+    every { aggregationRepository.findDailySummaryByPeriodRange(any(), any()) } returns emptyList()
+    every { aggregationRepository.sumEventCount() } returns 1L
+    every { playlistRepository.findAll() } returns emptyList()
     every { playlistCheckRepository.countAll() } returns 0L
     every { playlistCheckRepository.countSucceeded() } returns 0L
     every { catalogBrowser.getCatalogStats() } returns CatalogStats(0, 0, 0)
@@ -259,12 +259,11 @@ class DashboardServiceTests {
     every { appArtistRepository.findByArtistIds(any()) } returns emptyList()
 
     val playbackItem = AppPlaybackItem(
-      userId = userId,
       playedAt = Instant.fromEpochSeconds(1000),
       trackId = "track-1",
       secondsPlayed = 210L,
     )
-    every { appPlaybackRepository.findRecentlyPlayed(userId, any()) } returns listOf(playbackItem)
+    every { appPlaybackRepository.findRecentlyPlayed(any()) } returns listOf(playbackItem)
     every { appTrackRepository.findByTrackIds(setOf(TrackId("track-1"))) } returns listOf(track1)
     every { appArtistRepository.findByArtistIds(setOf(ArtistId("artist-1"))) } returns listOf(artist1)
 
@@ -278,31 +277,31 @@ class DashboardServiceTests {
   fun `getPlaybackStats only queries aggregation repository`() {
     every { currentUserResolver.userId() } returns userId
     val summary = emptySummary().copy(eventCount = 7L)
-    every { aggregationRepository.findDailySummaryByUserAndPeriodRange(userId, any(), any()) } returns listOf(summary)
-    every { aggregationRepository.sumEventCountByUser(userId) } returns 42L
+    every { aggregationRepository.findDailySummaryByPeriodRange(any(), any()) } returns listOf(summary)
+    every { aggregationRepository.sumEventCount() } returns 42L
 
     val stats = adapter.getPlaybackStats()
 
     assertThat(stats.totalPlaybackEvents).isEqualTo(42L)
     assertThat(stats.playbackEventsLast30Days).isEqualTo(7L)
     assertThat(stats.playbackEventsPerDay).hasSize(30)
-    verify(exactly = 0) { playlistRepository.findByUserId(any()) }
+    verify(exactly = 0) { playlistRepository.findAll() }
     verify(exactly = 0) { playlistCheckRepository.countAll() }
     verify(exactly = 0) { catalogBrowser.getCatalogStats() }
-    verify(exactly = 0) { appPlaybackRepository.findRecentlyPlayed(any(), any()) }
+    verify(exactly = 0) { appPlaybackRepository.findRecentlyPlayed(any()) }
   }
 
   @Test
   fun `getPlaylistMetadata only queries playlist repository`() {
     every { currentUserResolver.userId() } returns userId
-    every { playlistRepository.findByUserId(userId) } returns emptyList()
+    every { playlistRepository.findAll() } returns emptyList()
 
     val stats = adapter.getPlaylistMetadata()
 
     assertThat(stats.syncedPlaylists).isEqualTo(0L)
     assertThat(stats.totalPlaylists).isEqualTo(0L)
-    verify(exactly = 0) { aggregationRepository.findDailySummaryByUserAndPeriodRange(any(), any(), any()) }
-    verify(exactly = 0) { aggregationRepository.sumEventCountByUser(any()) }
+    verify(exactly = 0) { aggregationRepository.findDailySummaryByPeriodRange(any(), any()) }
+    verify(exactly = 0) { aggregationRepository.sumEventCount() }
     verify(exactly = 0) { playlistCheckRepository.countAll() }
     verify(exactly = 0) { catalogBrowser.getCatalogStats() }
   }
@@ -310,7 +309,7 @@ class DashboardServiceTests {
   @Test
   fun `getRecentlyPlayed only queries playback and catalog repositories for track data`() {
     every { currentUserResolver.userId() } returns userId
-    every { appPlaybackRepository.findRecentlyPlayed(userId, any()) } returns emptyList()
+    every { appPlaybackRepository.findRecentlyPlayed(any()) } returns emptyList()
     every { appTrackRepository.findByTrackIds(any()) } returns emptyList()
     every { appAlbumRepository.findByAlbumIds(any()) } returns emptyList()
     every { appArtistRepository.findByArtistIds(any()) } returns emptyList()
@@ -318,9 +317,9 @@ class DashboardServiceTests {
     val stats = adapter.getRecentlyPlayed()
 
     assertThat(stats.recentlyPlayedTracks).isEmpty()
-    verify(exactly = 0) { aggregationRepository.findDailySummaryByUserAndPeriodRange(any(), any(), any()) }
-    verify(exactly = 0) { aggregationRepository.sumEventCountByUser(any()) }
-    verify(exactly = 0) { playlistRepository.findByUserId(any()) }
+    verify(exactly = 0) { aggregationRepository.findDailySummaryByPeriodRange(any(), any()) }
+    verify(exactly = 0) { aggregationRepository.sumEventCount() }
+    verify(exactly = 0) { playlistRepository.findAll() }
     verify(exactly = 0) { playlistCheckRepository.countAll() }
     verify(exactly = 0) { catalogBrowser.getCatalogStats() }
   }
@@ -328,7 +327,7 @@ class DashboardServiceTests {
   @Test
   fun `getListeningStats only queries aggregation and catalog repositories for stats`() {
     every { currentUserResolver.userId() } returns userId
-    every { aggregationRepository.findDailySummaryByUserAndPeriodRange(userId, any(), any()) } returns emptyList()
+    every { aggregationRepository.findDailySummaryByPeriodRange(any(), any()) } returns emptyList()
     every { appTrackRepository.findByTrackIds(any()) } returns emptyList()
     every { appTrackRepository.findAlbumIdsByTrackIds(any()) } returns emptyMap()
     every { appAlbumRepository.findByAlbumIds(any()) } returns emptyList()
@@ -337,9 +336,9 @@ class DashboardServiceTests {
     val stats = adapter.getListeningStats()
 
     assertThat(stats.listeningStats.listenedMinutesLast30Days).isEqualTo(0L)
-    verify(exactly = 0) { aggregationRepository.sumEventCountByUser(any()) }
-    verify(exactly = 0) { appPlaybackRepository.findRecentlyPlayed(any(), any()) }
-    verify(exactly = 0) { playlistRepository.findByUserId(any()) }
+    verify(exactly = 0) { aggregationRepository.sumEventCount() }
+    verify(exactly = 0) { appPlaybackRepository.findRecentlyPlayed(any()) }
+    verify(exactly = 0) { playlistRepository.findAll() }
     verify(exactly = 0) { playlistCheckRepository.countAll() }
     verify(exactly = 0) { catalogBrowser.getCatalogStats() }
   }
@@ -354,9 +353,9 @@ class DashboardServiceTests {
     assertThat(stats.playlistCheckStats.totalChecks).isEqualTo(3L)
     assertThat(stats.playlistCheckStats.succeededChecks).isEqualTo(3L)
     assertThat(stats.playlistCheckStats.allSucceeded).isTrue()
-    verify(exactly = 0) { aggregationRepository.findDailySummaryByUserAndPeriodRange(any(), any(), any()) }
-    verify(exactly = 0) { aggregationRepository.sumEventCountByUser(any()) }
-    verify(exactly = 0) { playlistRepository.findByUserId(any()) }
+    verify(exactly = 0) { aggregationRepository.findDailySummaryByPeriodRange(any(), any()) }
+    verify(exactly = 0) { aggregationRepository.sumEventCount() }
+    verify(exactly = 0) { playlistRepository.findAll() }
     verify(exactly = 0) { catalogBrowser.getCatalogStats() }
   }
 
@@ -367,7 +366,7 @@ class DashboardServiceTests {
     val stats = adapter.getStats()
 
     assertThat(stats).isEqualTo(DashboardStats.EMPTY)
-    verify(exactly = 0) { aggregationRepository.findDailySummaryByUserAndPeriodRange(any(), any(), any()) }
+    verify(exactly = 0) { aggregationRepository.findDailySummaryByPeriodRange(any(), any()) }
   }
 
   @Test
@@ -379,9 +378,9 @@ class DashboardServiceTests {
     assertThat(stats.catalogStats.artistCount).isEqualTo(10L)
     assertThat(stats.catalogStats.albumCount).isEqualTo(20L)
     assertThat(stats.catalogStats.trackCount).isEqualTo(30L)
-    verify(exactly = 0) { aggregationRepository.findDailySummaryByUserAndPeriodRange(any(), any(), any()) }
-    verify(exactly = 0) { aggregationRepository.sumEventCountByUser(any()) }
-    verify(exactly = 0) { playlistRepository.findByUserId(any()) }
+    verify(exactly = 0) { aggregationRepository.findDailySummaryByPeriodRange(any(), any()) }
+    verify(exactly = 0) { aggregationRepository.sumEventCount() }
+    verify(exactly = 0) { playlistRepository.findAll() }
     verify(exactly = 0) { playlistCheckRepository.countAll() }
   }
 }

--- a/domain-impl/src/test/kotlin/de/chrgroth/spotify/control/domain/playback/FetchCurrentlyPlayingServiceTests.kt
+++ b/domain-impl/src/test/kotlin/de/chrgroth/spotify/control/domain/playback/FetchCurrentlyPlayingServiceTests.kt
@@ -78,7 +78,6 @@ class FetchCurrentlyPlayingServiceTests {
     observedAt: Instant = now,
     durationMs: Long = 600_000L,
   ) = CurrentlyPlayingItem(
-    spotifyUserId = userId,
     trackId = TrackId(trackId),
     trackName = "Track $trackId",
     artistIds = listOf(ArtistId("artist-$trackId")),
@@ -120,7 +119,7 @@ class FetchCurrentlyPlayingServiceTests {
     val item = currentlyPlayingItem("track-1", progressMs = 30_000L)
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
     every { spotifyPlayback.getCurrentlyPlaying(accessToken) } returns item.right()
-    every { currentlyPlayingRepository.findMostRecentByUserAndTrack(userId, item.trackId) } returns null
+    every { currentlyPlayingRepository.findMostRecentByTrack(item.trackId) } returns null
 
     service.fetchCurrentlyPlaying(userId)
 
@@ -137,7 +136,7 @@ class FetchCurrentlyPlayingServiceTests {
 
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
     every { spotifyPlayback.getCurrentlyPlaying(accessToken) } returns newItem.right()
-    every { currentlyPlayingRepository.findMostRecentByUserAndTrack(userId, newItem.trackId) } returns existingItem
+    every { currentlyPlayingRepository.findMostRecentByTrack(newItem.trackId) } returns existingItem
 
     service.fetchCurrentlyPlaying(userId)
 
@@ -154,7 +153,7 @@ class FetchCurrentlyPlayingServiceTests {
 
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
     every { spotifyPlayback.getCurrentlyPlaying(accessToken) } returns newItem.right()
-    every { currentlyPlayingRepository.findMostRecentByUserAndTrack(userId, newItem.trackId) } returns existingItem
+    every { currentlyPlayingRepository.findMostRecentByTrack(newItem.trackId) } returns existingItem
 
     service.fetchCurrentlyPlaying(userId)
 
@@ -173,7 +172,7 @@ class FetchCurrentlyPlayingServiceTests {
 
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
     every { spotifyPlayback.getCurrentlyPlaying(accessToken) } returns afterResumeItem.right()
-    every { currentlyPlayingRepository.findMostRecentByUserAndTrack(userId, afterResumeItem.trackId) } returns existingItem
+    every { currentlyPlayingRepository.findMostRecentByTrack(afterResumeItem.trackId) } returns existingItem
 
     service.fetchCurrentlyPlaying(userId)
 
@@ -191,11 +190,11 @@ class FetchCurrentlyPlayingServiceTests {
 
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
     every { spotifyPlayback.getCurrentlyPlaying(accessToken) } returns restartedItem.right()
-    every { currentlyPlayingRepository.findMostRecentByUserAndTrack(userId, restartedItem.trackId) } returns existingItem
+    every { currentlyPlayingRepository.findMostRecentByTrack(restartedItem.trackId) } returns existingItem
 
     service.fetchCurrentlyPlaying(userId)
 
-    verify { currentlyPlayingRepository.deleteByUserIdAndTrackIds(userId, setOf("track-1")) }
+    verify { currentlyPlayingRepository.deleteByTrackIds(setOf("track-1")) }
     verify { currentlyPlayingRepository.save(restartedItem) }
     verify(exactly = 0) { currentlyPlayingRepository.updateProgress(any()) }
   }
@@ -206,12 +205,12 @@ class FetchCurrentlyPlayingServiceTests {
 
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
     every { spotifyPlayback.getCurrentlyPlaying(accessToken) } returns newItem.right()
-    every { currentlyPlayingRepository.findMostRecentByUserAndTrack(userId, newItem.trackId) } returns null
+    every { currentlyPlayingRepository.findMostRecentByTrack(newItem.trackId) } returns null
 
     service.fetchCurrentlyPlaying(userId)
 
     verify { currentlyPlayingRepository.save(newItem) }
-    verify(exactly = 0) { currentlyPlayingRepository.deleteByUserIdAndTrackIds(any(), any()) }
+    verify(exactly = 0) { currentlyPlayingRepository.deleteByTrackIds(any()) }
     verify(exactly = 0) { currentlyPlayingRepository.updateProgress(any()) }
   }
 
@@ -223,9 +222,9 @@ class FetchCurrentlyPlayingServiceTests {
     val orphanedTrackA = currentlyPlayingItem("track-a", progressMs = 50_000L, observedAt = now - 5.minutes)
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
     every { spotifyPlayback.getCurrentlyPlaying(accessToken) } returns trackB.right()
-    every { currentlyPlayingRepository.findMostRecentByUserAndTrack(userId, trackB.trackId) } returns null
-    every { currentlyPlayingRepository.findByUserId(userId) } returns listOf(orphanedTrackA)
-    every { recentlyPartialPlayedRepository.findExistingPlayedAts(userId, any()) } returns emptySet()
+    every { currentlyPlayingRepository.findMostRecentByTrack(trackB.trackId) } returns null
+    every { currentlyPlayingRepository.findAll() } returns listOf(orphanedTrackA)
+    every { recentlyPartialPlayedRepository.findExistingPlayedAts(any()) } returns emptySet()
     every { recentlyPartialPlayedRepository.saveAll(any()) } just runs
 
     service.fetchCurrentlyPlaying(userId)
@@ -235,7 +234,7 @@ class FetchCurrentlyPlayingServiceTests {
     assertThat(savedSlot.captured).hasSize(1)
     assertThat(savedSlot.captured[0].trackId).isEqualTo(TrackId("track-a"))
     assertThat(savedSlot.captured[0].playedSeconds).isEqualTo(50L)
-    verify { currentlyPlayingRepository.deleteByUserIdAndTrackIds(userId, setOf("track-a")) }
+    verify { currentlyPlayingRepository.deleteByTrackIds(setOf("track-a")) }
     verify { dashboardRefresh.notifyUserPlaybackData() }
   }
 
@@ -245,13 +244,13 @@ class FetchCurrentlyPlayingServiceTests {
     val orphanedTrackA = currentlyPlayingItem("track-a", progressMs = 5_000L, observedAt = now - 5.minutes)
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
     every { spotifyPlayback.getCurrentlyPlaying(accessToken) } returns trackB.right()
-    every { currentlyPlayingRepository.findMostRecentByUserAndTrack(userId, trackB.trackId) } returns null
-    every { currentlyPlayingRepository.findByUserId(userId) } returns listOf(orphanedTrackA)
+    every { currentlyPlayingRepository.findMostRecentByTrack(trackB.trackId) } returns null
+    every { currentlyPlayingRepository.findAll() } returns listOf(orphanedTrackA)
 
     service.fetchCurrentlyPlaying(userId)
 
     verify(exactly = 0) { recentlyPartialPlayedRepository.saveAll(any()) }
-    verify { currentlyPlayingRepository.deleteByUserIdAndTrackIds(userId, setOf("track-a")) }
+    verify { currentlyPlayingRepository.deleteByTrackIds(setOf("track-a")) }
     verify(exactly = 0) { dashboardRefresh.notifyUserPlaybackData() }
   }
 
@@ -263,9 +262,9 @@ class FetchCurrentlyPlayingServiceTests {
     val trackB = currentlyPlayingItem("track-b", progressMs = 60_000L)
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
     every { spotifyPlayback.getCurrentlyPlaying(accessToken) } returns trackB.right()
-    every { currentlyPlayingRepository.findMostRecentByUserAndTrack(userId, trackB.trackId) } returns null
-    every { currentlyPlayingRepository.findByUserId(userId) } returns listOf(trackA)
-    every { recentlyPartialPlayedRepository.findExistingPlayedAts(userId, any()) } returns emptySet()
+    every { currentlyPlayingRepository.findMostRecentByTrack(trackB.trackId) } returns null
+    every { currentlyPlayingRepository.findAll() } returns listOf(trackA)
+    every { recentlyPartialPlayedRepository.findExistingPlayedAts(any()) } returns emptySet()
     every { recentlyPartialPlayedRepository.saveAll(any()) } just runs
 
     service.fetchCurrentlyPlaying(userId)
@@ -276,20 +275,20 @@ class FetchCurrentlyPlayingServiceTests {
     assertThat(savedSlot.captured[0].trackId).isEqualTo(TrackId("track-a"))
     assertThat(savedSlot.captured[0].startTime).isEqualTo(trackA.startTime)
     // Track A's currently playing entry is deleted
-    verify { currentlyPlayingRepository.deleteByUserIdAndTrackIds(userId, setOf("track-a")) }
+    verify { currentlyPlayingRepository.deleteByTrackIds(setOf("track-a")) }
   }
 
   @Test
   fun `fetchCurrentlyPlaying cleans up orphaned entries when nothing is playing`() {
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
     every { spotifyPlayback.getCurrentlyPlaying(accessToken) } returns null.right()
-    every { currentlyPlayingRepository.findByUserId(userId) } returns emptyList()
+    every { currentlyPlayingRepository.findAll() } returns emptyList()
 
     service.fetchCurrentlyPlaying(userId)
 
-    verify { currentlyPlayingRepository.findByUserId(userId) }
+    verify { currentlyPlayingRepository.findAll() }
     verify(exactly = 0) { recentlyPartialPlayedRepository.saveAll(any()) }
-    verify(exactly = 0) { currentlyPlayingRepository.deleteByUserIdAndTrackIds(any(), any()) }
+    verify(exactly = 0) { currentlyPlayingRepository.deleteByTrackIds(any()) }
   }
 
   @Test
@@ -297,8 +296,8 @@ class FetchCurrentlyPlayingServiceTests {
     val lingeringTrack = currentlyPlayingItem("track-a", progressMs = 50_000L, observedAt = now - 5.minutes)
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
     every { spotifyPlayback.getCurrentlyPlaying(accessToken) } returns null.right()
-    every { currentlyPlayingRepository.findByUserId(userId) } returns listOf(lingeringTrack)
-    every { recentlyPartialPlayedRepository.findExistingPlayedAts(userId, any()) } returns emptySet()
+    every { currentlyPlayingRepository.findAll() } returns listOf(lingeringTrack)
+    every { recentlyPartialPlayedRepository.findExistingPlayedAts(any()) } returns emptySet()
     every { recentlyPartialPlayedRepository.saveAll(any()) } just runs
 
     service.fetchCurrentlyPlaying(userId)
@@ -308,7 +307,7 @@ class FetchCurrentlyPlayingServiceTests {
     assertThat(savedSlot.captured).hasSize(1)
     assertThat(savedSlot.captured[0].trackId).isEqualTo(TrackId("track-a"))
     assertThat(savedSlot.captured[0].playedSeconds).isEqualTo(50L)
-    verify { currentlyPlayingRepository.deleteByUserIdAndTrackIds(userId, setOf("track-a")) }
+    verify { currentlyPlayingRepository.deleteByTrackIds(setOf("track-a")) }
     verify { dashboardRefresh.notifyUserPlaybackData() }
   }
 
@@ -317,12 +316,12 @@ class FetchCurrentlyPlayingServiceTests {
     val lingeringTrack = currentlyPlayingItem("track-a", progressMs = 5_000L, observedAt = now - 5.minutes)
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
     every { spotifyPlayback.getCurrentlyPlaying(accessToken) } returns null.right()
-    every { currentlyPlayingRepository.findByUserId(userId) } returns listOf(lingeringTrack)
+    every { currentlyPlayingRepository.findAll() } returns listOf(lingeringTrack)
 
     service.fetchCurrentlyPlaying(userId)
 
     verify(exactly = 0) { recentlyPartialPlayedRepository.saveAll(any()) }
-    verify { currentlyPlayingRepository.deleteByUserIdAndTrackIds(userId, setOf("track-a")) }
+    verify { currentlyPlayingRepository.deleteByTrackIds(setOf("track-a")) }
     verify(exactly = 0) { dashboardRefresh.notifyUserPlaybackData() }
   }
 
@@ -333,7 +332,7 @@ class FetchCurrentlyPlayingServiceTests {
     val item = currentlyPlayingItem("track-1", progressMs = 30_000L)
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
     every { spotifyPlayback.getCurrentlyPlaying(accessToken) } returns item.right()
-    every { currentlyPlayingRepository.findMostRecentByUserAndTrack(userId, item.trackId) } returns null
+    every { currentlyPlayingRepository.findMostRecentByTrack(item.trackId) } returns null
 
     service.fetchCurrentlyPlaying(userId)
 
@@ -345,7 +344,7 @@ class FetchCurrentlyPlayingServiceTests {
     val item = currentlyPlayingItem("track-1", progressMs = 30_000L).copy(isPlaying = false)
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
     every { spotifyPlayback.getCurrentlyPlaying(accessToken) } returns item.right()
-    every { currentlyPlayingRepository.findMostRecentByUserAndTrack(userId, item.trackId) } returns null
+    every { currentlyPlayingRepository.findMostRecentByTrack(item.trackId) } returns null
 
     service.fetchCurrentlyPlaying(userId)
 
@@ -357,7 +356,7 @@ class FetchCurrentlyPlayingServiceTests {
     val item = currentlyPlayingItem("track-1", progressMs = 30_000L)
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
     every { spotifyPlayback.getCurrentlyPlaying(accessToken) } returns item.right()
-    every { currentlyPlayingRepository.findMostRecentByUserAndTrack(userId, item.trackId) } returns null
+    every { currentlyPlayingRepository.findMostRecentByTrack(item.trackId) } returns null
 
     service.fetchCurrentlyPlaying(userId)
 

--- a/domain-impl/src/test/kotlin/de/chrgroth/spotify/control/domain/playback/PlaybackAggregationServiceTests.kt
+++ b/domain-impl/src/test/kotlin/de/chrgroth/spotify/control/domain/playback/PlaybackAggregationServiceTests.kt
@@ -56,10 +56,10 @@ class PlaybackAggregationServiceTests {
     every { currentUserResolver.userId() } returns userId
     val savedAggregation = slot<PlaybackAggregation>()
     every { aggregationRepository.save(capture(savedAggregation)) } returns Unit
-    every { appPlaybackRepository.findAllBetween(userId, any(), any()) } returns listOf(
-      AppPlaybackItem(userId, Instant.fromEpochSeconds(1), "track-1", 120L),
-      AppPlaybackItem(userId, Instant.fromEpochSeconds(2), "track-2", 180L),
-      AppPlaybackItem(userId, Instant.fromEpochSeconds(3), "track-3", 60L),
+    every { appPlaybackRepository.findAllBetween(any(), any()) } returns listOf(
+      AppPlaybackItem(Instant.fromEpochSeconds(1), "track-1", 120L),
+      AppPlaybackItem(Instant.fromEpochSeconds(2), "track-2", 180L),
+      AppPlaybackItem(Instant.fromEpochSeconds(3), "track-3", 60L),
     )
     every { appTrackRepository.findByTrackIds(setOf(TrackId("track-1"), TrackId("track-2"), TrackId("track-3"))) } returns listOf(
       AppTrack(
@@ -110,8 +110,7 @@ class PlaybackAggregationServiceTests {
     val savedAggregation = slot<PlaybackAggregation>()
     every { aggregationRepository.save(capture(savedAggregation)) } returns Unit
     every {
-      aggregationRepository.findByUserTypeAndPeriodRange(
-        userId,
+      aggregationRepository.findByTypeAndPeriodRange(
         AggregationPeriodType.DAY,
         weekStart,
         LocalDate(2024, 1, 21),
@@ -135,7 +134,7 @@ class PlaybackAggregationServiceTests {
       AggregationRankEntry("album-1", "Album One", 300L),
       AggregationRankEntry("album-2", "Album Two", 60L),
     )
-    verify(exactly = 1) { aggregationRepository.findByUserTypeAndPeriodRange(userId, AggregationPeriodType.DAY, weekStart, LocalDate(2024, 1, 21)) }
+    verify(exactly = 1) { aggregationRepository.findByTypeAndPeriodRange(AggregationPeriodType.DAY, weekStart, LocalDate(2024, 1, 21)) }
   }
 
   @Test
@@ -146,7 +145,7 @@ class PlaybackAggregationServiceTests {
     every { aggregationRepository.save(capture(savedAggregation)) } returns Unit
     val manyTrackEntries = (1..STORED_ENTRIES_LIMIT_PLUS_MARGIN).map { AggregationRankEntry(id = "track-$it", name = "Track $it", totalSeconds = it.toLong()) }
     every {
-      aggregationRepository.findByUserTypeAndPeriodRange(userId, AggregationPeriodType.DAY, weekStart, LocalDate(2024, 1, 21))
+      aggregationRepository.findByTypeAndPeriodRange(AggregationPeriodType.DAY, weekStart, LocalDate(2024, 1, 21))
     } returns listOf(dayAggregation(weekStart, trackEntries = manyTrackEntries))
 
     val result = service.handle(DomainOutboxEvent.AggregatePlaybackData(AggregationPeriodType.WEEK, weekStart))
@@ -164,7 +163,6 @@ class PlaybackAggregationServiceTests {
     albumEntries: List<AggregationRankEntry> = emptyList(),
     trackEntries: List<AggregationRankEntry> = emptyList(),
   ) = PlaybackAggregation(
-    userId = userId,
     type = AggregationPeriodType.DAY,
     periodStart = periodStart,
     totalPlaybackSeconds = albumEntries.sumOf { it.totalSeconds } + trackEntries.sumOf { it.totalSeconds },

--- a/domain-impl/src/test/kotlin/de/chrgroth/spotify/control/domain/playback/RecentlyPlayedServiceTests.kt
+++ b/domain-impl/src/test/kotlin/de/chrgroth/spotify/control/domain/playback/RecentlyPlayedServiceTests.kt
@@ -80,8 +80,7 @@ class RecentlyPlayedServiceTests {
   private val accessToken = AccessToken("token")
   private val now = Clock.System.now()
 
-  private fun item(index: Int, forUserId: UserId = userId, albumId: String? = null) = RecentlyPlayedItem(
-    spotifyUserId = forUserId,
+  private fun item(index: Int, albumId: String? = null) = RecentlyPlayedItem(
     trackId = TrackId("track-$index"),
     trackName = "Track $index",
     artistIds = listOf(ArtistId("artist-id-$index")),
@@ -96,7 +95,6 @@ class RecentlyPlayedServiceTests {
     observedAt: Instant = now,
     durationMs: Long = 600_000L,
   ) = CurrentlyPlayingItem(
-    spotifyUserId = userId,
     trackId = TrackId(trackId),
     trackName = "Track $trackId",
     artistIds = listOf(ArtistId("artist-$trackId")),
@@ -109,7 +107,7 @@ class RecentlyPlayedServiceTests {
   )
 
   private fun setupNoConsolidation() {
-    every { currentlyPlayingRepository.findByUserId(userId) } returns emptyList()
+    every { currentlyPlayingRepository.findAll() } returns emptyList()
   }
 
   // --- enqueueUpdates tests ---
@@ -139,9 +137,9 @@ class RecentlyPlayedServiceTests {
   fun `update persists new tracks`() {
     val items = listOf(item(1), item(2))
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
-    every { recentlyPlayedRepository.findMostRecentPlayedAt(userId) } returns null
+    every { recentlyPlayedRepository.findMostRecentPlayedAt() } returns null
     every { spotifyPlayback.getRecentlyPlayed(accessToken, null) } returns items.right()
-    every { recentlyPlayedRepository.findExistingPlayedAts(userId, any()) } returns emptySet()
+    every { recentlyPlayedRepository.findExistingPlayedAts(any()) } returns emptySet()
     every { recentlyPlayedRepository.saveAll(any()) } just runs
     setupNoConsolidation()
 
@@ -157,9 +155,9 @@ class RecentlyPlayedServiceTests {
   fun `update notifies playback data when new items are persisted`() {
     val items = listOf(item(1))
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
-    every { recentlyPlayedRepository.findMostRecentPlayedAt(userId) } returns null
+    every { recentlyPlayedRepository.findMostRecentPlayedAt() } returns null
     every { spotifyPlayback.getRecentlyPlayed(accessToken, null) } returns items.right()
-    every { recentlyPlayedRepository.findExistingPlayedAts(userId, any()) } returns emptySet()
+    every { recentlyPlayedRepository.findExistingPlayedAts(any()) } returns emptySet()
     every { recentlyPlayedRepository.saveAll(any()) } just runs
     setupNoConsolidation()
 
@@ -172,9 +170,9 @@ class RecentlyPlayedServiceTests {
   fun `update does not notify playback data when no new items exist`() {
     val items = listOf(item(1))
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
-    every { recentlyPlayedRepository.findMostRecentPlayedAt(userId) } returns null
+    every { recentlyPlayedRepository.findMostRecentPlayedAt() } returns null
     every { spotifyPlayback.getRecentlyPlayed(accessToken, null) } returns items.right()
-    every { recentlyPlayedRepository.findExistingPlayedAts(userId, any()) } returns setOf(items[0].playedAt)
+    every { recentlyPlayedRepository.findExistingPlayedAts(any()) } returns setOf(items[0].playedAt)
     setupNoConsolidation()
 
     adapter.fetchRecentlyPlayed(userId)
@@ -187,9 +185,9 @@ class RecentlyPlayedServiceTests {
     val after = now - 2.hours
     val items = listOf(item(1))
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
-    every { recentlyPlayedRepository.findMostRecentPlayedAt(userId) } returns after
+    every { recentlyPlayedRepository.findMostRecentPlayedAt() } returns after
     every { spotifyPlayback.getRecentlyPlayed(accessToken, after) } returns items.right()
-    every { recentlyPlayedRepository.findExistingPlayedAts(userId, any()) } returns emptySet()
+    every { recentlyPlayedRepository.findExistingPlayedAts(any()) } returns emptySet()
     every { recentlyPlayedRepository.saveAll(any()) } just runs
     setupNoConsolidation()
 
@@ -202,9 +200,9 @@ class RecentlyPlayedServiceTests {
   fun `update skips duplicate tracks`() {
     val items = listOf(item(1), item(2))
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
-    every { recentlyPlayedRepository.findMostRecentPlayedAt(userId) } returns null
+    every { recentlyPlayedRepository.findMostRecentPlayedAt() } returns null
     every { spotifyPlayback.getRecentlyPlayed(accessToken, null) } returns items.right()
-    every { recentlyPlayedRepository.findExistingPlayedAts(userId, any()) } returns setOf(items[0].playedAt)
+    every { recentlyPlayedRepository.findExistingPlayedAts(any()) } returns setOf(items[0].playedAt)
     every { recentlyPlayedRepository.saveAll(any()) } just runs
     setupNoConsolidation()
 
@@ -220,9 +218,9 @@ class RecentlyPlayedServiceTests {
   fun `update does not call saveAll when all tracks are duplicates`() {
     val items = listOf(item(1))
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
-    every { recentlyPlayedRepository.findMostRecentPlayedAt(userId) } returns null
+    every { recentlyPlayedRepository.findMostRecentPlayedAt() } returns null
     every { spotifyPlayback.getRecentlyPlayed(accessToken, null) } returns items.right()
-    every { recentlyPlayedRepository.findExistingPlayedAts(userId, any()) } returns setOf(items[0].playedAt)
+    every { recentlyPlayedRepository.findExistingPlayedAts(any()) } returns setOf(items[0].playedAt)
     setupNoConsolidation()
 
     adapter.fetchRecentlyPlayed(userId)
@@ -233,9 +231,9 @@ class RecentlyPlayedServiceTests {
   @Test
   fun `update does not call saveAll when no tracks returned`() {
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
-    every { recentlyPlayedRepository.findMostRecentPlayedAt(userId) } returns null
+    every { recentlyPlayedRepository.findMostRecentPlayedAt() } returns null
     every { spotifyPlayback.getRecentlyPlayed(accessToken, null) } returns emptyList<RecentlyPlayedItem>().right()
-    every { recentlyPlayedRepository.findExistingPlayedAts(userId, any()) } returns emptySet()
+    every { recentlyPlayedRepository.findExistingPlayedAts(any()) } returns emptySet()
     setupNoConsolidation()
 
     adapter.fetchRecentlyPlayed(userId)
@@ -246,7 +244,7 @@ class RecentlyPlayedServiceTests {
   @Test
   fun `update returns Left on domain error`() {
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
-    every { recentlyPlayedRepository.findMostRecentPlayedAt(userId) } returns null
+    every { recentlyPlayedRepository.findMostRecentPlayedAt() } returns null
     every { spotifyPlayback.getRecentlyPlayed(accessToken, null) } returns PlaybackError.RECENTLY_PLAYED_FETCH_FAILED.left()
 
     val result = adapter.fetchRecentlyPlayed(userId)
@@ -261,29 +259,29 @@ class RecentlyPlayedServiceTests {
   fun `update deletes currently playing entries for completed tracks at end`() {
     val items = listOf(item(1))
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
-    every { recentlyPlayedRepository.findMostRecentPlayedAt(userId) } returns null
+    every { recentlyPlayedRepository.findMostRecentPlayedAt() } returns null
     every { spotifyPlayback.getRecentlyPlayed(accessToken, null) } returns items.right()
-    every { recentlyPlayedRepository.findExistingPlayedAts(userId, any()) } returns emptySet()
+    every { recentlyPlayedRepository.findExistingPlayedAts(any()) } returns emptySet()
     every { recentlyPlayedRepository.saveAll(any()) } just runs
     setupNoConsolidation()
 
     adapter.fetchRecentlyPlayed(userId)
 
-    verify { currentlyPlayingRepository.deleteByUserIdAndTrackIds(userId, setOf("track-1")) }
+    verify { currentlyPlayingRepository.deleteByTrackIds(setOf("track-1")) }
   }
 
   @Test
   fun `update converts partial plays exceeding 25s to recently partial played`() {
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
-    every { recentlyPlayedRepository.findMostRecentPlayedAt(userId) } returns null
+    every { recentlyPlayedRepository.findMostRecentPlayedAt() } returns null
     every { spotifyPlayback.getRecentlyPlayed(accessToken, null) } returns emptyList<RecentlyPlayedItem>().right()
-    every { recentlyPlayedRepository.findExistingPlayedAts(userId, any()) } returns emptySet()
-    every { recentlyPartialPlayedRepository.findExistingPlayedAts(userId, any()) } returns emptySet()
+    every { recentlyPlayedRepository.findExistingPlayedAts(any()) } returns emptySet()
+    every { recentlyPartialPlayedRepository.findExistingPlayedAts(any()) } returns emptySet()
     every { recentlyPartialPlayedRepository.saveAll(any()) } just runs
 
     val olderItem = currentlyPlayingItem("track-old", progressMs = 50_000L, observedAt = now - 4.minutes)
     val latestTrack = currentlyPlayingItem("track-latest", progressMs = 10_000L, observedAt = now)
-    every { currentlyPlayingRepository.findByUserId(userId) } returns listOf(olderItem, latestTrack)
+    every { currentlyPlayingRepository.findAll() } returns listOf(olderItem, latestTrack)
 
     adapter.fetchRecentlyPlayed(userId)
 
@@ -296,15 +294,15 @@ class RecentlyPlayedServiceTests {
   @Test
   fun `update computes playedSeconds using progressMs when another track was observed next`() {
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
-    every { recentlyPlayedRepository.findMostRecentPlayedAt(userId) } returns null
+    every { recentlyPlayedRepository.findMostRecentPlayedAt() } returns null
     every { spotifyPlayback.getRecentlyPlayed(accessToken, null) } returns emptyList<RecentlyPlayedItem>().right()
-    every { recentlyPlayedRepository.findExistingPlayedAts(userId, any()) } returns emptySet()
-    every { recentlyPartialPlayedRepository.findExistingPlayedAts(userId, any()) } returns emptySet()
+    every { recentlyPlayedRepository.findExistingPlayedAts(any()) } returns emptySet()
+    every { recentlyPartialPlayedRepository.findExistingPlayedAts(any()) } returns emptySet()
     every { recentlyPartialPlayedRepository.saveAll(any()) } just runs
 
     val olderItem = currentlyPlayingItem("track-old", progressMs = 30_000L, observedAt = now - 5.minutes)
     val latestTrack = currentlyPlayingItem("track-latest", progressMs = 10_000L, observedAt = now - 1.minutes)
-    every { currentlyPlayingRepository.findByUserId(userId) } returns listOf(olderItem, latestTrack)
+    every { currentlyPlayingRepository.findAll() } returns listOf(olderItem, latestTrack)
 
     adapter.fetchRecentlyPlayed(userId)
 
@@ -316,10 +314,10 @@ class RecentlyPlayedServiceTests {
   @Test
   fun `update converts each item independently to a separate partial played record`() {
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
-    every { recentlyPlayedRepository.findMostRecentPlayedAt(userId) } returns null
+    every { recentlyPlayedRepository.findMostRecentPlayedAt() } returns null
     every { spotifyPlayback.getRecentlyPlayed(accessToken, null) } returns emptyList<RecentlyPlayedItem>().right()
-    every { recentlyPlayedRepository.findExistingPlayedAts(userId, any()) } returns emptySet()
-    every { recentlyPartialPlayedRepository.findExistingPlayedAts(userId, any()) } returns emptySet()
+    every { recentlyPlayedRepository.findExistingPlayedAts(any()) } returns emptySet()
+    every { recentlyPartialPlayedRepository.findExistingPlayedAts(any()) } returns emptySet()
     every { recentlyPartialPlayedRepository.saveAll(any()) } just runs
 
     // Three observations of the same track — each becomes its own partial play record
@@ -327,7 +325,7 @@ class RecentlyPlayedServiceTests {
     val olderSecond = currentlyPlayingItem("track-old", progressMs = 45_000L, observedAt = now - 4.minutes)
     val olderThird = currentlyPlayingItem("track-old", progressMs = 50_000L, observedAt = now - 2.minutes)
     val latestTrack = currentlyPlayingItem("track-latest", progressMs = 10_000L, observedAt = now)
-    every { currentlyPlayingRepository.findByUserId(userId) } returns listOf(olderFirst, olderSecond, olderThird, latestTrack)
+    every { currentlyPlayingRepository.findAll() } returns listOf(olderFirst, olderSecond, olderThird, latestTrack)
 
     adapter.fetchRecentlyPlayed(userId)
 
@@ -341,10 +339,10 @@ class RecentlyPlayedServiceTests {
   @Test
   fun `update computes playedSeconds using progressMs regardless of observation gap to next track`() {
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
-    every { recentlyPlayedRepository.findMostRecentPlayedAt(userId) } returns null
+    every { recentlyPlayedRepository.findMostRecentPlayedAt() } returns null
     every { spotifyPlayback.getRecentlyPlayed(accessToken, null) } returns emptyList<RecentlyPlayedItem>().right()
-    every { recentlyPlayedRepository.findExistingPlayedAts(userId, any()) } returns emptySet()
-    every { recentlyPartialPlayedRepository.findExistingPlayedAts(userId, any()) } returns emptySet()
+    every { recentlyPlayedRepository.findExistingPlayedAts(any()) } returns emptySet()
+    every { recentlyPartialPlayedRepository.findExistingPlayedAts(any()) } returns emptySet()
     every { recentlyPartialPlayedRepository.saveAll(any()) } just runs
 
     // track-old was briefly played hours ago; a different track is observed much later.
@@ -352,7 +350,7 @@ class RecentlyPlayedServiceTests {
     val trackDurationMs = 210_000L // 3.5 minutes
     val olderItem = currentlyPlayingItem("track-old", progressMs = 30_000L, observedAt = now - 12.hours, durationMs = trackDurationMs)
     val latestTrack = currentlyPlayingItem("track-latest", progressMs = 10_000L, observedAt = now)
-    every { currentlyPlayingRepository.findByUserId(userId) } returns listOf(olderItem, latestTrack)
+    every { currentlyPlayingRepository.findAll() } returns listOf(olderItem, latestTrack)
 
     adapter.fetchRecentlyPlayed(userId)
 
@@ -365,10 +363,10 @@ class RecentlyPlayedServiceTests {
   @Test
   fun `update caps playedSeconds at track durationMs when progressMs exceeds track length`() {
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
-    every { recentlyPlayedRepository.findMostRecentPlayedAt(userId) } returns null
+    every { recentlyPlayedRepository.findMostRecentPlayedAt() } returns null
     every { spotifyPlayback.getRecentlyPlayed(accessToken, null) } returns emptyList<RecentlyPlayedItem>().right()
-    every { recentlyPlayedRepository.findExistingPlayedAts(userId, any()) } returns emptySet()
-    every { recentlyPartialPlayedRepository.findExistingPlayedAts(userId, any()) } returns emptySet()
+    every { recentlyPlayedRepository.findExistingPlayedAts(any()) } returns emptySet()
+    every { recentlyPartialPlayedRepository.findExistingPlayedAts(any()) } returns emptySet()
     every { recentlyPartialPlayedRepository.saveAll(any()) } just runs
 
     // Spotify returned a progressMs larger than the track's durationMs (bad data);
@@ -376,7 +374,7 @@ class RecentlyPlayedServiceTests {
     val trackDurationMs = 210_000L // 3.5 minutes
     val olderItem = currentlyPlayingItem("track-old", progressMs = 999_000L, observedAt = now - 5.minutes, durationMs = trackDurationMs)
     val latestTrack = currentlyPlayingItem("track-latest", progressMs = 10_000L, observedAt = now)
-    every { currentlyPlayingRepository.findByUserId(userId) } returns listOf(olderItem, latestTrack)
+    every { currentlyPlayingRepository.findAll() } returns listOf(olderItem, latestTrack)
 
     adapter.fetchRecentlyPlayed(userId)
 
@@ -390,13 +388,13 @@ class RecentlyPlayedServiceTests {
   fun `update does not convert the sole non-completed track even when completed tracks exist`() {
     val completedItems = listOf(item(1))
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
-    every { recentlyPlayedRepository.findMostRecentPlayedAt(userId) } returns null
+    every { recentlyPlayedRepository.findMostRecentPlayedAt() } returns null
     every { spotifyPlayback.getRecentlyPlayed(accessToken, null) } returns completedItems.right()
-    every { recentlyPlayedRepository.findExistingPlayedAts(userId, any()) } returns emptySet()
+    every { recentlyPlayedRepository.findExistingPlayedAts(any()) } returns emptySet()
     every { recentlyPlayedRepository.saveAll(any()) } just runs
 
     val olderItem = currentlyPlayingItem("track-old", progressMs = 45_000L, observedAt = now - 5.minutes)
-    every { currentlyPlayingRepository.findByUserId(userId) } returns listOf(olderItem)
+    every { currentlyPlayingRepository.findAll() } returns listOf(olderItem)
 
     adapter.fetchRecentlyPlayed(userId)
 
@@ -407,18 +405,18 @@ class RecentlyPlayedServiceTests {
   fun `update converts each item using its own progressMs even when later track is completed`() {
     val completedItems = listOf(item(1))
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
-    every { recentlyPlayedRepository.findMostRecentPlayedAt(userId) } returns null
+    every { recentlyPlayedRepository.findMostRecentPlayedAt() } returns null
     every { spotifyPlayback.getRecentlyPlayed(accessToken, null) } returns completedItems.right()
-    every { recentlyPlayedRepository.findExistingPlayedAts(userId, any()) } returns emptySet()
+    every { recentlyPlayedRepository.findExistingPlayedAts(any()) } returns emptySet()
     every { recentlyPlayedRepository.saveAll(any()) } just runs
-    every { recentlyPartialPlayedRepository.findExistingPlayedAts(userId, any()) } returns emptySet()
+    every { recentlyPartialPlayedRepository.findExistingPlayedAts(any()) } returns emptySet()
     every { recentlyPartialPlayedRepository.saveAll(any()) } just runs
 
     val olderTrackFirst = currentlyPlayingItem("track-old", progressMs = 30_000L, observedAt = now - 8.minutes)
     val olderTrackSecond = currentlyPlayingItem("track-old", progressMs = 45_000L, observedAt = now - 6.minutes)
     val completedEntry = currentlyPlayingItem("track-1", progressMs = 5_000L, observedAt = now - 4.minutes)
     val latestTrack = currentlyPlayingItem("track-latest", progressMs = 10_000L, observedAt = now - 2.minutes)
-    every { currentlyPlayingRepository.findByUserId(userId) } returns listOf(olderTrackFirst, olderTrackSecond, completedEntry, latestTrack)
+    every { currentlyPlayingRepository.findAll() } returns listOf(olderTrackFirst, olderTrackSecond, completedEntry, latestTrack)
 
     adapter.fetchRecentlyPlayed(userId)
 
@@ -433,10 +431,10 @@ class RecentlyPlayedServiceTests {
   @Test
   fun `update creates two partial played items when same track played twice`() {
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
-    every { recentlyPlayedRepository.findMostRecentPlayedAt(userId) } returns null
+    every { recentlyPlayedRepository.findMostRecentPlayedAt() } returns null
     every { spotifyPlayback.getRecentlyPlayed(accessToken, null) } returns emptyList<RecentlyPlayedItem>().right()
-    every { recentlyPlayedRepository.findExistingPlayedAts(userId, any()) } returns emptySet()
-    every { recentlyPartialPlayedRepository.findExistingPlayedAts(userId, any()) } returns emptySet()
+    every { recentlyPlayedRepository.findExistingPlayedAts(any()) } returns emptySet()
+    every { recentlyPartialPlayedRepository.findExistingPlayedAts(any()) } returns emptySet()
     every { recentlyPartialPlayedRepository.saveAll(any()) } just runs
 
     // First play of track-a: one observation below threshold, one above
@@ -449,7 +447,7 @@ class RecentlyPlayedServiceTests {
     val session2Second = currentlyPlayingItem("track-a", progressMs = 30_000L, observedAt = now - 5.minutes)
     // track-latest is the protected item
     val latestTrack = currentlyPlayingItem("track-latest", progressMs = 10_000L, observedAt = now)
-    every { currentlyPlayingRepository.findByUserId(userId) } returns listOf(
+    every { currentlyPlayingRepository.findAll() } returns listOf(
       session1First, session1Second, differentTrack, session2First, session2Second, latestTrack,
     )
 
@@ -469,10 +467,10 @@ class RecentlyPlayedServiceTests {
   @Test
   fun `update creates two partial played items when same track played twice consecutively with progress reset`() {
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
-    every { recentlyPlayedRepository.findMostRecentPlayedAt(userId) } returns null
+    every { recentlyPlayedRepository.findMostRecentPlayedAt() } returns null
     every { spotifyPlayback.getRecentlyPlayed(accessToken, null) } returns emptyList<RecentlyPlayedItem>().right()
-    every { recentlyPlayedRepository.findExistingPlayedAts(userId, any()) } returns emptySet()
-    every { recentlyPartialPlayedRepository.findExistingPlayedAts(userId, any()) } returns emptySet()
+    every { recentlyPlayedRepository.findExistingPlayedAts(any()) } returns emptySet()
+    every { recentlyPartialPlayedRepository.findExistingPlayedAts(any()) } returns emptySet()
     every { recentlyPartialPlayedRepository.saveAll(any()) } just runs
 
     // First play of track-a
@@ -483,7 +481,7 @@ class RecentlyPlayedServiceTests {
     val secondPlay2 = currentlyPlayingItem("track-a", progressMs = 30_000L, observedAt = now - 7.minutes)
     // track-latest is the protected item
     val latestTrack = currentlyPlayingItem("track-latest", progressMs = 10_000L, observedAt = now)
-    every { currentlyPlayingRepository.findByUserId(userId) } returns listOf(
+    every { currentlyPlayingRepository.findAll() } returns listOf(
       firstPlay1, firstPlay2, secondPlay1, secondPlay2, latestTrack,
     )
 
@@ -502,12 +500,12 @@ class RecentlyPlayedServiceTests {
   @Test
   fun `update does not convert the latest currently playing item`() {
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
-    every { recentlyPlayedRepository.findMostRecentPlayedAt(userId) } returns null
+    every { recentlyPlayedRepository.findMostRecentPlayedAt() } returns null
     every { spotifyPlayback.getRecentlyPlayed(accessToken, null) } returns emptyList<RecentlyPlayedItem>().right()
-    every { recentlyPlayedRepository.findExistingPlayedAts(userId, any()) } returns emptySet()
+    every { recentlyPlayedRepository.findExistingPlayedAts(any()) } returns emptySet()
 
     val latestTrack = currentlyPlayingItem("track-latest", progressMs = 60_000L, observedAt = now)
-    every { currentlyPlayingRepository.findByUserId(userId) } returns listOf(latestTrack)
+    every { currentlyPlayingRepository.findAll() } returns listOf(latestTrack)
 
     adapter.fetchRecentlyPlayed(userId)
 
@@ -517,32 +515,32 @@ class RecentlyPlayedServiceTests {
   @Test
   fun `update does not convert partial plays shorter than minimum progress but still deletes them`() {
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
-    every { recentlyPlayedRepository.findMostRecentPlayedAt(userId) } returns null
+    every { recentlyPlayedRepository.findMostRecentPlayedAt() } returns null
     every { spotifyPlayback.getRecentlyPlayed(accessToken, null) } returns emptyList<RecentlyPlayedItem>().right()
-    every { recentlyPlayedRepository.findExistingPlayedAts(userId, any()) } returns emptySet()
+    every { recentlyPlayedRepository.findExistingPlayedAts(any()) } returns emptySet()
 
     val olderTrack = currentlyPlayingItem("track-old", progressMs = 10_000L, observedAt = now - 5.minutes)
     val latestTrack = currentlyPlayingItem("track-latest", progressMs = 5_000L, observedAt = now)
-    every { currentlyPlayingRepository.findByUserId(userId) } returns listOf(olderTrack, latestTrack)
+    every { currentlyPlayingRepository.findAll() } returns listOf(olderTrack, latestTrack)
 
     adapter.fetchRecentlyPlayed(userId)
 
     verify(exactly = 0) { recentlyPartialPlayedRepository.saveAll(any()) }
-    verify { currentlyPlayingRepository.deleteByUserIdAndTrackIds(userId, setOf("track-old")) }
+    verify { currentlyPlayingRepository.deleteByTrackIds(setOf("track-old")) }
   }
 
   @Test
   fun `update notifies dashboard when partial plays are converted`() {
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
-    every { recentlyPlayedRepository.findMostRecentPlayedAt(userId) } returns null
+    every { recentlyPlayedRepository.findMostRecentPlayedAt() } returns null
     every { spotifyPlayback.getRecentlyPlayed(accessToken, null) } returns emptyList<RecentlyPlayedItem>().right()
-    every { recentlyPlayedRepository.findExistingPlayedAts(userId, any()) } returns emptySet()
-    every { recentlyPartialPlayedRepository.findExistingPlayedAts(userId, any()) } returns emptySet()
+    every { recentlyPlayedRepository.findExistingPlayedAts(any()) } returns emptySet()
+    every { recentlyPartialPlayedRepository.findExistingPlayedAts(any()) } returns emptySet()
     every { recentlyPartialPlayedRepository.saveAll(any()) } just runs
 
     val olderTrack = currentlyPlayingItem("track-old", progressMs = 30_000L, observedAt = now - 5.minutes)
     val latestTrack = currentlyPlayingItem("track-latest", progressMs = 10_000L, observedAt = now)
-    every { currentlyPlayingRepository.findByUserId(userId) } returns listOf(olderTrack, latestTrack)
+    every { currentlyPlayingRepository.findAll() } returns listOf(olderTrack, latestTrack)
 
     adapter.fetchRecentlyPlayed(userId)
 
@@ -552,76 +550,76 @@ class RecentlyPlayedServiceTests {
   @Test
   fun `update deletes converted currently playing entries at end`() {
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
-    every { recentlyPlayedRepository.findMostRecentPlayedAt(userId) } returns null
+    every { recentlyPlayedRepository.findMostRecentPlayedAt() } returns null
     every { spotifyPlayback.getRecentlyPlayed(accessToken, null) } returns emptyList<RecentlyPlayedItem>().right()
-    every { recentlyPlayedRepository.findExistingPlayedAts(userId, any()) } returns emptySet()
-    every { recentlyPartialPlayedRepository.findExistingPlayedAts(userId, any()) } returns emptySet()
+    every { recentlyPlayedRepository.findExistingPlayedAts(any()) } returns emptySet()
+    every { recentlyPartialPlayedRepository.findExistingPlayedAts(any()) } returns emptySet()
     every { recentlyPartialPlayedRepository.saveAll(any()) } just runs
 
     val olderTrack = currentlyPlayingItem("track-old", progressMs = 30_000L, observedAt = now - 5.minutes)
     val latestTrack = currentlyPlayingItem("track-latest", progressMs = 10_000L, observedAt = now)
-    every { currentlyPlayingRepository.findByUserId(userId) } returns listOf(olderTrack, latestTrack)
+    every { currentlyPlayingRepository.findAll() } returns listOf(olderTrack, latestTrack)
 
     adapter.fetchRecentlyPlayed(userId)
 
-    verify { currentlyPlayingRepository.deleteByUserIdAndTrackIds(userId, setOf("track-old")) }
+    verify { currentlyPlayingRepository.deleteByTrackIds(setOf("track-old")) }
   }
 
   @Test
   fun `update deletes both completed and converted tracks together at end`() {
     val completedItems = listOf(item(1))
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
-    every { recentlyPlayedRepository.findMostRecentPlayedAt(userId) } returns null
+    every { recentlyPlayedRepository.findMostRecentPlayedAt() } returns null
     every { spotifyPlayback.getRecentlyPlayed(accessToken, null) } returns completedItems.right()
-    every { recentlyPlayedRepository.findExistingPlayedAts(userId, any()) } returns emptySet()
+    every { recentlyPlayedRepository.findExistingPlayedAts(any()) } returns emptySet()
     every { recentlyPlayedRepository.saveAll(any()) } just runs
-    every { recentlyPartialPlayedRepository.findExistingPlayedAts(userId, any()) } returns emptySet()
+    every { recentlyPartialPlayedRepository.findExistingPlayedAts(any()) } returns emptySet()
     every { recentlyPartialPlayedRepository.saveAll(any()) } just runs
 
     val olderTrack = currentlyPlayingItem("track-old", progressMs = 30_000L, observedAt = now - 5.minutes)
     val latestTrack = currentlyPlayingItem("track-latest", progressMs = 10_000L, observedAt = now)
-    every { currentlyPlayingRepository.findByUserId(userId) } returns listOf(olderTrack, latestTrack)
+    every { currentlyPlayingRepository.findAll() } returns listOf(olderTrack, latestTrack)
 
     adapter.fetchRecentlyPlayed(userId)
 
-    verify { currentlyPlayingRepository.deleteByUserIdAndTrackIds(userId, setOf("track-1", "track-old")) }
+    verify { currentlyPlayingRepository.deleteByTrackIds(setOf("track-1", "track-old")) }
   }
 
   @Test
   fun `update does not delete latest item trackId even when older items of same track are converted`() {
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
-    every { recentlyPlayedRepository.findMostRecentPlayedAt(userId) } returns null
+    every { recentlyPlayedRepository.findMostRecentPlayedAt() } returns null
     every { spotifyPlayback.getRecentlyPlayed(accessToken, null) } returns emptyList<RecentlyPlayedItem>().right()
-    every { recentlyPlayedRepository.findExistingPlayedAts(userId, any()) } returns emptySet()
-    every { recentlyPartialPlayedRepository.findExistingPlayedAts(userId, any()) } returns emptySet()
+    every { recentlyPlayedRepository.findExistingPlayedAts(any()) } returns emptySet()
+    every { recentlyPartialPlayedRepository.findExistingPlayedAts(any()) } returns emptySet()
     every { recentlyPartialPlayedRepository.saveAll(any()) } just runs
 
     // session1 of track-a is eligible; different (track-b, below threshold) is not converted; session2 of track-a is the latest (protected)
     val session1 = currentlyPlayingItem("track-a", progressMs = 30_000L, observedAt = now - 6.minutes)
     val different = currentlyPlayingItem("track-b", progressMs = 10_000L, observedAt = now - 4.minutes)
     val session2 = currentlyPlayingItem("track-a", progressMs = 5_000L, observedAt = now)
-    every { currentlyPlayingRepository.findByUserId(userId) } returns listOf(session1, different, session2)
+    every { currentlyPlayingRepository.findAll() } returns listOf(session1, different, session2)
 
     adapter.fetchRecentlyPlayed(userId)
 
     // track-a must NOT be deleted (session2 is the latest item, its trackId is protected)
     // track-b IS deleted even though it's below the conversion threshold — it must not accumulate forever
-    verify { currentlyPlayingRepository.deleteByUserIdAndTrackIds(userId, setOf("track-b")) }
+    verify { currentlyPlayingRepository.deleteByTrackIds(setOf("track-b")) }
   }
 
   @Test
   fun `update saves partial played item with first observedAt as playedAt`() {
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
-    every { recentlyPlayedRepository.findMostRecentPlayedAt(userId) } returns null
+    every { recentlyPlayedRepository.findMostRecentPlayedAt() } returns null
     every { spotifyPlayback.getRecentlyPlayed(accessToken, null) } returns emptyList<RecentlyPlayedItem>().right()
-    every { recentlyPlayedRepository.findExistingPlayedAts(userId, any()) } returns emptySet()
-    every { recentlyPartialPlayedRepository.findExistingPlayedAts(userId, any()) } returns emptySet()
+    every { recentlyPlayedRepository.findExistingPlayedAts(any()) } returns emptySet()
+    every { recentlyPartialPlayedRepository.findExistingPlayedAts(any()) } returns emptySet()
     every { recentlyPartialPlayedRepository.saveAll(any()) } just runs
 
     val firstObserved = now - 5.minutes
     val olderTrack = currentlyPlayingItem("track-old", progressMs = 30_000L, observedAt = firstObserved)
     val latestTrack = currentlyPlayingItem("track-latest", progressMs = 10_000L, observedAt = now)
-    every { currentlyPlayingRepository.findByUserId(userId) } returns listOf(olderTrack, latestTrack)
+    every { currentlyPlayingRepository.findAll() } returns listOf(olderTrack, latestTrack)
 
     adapter.fetchRecentlyPlayed(userId)
 
@@ -633,15 +631,15 @@ class RecentlyPlayedServiceTests {
   @Test
   fun `update does not save partial played item to recently played repository`() {
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
-    every { recentlyPlayedRepository.findMostRecentPlayedAt(userId) } returns null
+    every { recentlyPlayedRepository.findMostRecentPlayedAt() } returns null
     every { spotifyPlayback.getRecentlyPlayed(accessToken, null) } returns emptyList<RecentlyPlayedItem>().right()
-    every { recentlyPlayedRepository.findExistingPlayedAts(userId, any()) } returns emptySet()
-    every { recentlyPartialPlayedRepository.findExistingPlayedAts(userId, any()) } returns emptySet()
+    every { recentlyPlayedRepository.findExistingPlayedAts(any()) } returns emptySet()
+    every { recentlyPartialPlayedRepository.findExistingPlayedAts(any()) } returns emptySet()
     every { recentlyPartialPlayedRepository.saveAll(any()) } just runs
 
     val olderTrack = currentlyPlayingItem("track-old", progressMs = 30_000L, observedAt = now - 5.minutes)
     val latestTrack = currentlyPlayingItem("track-latest", progressMs = 10_000L, observedAt = now)
-    every { currentlyPlayingRepository.findByUserId(userId) } returns listOf(olderTrack, latestTrack)
+    every { currentlyPlayingRepository.findAll() } returns listOf(olderTrack, latestTrack)
 
     adapter.fetchRecentlyPlayed(userId)
 
@@ -655,10 +653,10 @@ class RecentlyPlayedServiceTests {
     partialPlayed: List<RecentlyPartialPlayedItem> = emptyList(),
   ) {
     every { currentUserResolver.userId() } returns userId
-    every { appPlaybackRepository.findMostRecentPlayedAt(userId) } returns null
-    every { recentlyPlayedRepository.findSince(userId, null) } returns recentlyPlayed
-    every { recentlyPartialPlayedRepository.findSince(userId, null) } returns partialPlayed
-    every { appPlaybackRepository.findExistingPlayedAts(userId, any()) } returns emptySet()
+    every { appPlaybackRepository.findMostRecentPlayedAt() } returns null
+    every { recentlyPlayedRepository.findSince(null) } returns recentlyPlayed
+    every { recentlyPartialPlayedRepository.findSince(null) } returns partialPlayed
+    every { appPlaybackRepository.findExistingPlayedAts(any()) } returns emptySet()
     every { appPlaybackRepository.saveAll(any()) } just runs
     every { outboxPort.enqueue(any()) } just runs
   }

--- a/domain-impl/src/test/kotlin/de/chrgroth/spotify/control/domain/playlist/PlaylistCheckServiceTests.kt
+++ b/domain-impl/src/test/kotlin/de/chrgroth/spotify/control/domain/playlist/PlaylistCheckServiceTests.kt
@@ -109,14 +109,14 @@ class PlaylistCheckServiceTests {
     every { checkRunner.checkId } returns checkId
     every { checkRunner.displayName } returns "Test Check"
     every { checkRunner.isApplicable(any()) } returns true
-    every { checkRunner.run(any(), any(), any(), any(), any()) } returns check
+    every { checkRunner.run(any(), any(), any(), any()) } returns check
     every { checkRunners.iterator() } answers { mutableListOf(checkRunner).iterator() }
   }
 
   @Test
   fun `handle returns success and skips notifications when playlist not found`() {
     every { currentUserResolver.userId() } returns userId
-    every { playlistRepository.findByUserIdAndPlaylistId(userId, playlistId) } returns null
+    every { playlistRepository.findByPlaylistId(playlistId) } returns null
 
     val result = adapter.handle(event)
 
@@ -132,8 +132,8 @@ class PlaylistCheckServiceTests {
     val check = buildCheck(succeeded = true)
     setupCheckRunner(check)
     every { currentUserResolver.userId() } returns userId
-    every { playlistRepository.findByUserIdAndPlaylistId(userId, playlistId) } returns playlist
-    every { playlistRepository.findByUserId(userId) } returns listOf(buildPlaylistInfo())
+    every { playlistRepository.findByPlaylistId(playlistId) } returns playlist
+    every { playlistRepository.findAll() } returns listOf(buildPlaylistInfo())
     every { playlistCheckRepository.findByCheckId(fullCheckId) } returns null
     every { playlistCheckRepository.save(any()) } just runs
     every { dashboardRefresh.notifyUserPlaylistChecks() } just runs
@@ -153,8 +153,8 @@ class PlaylistCheckServiceTests {
     val previousCheck = buildCheck(succeeded = false, violations = listOf("Artist – Track t1"))
     setupCheckRunner(check)
     every { currentUserResolver.userId() } returns userId
-    every { playlistRepository.findByUserIdAndPlaylistId(userId, playlistId) } returns playlist
-    every { playlistRepository.findByUserId(userId) } returns listOf(buildPlaylistInfo())
+    every { playlistRepository.findByPlaylistId(playlistId) } returns playlist
+    every { playlistRepository.findAll() } returns listOf(buildPlaylistInfo())
     every { playlistCheckRepository.findByCheckId(fullCheckId) } returns previousCheck
     every { playlistCheckRepository.save(any()) } just runs
     every { dashboardRefresh.notifyUserPlaylistChecks() } just runs
@@ -174,8 +174,8 @@ class PlaylistCheckServiceTests {
     val previousCheck = buildCheck(succeeded = false, violations = listOf("Artist A – Track A"))
     setupCheckRunner(check)
     every { currentUserResolver.userId() } returns userId
-    every { playlistRepository.findByUserIdAndPlaylistId(userId, playlistId) } returns playlist
-    every { playlistRepository.findByUserId(userId) } returns listOf(buildPlaylistInfo())
+    every { playlistRepository.findByPlaylistId(playlistId) } returns playlist
+    every { playlistRepository.findAll() } returns listOf(buildPlaylistInfo())
     every { playlistCheckRepository.findByCheckId(fullCheckId) } returns previousCheck
     every { playlistCheckRepository.save(any()) } just runs
     every { dashboardRefresh.notifyUserPlaylistChecks() } just runs
@@ -196,8 +196,8 @@ class PlaylistCheckServiceTests {
     val previousCheck = buildCheck(succeeded = false, violations = violations)
     setupCheckRunner(check)
     every { currentUserResolver.userId() } returns userId
-    every { playlistRepository.findByUserIdAndPlaylistId(userId, playlistId) } returns playlist
-    every { playlistRepository.findByUserId(userId) } returns listOf(buildPlaylistInfo())
+    every { playlistRepository.findByPlaylistId(playlistId) } returns playlist
+    every { playlistRepository.findAll() } returns listOf(buildPlaylistInfo())
     every { playlistCheckRepository.findByCheckId(fullCheckId) } returns previousCheck
     every { playlistCheckRepository.save(any()) } just runs
     every { dashboardRefresh.notifyUserPlaylistChecks() } just runs
@@ -216,8 +216,8 @@ class PlaylistCheckServiceTests {
     val previousCheck = buildCheck(succeeded = true)
     setupCheckRunner(check)
     every { currentUserResolver.userId() } returns userId
-    every { playlistRepository.findByUserIdAndPlaylistId(userId, playlistId) } returns playlist
-    every { playlistRepository.findByUserId(userId) } returns listOf(buildPlaylistInfo())
+    every { playlistRepository.findByPlaylistId(playlistId) } returns playlist
+    every { playlistRepository.findAll() } returns listOf(buildPlaylistInfo())
     every { playlistCheckRepository.findByCheckId(fullCheckId) } returns previousCheck
     every { playlistCheckRepository.save(any()) } just runs
     every { dashboardRefresh.notifyUserPlaylistChecks() } just runs
@@ -232,7 +232,7 @@ class PlaylistCheckServiceTests {
   @Test
   fun `handle propagates unexpected exception`() {
     every { currentUserResolver.userId() } returns userId
-    every { playlistRepository.findByUserIdAndPlaylistId(userId, playlistId) } throws RuntimeException("DB error")
+    every { playlistRepository.findByPlaylistId(playlistId) } throws RuntimeException("DB error")
 
     org.assertj.core.api.Assertions.assertThatThrownBy { adapter.handle(event) }
       .isInstanceOf(RuntimeException::class.java)
@@ -245,8 +245,8 @@ class PlaylistCheckServiceTests {
     every { checkRunner.isApplicable(any()) } returns false
     every { checkRunners.iterator() } answers { mutableListOf(checkRunner).iterator() }
     every { currentUserResolver.userId() } returns userId
-    every { playlistRepository.findByUserIdAndPlaylistId(userId, playlistId) } returns playlist
-    every { playlistRepository.findByUserId(userId) } returns listOf(buildPlaylistInfo())
+    every { playlistRepository.findByPlaylistId(playlistId) } returns playlist
+    every { playlistRepository.findAll() } returns listOf(buildPlaylistInfo())
     every { dashboardRefresh.notifyUserPlaylistChecks() } just runs
 
     val result = adapter.handle(event)
@@ -269,7 +269,7 @@ class PlaylistCheckServiceTests {
     val playlistInfo = buildPlaylistInfo()
     every { currentUserResolver.userId() } returns userId
     every { userRepository.findById(userId) } returns user
-    every { playlistRepository.findByUserId(userId) } returns listOf(playlistInfo)
+    every { playlistRepository.findAll() } returns listOf(playlistInfo)
     every { playlistCheckRepository.findAll() } returns listOf(check)
     every { checkRunners.iterator() } answers { mutableListOf(checkRunner).iterator() }
     every { checkRunner.checkId } returns checkId
@@ -289,7 +289,7 @@ class PlaylistCheckServiceTests {
   fun `getCheckDashboard falls back to userId when user not found`() {
     every { currentUserResolver.userId() } returns userId
     every { userRepository.findById(userId) } returns null
-    every { playlistRepository.findByUserId(userId) } returns emptyList()
+    every { playlistRepository.findAll() } returns emptyList()
     every { playlistCheckRepository.findAll() } returns emptyList()
     every { checkRunners.iterator() } answers { mutableListOf<PlaylistCheckRunner>().iterator() }
 
@@ -348,7 +348,7 @@ class PlaylistCheckServiceTests {
     every { checkRunners.iterator() } returns mutableListOf(checkRunner).iterator()
     every { checkRunner.checkId } returns checkId
     every { checkRunner.canFix() } returns true
-    every { playlistRepository.findByUserIdAndPlaylistId(userId, playlistId) } returns null
+    every { playlistRepository.findByPlaylistId(playlistId) } returns null
 
     val result = adapter.runFix(playlistId, checkId)
 
@@ -364,10 +364,10 @@ class PlaylistCheckServiceTests {
     every { checkRunners.iterator() } returns mutableListOf(checkRunner).iterator()
     every { checkRunner.checkId } returns checkId
     every { checkRunner.canFix() } returns true
-    every { playlistRepository.findByUserIdAndPlaylistId(userId, playlistId) } returns playlist
-    every { playlistRepository.findByUserId(userId) } returns listOf(playlistInfo)
+    every { playlistRepository.findByPlaylistId(playlistId) } returns playlist
+    every { playlistRepository.findAll() } returns listOf(playlistInfo)
     every { spotifyAccessToken.getValidAccessToken() } returns AccessToken("token")
-    every { checkRunner.fix(userId, AccessToken("token"), playlistId, playlist, playlistInfo, listOf(playlistInfo)) } returns Unit.right()
+    every { checkRunner.fix(AccessToken("token"), playlistId, playlist, playlistInfo, listOf(playlistInfo)) } returns Unit.right()
     every { outboxPort.enqueue(any()) } just runs
 
     val result = adapter.runFix(playlistId, checkId)

--- a/domain-impl/src/test/kotlin/de/chrgroth/spotify/control/domain/playlist/PlaylistServiceTests.kt
+++ b/domain-impl/src/test/kotlin/de/chrgroth/spotify/control/domain/playlist/PlaylistServiceTests.kt
@@ -141,15 +141,15 @@ class PlaylistServiceTests {
       buildSpotifyItem("p1", ownerId = "user-1"),
       buildSpotifyItem("p2", ownerId = "other-user"),
     ).right()
-    every { playlistRepository.findByUserId(userId) } returns emptyList()
-    every { playlistRepository.replaceAll(any(), any()) } just runs
+    every { playlistRepository.findAll() } returns emptyList()
+    every { playlistRepository.replaceAll(any()) } just runs
     every { dashboardRefresh.notifyUserPlaylistMetadata() } just runs
 
     val result = adapter.syncPlaylists()
 
     assertThat(result.isRight()).isTrue()
     val savedSlot = slot<List<PlaylistInfo>>()
-    verify { playlistRepository.replaceAll(userId, capture(savedSlot)) }
+    verify { playlistRepository.replaceAll(capture(savedSlot)) }
     assertThat(savedSlot.captured).hasSize(1)
     assertThat(savedSlot.captured[0].spotifyPlaylistId).isEqualTo("p1")
   }
@@ -161,15 +161,15 @@ class PlaylistServiceTests {
     every { currentUserResolver.userId() } returns userId
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
     every { spotifyPlaylist.getPlaylists(accessToken) } returns listOf(buildSpotifyItem("p1")).right()
-    every { playlistRepository.findByUserId(userId) } returns emptyList()
-    every { playlistRepository.replaceAll(any(), any()) } just runs
+    every { playlistRepository.findAll() } returns emptyList()
+    every { playlistRepository.replaceAll(any()) } just runs
     every { dashboardRefresh.notifyUserPlaylistMetadata() } just runs
 
     val result = adapter.syncPlaylists()
 
     assertThat(result.isRight()).isTrue()
     val savedSlot = slot<List<PlaylistInfo>>()
-    verify { playlistRepository.replaceAll(userId, capture(savedSlot)) }
+    verify { playlistRepository.replaceAll(capture(savedSlot)) }
     assertThat(savedSlot.captured).hasSize(1)
     assertThat(savedSlot.captured[0].spotifyPlaylistId).isEqualTo("p1")
     assertThat(savedSlot.captured[0].syncStatus).isEqualTo(PlaylistSyncStatus.PASSIVE)
@@ -182,13 +182,13 @@ class PlaylistServiceTests {
     every { currentUserResolver.userId() } returns userId
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
     every { spotifyPlaylist.getPlaylists(accessToken) } returns listOf(buildSpotifyItem("p1")).right()
-    every { playlistRepository.findByUserId(userId) } returns listOf(buildPlaylistInfo("p1", syncStatus = PlaylistSyncStatus.PASSIVE))
-    every { playlistRepository.replaceAll(any(), any()) } just runs
+    every { playlistRepository.findAll() } returns listOf(buildPlaylistInfo("p1", syncStatus = PlaylistSyncStatus.PASSIVE))
+    every { playlistRepository.replaceAll(any()) } just runs
 
     adapter.syncPlaylists()
 
     val savedSlot = slot<List<PlaylistInfo>>()
-    verify { playlistRepository.replaceAll(userId, capture(savedSlot)) }
+    verify { playlistRepository.replaceAll(capture(savedSlot)) }
     assertThat(savedSlot.captured[0].syncStatus).isEqualTo(PlaylistSyncStatus.PASSIVE)
   }
 
@@ -199,14 +199,14 @@ class PlaylistServiceTests {
     every { currentUserResolver.userId() } returns userId
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
     every { spotifyPlaylist.getPlaylists(accessToken) } returns listOf(buildSpotifyItem("p1")).right()
-    every { playlistRepository.findByUserId(userId) } returns listOf(buildPlaylistInfo("p1", syncStatus = PlaylistSyncStatus.ACTIVE))
-    every { playlistRepository.replaceAll(any(), any()) } just runs
-    every { playlistRepository.findByUserIdAndPlaylistId(userId, "p1") } returns mockk()
+    every { playlistRepository.findAll() } returns listOf(buildPlaylistInfo("p1", syncStatus = PlaylistSyncStatus.ACTIVE))
+    every { playlistRepository.replaceAll(any()) } just runs
+    every { playlistRepository.findByPlaylistId("p1") } returns mockk()
 
     adapter.syncPlaylists()
 
     val savedSlot = slot<List<PlaylistInfo>>()
-    verify { playlistRepository.replaceAll(userId, capture(savedSlot)) }
+    verify { playlistRepository.replaceAll(capture(savedSlot)) }
     assertThat(savedSlot.captured[0].syncStatus).isEqualTo(PlaylistSyncStatus.ACTIVE)
   }
 
@@ -217,14 +217,14 @@ class PlaylistServiceTests {
     every { currentUserResolver.userId() } returns userId
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
     every { spotifyPlaylist.getPlaylists(accessToken) } returns listOf(buildSpotifyItem("p1", snapshotId = "snap-1")).right()
-    every { playlistRepository.findByUserId(userId) } returns listOf(buildPlaylistInfo("p1", snapshotId = "snap-1"))
-    every { playlistRepository.replaceAll(any(), any()) } just runs
-    every { playlistRepository.findByUserIdAndPlaylistId(userId, "p1") } returns mockk()
+    every { playlistRepository.findAll() } returns listOf(buildPlaylistInfo("p1", snapshotId = "snap-1"))
+    every { playlistRepository.replaceAll(any()) } just runs
+    every { playlistRepository.findByPlaylistId("p1") } returns mockk()
 
     adapter.syncPlaylists()
 
     val savedSlot = slot<List<PlaylistInfo>>()
-    verify { playlistRepository.replaceAll(userId, capture(savedSlot)) }
+    verify { playlistRepository.replaceAll(capture(savedSlot)) }
     assertThat(savedSlot.captured[0].lastSnapshotIdSyncTime).isEqualTo(now - 1.hours)
   }
 
@@ -235,14 +235,14 @@ class PlaylistServiceTests {
     every { currentUserResolver.userId() } returns userId
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
     every { spotifyPlaylist.getPlaylists(accessToken) } returns listOf(buildSpotifyItem("p1", snapshotId = "snap-2")).right()
-    every { playlistRepository.findByUserId(userId) } returns listOf(buildPlaylistInfo("p1", snapshotId = "snap-1"))
-    every { playlistRepository.replaceAll(any(), any()) } just runs
+    every { playlistRepository.findAll() } returns listOf(buildPlaylistInfo("p1", snapshotId = "snap-1"))
+    every { playlistRepository.replaceAll(any()) } just runs
     every { outboxPort.enqueue(any()) } just runs
 
     adapter.syncPlaylists()
 
     val savedSlot = slot<List<PlaylistInfo>>()
-    verify { playlistRepository.replaceAll(userId, capture(savedSlot)) }
+    verify { playlistRepository.replaceAll(capture(savedSlot)) }
     assertThat(savedSlot.captured[0].lastSnapshotIdSyncTime).isGreaterThan(now - 1.hours)
   }
 
@@ -253,9 +253,9 @@ class PlaylistServiceTests {
     every { currentUserResolver.userId() } returns userId
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
     every { spotifyPlaylist.getPlaylists(accessToken) } returns listOf(buildSpotifyItem("p1"), buildSpotifyItem("p2")).right()
-    every { playlistRepository.findByUserId(userId) } returns listOf(buildPlaylistInfo("p1"))
-    every { playlistRepository.replaceAll(any(), any()) } just runs
-    every { playlistRepository.findByUserIdAndPlaylistId(userId, "p1") } returns mockk()
+    every { playlistRepository.findAll() } returns listOf(buildPlaylistInfo("p1"))
+    every { playlistRepository.replaceAll(any()) } just runs
+    every { playlistRepository.findByPlaylistId("p1") } returns mockk()
     every { outboxPort.enqueue(any()) } just runs
     every { dashboardRefresh.notifyUserPlaylistMetadata() } just runs
 
@@ -272,9 +272,9 @@ class PlaylistServiceTests {
     every { currentUserResolver.userId() } returns userId
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
     every { spotifyPlaylist.getPlaylists(accessToken) } returns listOf(buildSpotifyItem("p1")).right()
-    every { playlistRepository.findByUserId(userId) } returns listOf(buildPlaylistInfo("p1"), buildPlaylistInfo("p2"))
-    every { playlistRepository.replaceAll(any(), any()) } just runs
-    every { playlistRepository.findByUserIdAndPlaylistId(userId, "p1") } returns mockk()
+    every { playlistRepository.findAll() } returns listOf(buildPlaylistInfo("p1"), buildPlaylistInfo("p2"))
+    every { playlistRepository.replaceAll(any()) } just runs
+    every { playlistRepository.findByPlaylistId("p1") } returns mockk()
     every { dashboardRefresh.notifyUserPlaylistMetadata() } just runs
 
     val result = adapter.syncPlaylists()
@@ -290,9 +290,9 @@ class PlaylistServiceTests {
     every { currentUserResolver.userId() } returns userId
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
     every { spotifyPlaylist.getPlaylists(accessToken) } returns listOf(buildSpotifyItem("p1")).right()
-    every { playlistRepository.findByUserId(userId) } returns listOf(buildPlaylistInfo("p1"))
-    every { playlistRepository.replaceAll(any(), any()) } just runs
-    every { playlistRepository.findByUserIdAndPlaylistId(userId, "p1") } returns mockk()
+    every { playlistRepository.findAll() } returns listOf(buildPlaylistInfo("p1"))
+    every { playlistRepository.replaceAll(any()) } just runs
+    every { playlistRepository.findByPlaylistId("p1") } returns mockk()
 
     val result = adapter.syncPlaylists()
 
@@ -311,7 +311,7 @@ class PlaylistServiceTests {
     val result = adapter.syncPlaylists()
 
     assertThat(result.isLeft()).isTrue()
-    verify(exactly = 0) { playlistRepository.replaceAll(any(), any()) }
+    verify(exactly = 0) { playlistRepository.replaceAll(any()) }
   }
 
   @Test
@@ -345,7 +345,7 @@ class PlaylistServiceTests {
     val user = buildUser()
     every { userRepository.findById(userId) } returns user
     every { currentUserResolver.userId() } returns userId
-    every { playlistRepository.findByUserId(userId) } returns listOf(buildPlaylistInfo("p1"))
+    every { playlistRepository.findAll() } returns listOf(buildPlaylistInfo("p1"))
 
     val result = adapter.updateSyncStatus("p-unknown", PlaylistSyncStatus.PASSIVE)
 
@@ -358,12 +358,12 @@ class PlaylistServiceTests {
     val user = buildUser()
     every { userRepository.findById(userId) } returns user
     every { currentUserResolver.userId() } returns userId
-    every { playlistRepository.findByUserId(userId) } returns listOf(
+    every { playlistRepository.findAll() } returns listOf(
       buildPlaylistInfo("p1", syncStatus = PlaylistSyncStatus.ACTIVE),
       buildPlaylistInfo("p2", syncStatus = PlaylistSyncStatus.ACTIVE),
     )
-    every { playlistRepository.replaceAll(any(), any()) } just runs
-    every { playlistRepository.findByUserIdAndPlaylistId(userId, "p1") } returns mockk()
+    every { playlistRepository.replaceAll(any()) } just runs
+    every { playlistRepository.findByPlaylistId("p1") } returns mockk()
     every { dashboardRefresh.notifyUserPlaylistMetadata() } just runs
     every { playlistCheckRepository.deleteByPlaylistId("p1") } just runs
 
@@ -371,7 +371,7 @@ class PlaylistServiceTests {
 
     assertThat(result.isRight()).isTrue()
     val savedSlot = slot<List<PlaylistInfo>>()
-    verify { playlistRepository.replaceAll(userId, capture(savedSlot)) }
+    verify { playlistRepository.replaceAll(capture(savedSlot)) }
     val updated = savedSlot.captured.associateBy { it.spotifyPlaylistId }
     assertThat(updated["p1"]!!.syncStatus).isEqualTo(PlaylistSyncStatus.PASSIVE)
     assertThat(updated["p2"]!!.syncStatus).isEqualTo(PlaylistSyncStatus.ACTIVE)
@@ -384,8 +384,8 @@ class PlaylistServiceTests {
     every { currentUserResolver.userId() } returns userId
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
     every { spotifyPlaylist.getPlaylists(accessToken) } returns listOf(buildSpotifyItem("p1", snapshotId = "snap-2")).right()
-    every { playlistRepository.findByUserId(userId) } returns listOf(buildPlaylistInfo("p1", snapshotId = "snap-1"))
-    every { playlistRepository.replaceAll(any(), any()) } just runs
+    every { playlistRepository.findAll() } returns listOf(buildPlaylistInfo("p1", snapshotId = "snap-1"))
+    every { playlistRepository.replaceAll(any()) } just runs
     every { outboxPort.enqueue(any()) } just runs
 
     adapter.syncPlaylists()
@@ -400,9 +400,9 @@ class PlaylistServiceTests {
     every { currentUserResolver.userId() } returns userId
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
     every { spotifyPlaylist.getPlaylists(accessToken) } returns listOf(buildSpotifyItem("p1")).right()
-    every { playlistRepository.findByUserId(userId) } returns listOf(buildPlaylistInfo("p1"))
-    every { playlistRepository.replaceAll(any(), any()) } just runs
-    every { playlistRepository.findByUserIdAndPlaylistId(userId, "p1") } returns null
+    every { playlistRepository.findAll() } returns listOf(buildPlaylistInfo("p1"))
+    every { playlistRepository.replaceAll(any()) } just runs
+    every { playlistRepository.findByPlaylistId("p1") } returns null
     every { outboxPort.enqueue(any()) } just runs
 
     adapter.syncPlaylists()
@@ -417,8 +417,8 @@ class PlaylistServiceTests {
     every { currentUserResolver.userId() } returns userId
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
     every { spotifyPlaylist.getPlaylists(accessToken) } returns listOf(buildSpotifyItem("p1")).right()
-    every { playlistRepository.findByUserId(userId) } returns listOf(buildPlaylistInfo("p1", syncStatus = PlaylistSyncStatus.PASSIVE))
-    every { playlistRepository.replaceAll(any(), any()) } just runs
+    every { playlistRepository.findAll() } returns listOf(buildPlaylistInfo("p1", syncStatus = PlaylistSyncStatus.PASSIVE))
+    every { playlistRepository.replaceAll(any()) } just runs
 
     adapter.syncPlaylists()
 
@@ -432,9 +432,9 @@ class PlaylistServiceTests {
     every { currentUserResolver.userId() } returns userId
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
     every { spotifyPlaylist.getPlaylists(accessToken) } returns listOf(buildSpotifyItem("p1")).right()
-    every { playlistRepository.findByUserId(userId) } returns listOf(buildPlaylistInfo("p1"))
-    every { playlistRepository.replaceAll(any(), any()) } just runs
-    every { playlistRepository.findByUserIdAndPlaylistId(userId, "p1") } returns mockk()
+    every { playlistRepository.findAll() } returns listOf(buildPlaylistInfo("p1"))
+    every { playlistRepository.replaceAll(any()) } just runs
+    every { playlistRepository.findByPlaylistId("p1") } returns mockk()
 
     adapter.syncPlaylists()
 
@@ -479,14 +479,14 @@ class PlaylistServiceTests {
     every { currentUserResolver.userId() } returns userId
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
     every { spotifyPlaylist.getPlaylistTracksPage(accessToken, "p1", null) } returns page.right()
-    every { playlistRepository.save(userId, buildPlaylist("p1")) } just runs
+    every { playlistRepository.save(buildPlaylist("p1")) } just runs
     every { outboxPort.enqueue(any()) } just runs
-    every { playlistRepository.updateLastSyncTime(userId, "p1", any()) } just runs
+    every { playlistRepository.updateLastSyncTime("p1", any()) } just runs
 
     val result = adapter.syncPlaylistData("p1")
 
     assertThat(result.isRight()).isTrue()
-    verify { playlistRepository.save(userId, buildPlaylist("p1")) }
+    verify { playlistRepository.save(buildPlaylist("p1")) }
   }
 
   @Test
@@ -497,9 +497,9 @@ class PlaylistServiceTests {
     every { currentUserResolver.userId() } returns userId
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
     every { spotifyPlaylist.getPlaylistTracksPage(accessToken, "p1", null) } returns page.right()
-    every { playlistRepository.save(userId, any()) } just runs
+    every { playlistRepository.save(any()) } just runs
     every { outboxPort.enqueue(any()) } just runs
-    every { playlistRepository.updateLastSyncTime(userId, "p1", any()) } just runs
+    every { playlistRepository.updateLastSyncTime("p1", any()) } just runs
 
     adapter.syncPlaylistData("p1")
 
@@ -518,13 +518,13 @@ class PlaylistServiceTests {
     every { currentUserResolver.userId() } returns userId
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
     every { spotifyPlaylist.getPlaylistTracksPage(accessToken, "p1", null) } returns page.right()
-    every { playlistRepository.save(userId, any()) } just runs
+    every { playlistRepository.save(any()) } just runs
     every { outboxPort.enqueue(any()) } just runs
-    every { playlistRepository.updateLastSyncTime(userId, "p1", any()) } just runs
+    every { playlistRepository.updateLastSyncTime("p1", any()) } just runs
 
     adapter.syncPlaylistData("p1")
 
-    verify(exactly = 1) { playlistRepository.updateLastSyncTime(eq(userId), eq("p1"), any()) }
+    verify(exactly = 1) { playlistRepository.updateLastSyncTime(eq("p1"), any()) }
   }
 
   @Test
@@ -536,12 +536,12 @@ class PlaylistServiceTests {
     every { currentUserResolver.userId() } returns userId
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
     every { spotifyPlaylist.getPlaylistTracksPage(accessToken, "p1", null) } returns page.right()
-    every { playlistRepository.save(userId, any()) } just runs
+    every { playlistRepository.save(any()) } just runs
     every { outboxPort.enqueue(any()) } just runs
 
     adapter.syncPlaylistData("p1")
 
-    verify(exactly = 0) { playlistRepository.updateLastSyncTime(any(), any(), any()) }
+    verify(exactly = 0) { playlistRepository.updateLastSyncTime(any(), any()) }
   }
 
   @Test
@@ -553,7 +553,7 @@ class PlaylistServiceTests {
     every { currentUserResolver.userId() } returns userId
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
     every { spotifyPlaylist.getPlaylistTracksPage(accessToken, "p1", null) } returns page.right()
-    every { playlistRepository.save(userId, any()) } just runs
+    every { playlistRepository.save(any()) } just runs
     every { outboxPort.enqueue(any()) } just runs
 
     adapter.syncPlaylistData("p1")
@@ -570,9 +570,9 @@ class PlaylistServiceTests {
     every { currentUserResolver.userId() } returns userId
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
     every { spotifyPlaylist.getPlaylistTracksPage(accessToken, "p1", null) } returns page.right()
-    every { playlistRepository.save(userId, any()) } just runs
+    every { playlistRepository.save(any()) } just runs
     every { outboxPort.enqueue(any()) } just runs
-    every { playlistRepository.updateLastSyncTime(userId, "p1", any()) } just runs
+    every { playlistRepository.updateLastSyncTime("p1", any()) } just runs
 
     adapter.syncPlaylistData("p1")
 
@@ -589,15 +589,15 @@ class PlaylistServiceTests {
     every { currentUserResolver.userId() } returns userId
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
     every { spotifyPlaylist.getPlaylistTracksPage(accessToken, "p1", nextPageUrl) } returns page.right()
-    every { playlistRepository.appendTracks(userId, "p1", page.tracks) } just runs
+    every { playlistRepository.appendTracks("p1", page.tracks) } just runs
     every { outboxPort.enqueue(any()) } just runs
-    every { playlistRepository.updateLastSyncTime(userId, "p1", any()) } just runs
+    every { playlistRepository.updateLastSyncTime("p1", any()) } just runs
 
     val result = adapter.syncPlaylistData("p1", nextPageUrl)
 
     assertThat(result.isRight()).isTrue()
-    verify(exactly = 1) { playlistRepository.appendTracks(userId, "p1", page.tracks) }
-    verify(exactly = 0) { playlistRepository.save(any(), any()) }
+    verify(exactly = 1) { playlistRepository.appendTracks("p1", page.tracks) }
+    verify(exactly = 0) { playlistRepository.save(any()) }
   }
 
   @Test
@@ -615,8 +615,8 @@ class PlaylistServiceTests {
 
     assertThat(result.isRight()).isTrue()
     verify(exactly = 1) { outboxPort.enqueue(DomainOutboxEvent.SyncPlaylistData("p1")) }
-    verify(exactly = 0) { playlistRepository.appendTracks(any(), any(), any()) }
-    verify(exactly = 0) { playlistRepository.save(any(), any()) }
+    verify(exactly = 0) { playlistRepository.appendTracks(any(), any()) }
+    verify(exactly = 0) { playlistRepository.save(any()) }
   }
 
   @Test
@@ -628,14 +628,14 @@ class PlaylistServiceTests {
     every { currentUserResolver.userId() } returns userId
     every { spotifyAccessToken.getValidAccessToken() } returns accessToken
     every { spotifyPlaylist.getPlaylistTracksPage(accessToken, "p1", nextPageUrl) } returns page.right()
-    every { playlistRepository.appendTracks(userId, "p1", page.tracks) } just runs
+    every { playlistRepository.appendTracks("p1", page.tracks) } just runs
     every { outboxPort.enqueue(any()) } just runs
-    every { playlistRepository.updateLastSyncTime(userId, "p1", any()) } just runs
+    every { playlistRepository.updateLastSyncTime("p1", any()) } just runs
 
     val result = adapter.syncPlaylistData("p1", nextPageUrl, "snap-1")
 
     assertThat(result.isRight()).isTrue()
-    verify(exactly = 1) { playlistRepository.appendTracks(userId, "p1", page.tracks) }
+    verify(exactly = 1) { playlistRepository.appendTracks("p1", page.tracks) }
     verify(exactly = 0) { outboxPort.enqueue(DomainOutboxEvent.SyncPlaylistData("p1")) }
   }
 
@@ -651,7 +651,7 @@ class PlaylistServiceTests {
     val result = adapter.syncPlaylistData("p1")
 
     assertThat(result.isLeft()).isTrue()
-    verify(exactly = 0) { playlistRepository.save(any(), any()) }
+    verify(exactly = 0) { playlistRepository.save(any()) }
   }
 
   // --- updateSyncStatus enqueue tests ---
@@ -661,8 +661,8 @@ class PlaylistServiceTests {
     val user = buildUser()
     every { userRepository.findById(userId) } returns user
     every { currentUserResolver.userId() } returns userId
-    every { playlistRepository.findByUserId(userId) } returns listOf(buildPlaylistInfo("p1", syncStatus = PlaylistSyncStatus.PASSIVE))
-    every { playlistRepository.replaceAll(any(), any()) } just runs
+    every { playlistRepository.findAll() } returns listOf(buildPlaylistInfo("p1", syncStatus = PlaylistSyncStatus.PASSIVE))
+    every { playlistRepository.replaceAll(any()) } just runs
     every { outboxPort.enqueue(any()) } just runs
     every { dashboardRefresh.notifyUserPlaylistMetadata() } just runs
 
@@ -677,8 +677,8 @@ class PlaylistServiceTests {
     val user = buildUser()
     every { userRepository.findById(userId) } returns user
     every { currentUserResolver.userId() } returns userId
-    every { playlistRepository.findByUserId(userId) } returns listOf(buildPlaylistInfo("p1", syncStatus = PlaylistSyncStatus.PASSIVE))
-    every { playlistRepository.replaceAll(any(), any()) } just runs
+    every { playlistRepository.findAll() } returns listOf(buildPlaylistInfo("p1", syncStatus = PlaylistSyncStatus.PASSIVE))
+    every { playlistRepository.replaceAll(any()) } just runs
     every { outboxPort.enqueue(any()) } just runs
     every { dashboardRefresh.notifyUserPlaylistMetadata() } just runs
 
@@ -694,9 +694,9 @@ class PlaylistServiceTests {
     val user = buildUser()
     every { userRepository.findById(userId) } returns user
     every { currentUserResolver.userId() } returns userId
-    every { playlistRepository.findByUserId(userId) } returns listOf(buildPlaylistInfo("p1", syncStatus = PlaylistSyncStatus.ACTIVE))
-    every { playlistRepository.replaceAll(any(), any()) } just runs
-    every { playlistRepository.findByUserIdAndPlaylistId(userId, "p1") } returns mockk()
+    every { playlistRepository.findAll() } returns listOf(buildPlaylistInfo("p1", syncStatus = PlaylistSyncStatus.ACTIVE))
+    every { playlistRepository.replaceAll(any()) } just runs
+    every { playlistRepository.findByPlaylistId("p1") } returns mockk()
     every { dashboardRefresh.notifyUserPlaylistMetadata() } just runs
     every { playlistCheckRepository.deleteByPlaylistId("p1") } just runs
 
@@ -711,9 +711,9 @@ class PlaylistServiceTests {
     val user = buildUser()
     every { userRepository.findById(userId) } returns user
     every { currentUserResolver.userId() } returns userId
-    every { playlistRepository.findByUserId(userId) } returns listOf(buildPlaylistInfo("p1", syncStatus = PlaylistSyncStatus.PASSIVE))
-    every { playlistRepository.replaceAll(any(), any()) } just runs
-    every { playlistRepository.findByUserIdAndPlaylistId(userId, "p1") } returns mockk()
+    every { playlistRepository.findAll() } returns listOf(buildPlaylistInfo("p1", syncStatus = PlaylistSyncStatus.PASSIVE))
+    every { playlistRepository.replaceAll(any()) } just runs
+    every { playlistRepository.findByPlaylistId("p1") } returns mockk()
     every { outboxPort.enqueue(any()) } just runs
     every { dashboardRefresh.notifyUserPlaylistMetadata() } just runs
 
@@ -728,9 +728,9 @@ class PlaylistServiceTests {
     val user = buildUser()
     every { userRepository.findById(userId) } returns user
     every { currentUserResolver.userId() } returns userId
-    every { playlistRepository.findByUserId(userId) } returns listOf(buildPlaylistInfo("p1", syncStatus = PlaylistSyncStatus.ACTIVE))
-    every { playlistRepository.replaceAll(any(), any()) } just runs
-    every { playlistRepository.findByUserIdAndPlaylistId(userId, "p1") } returns mockk()
+    every { playlistRepository.findAll() } returns listOf(buildPlaylistInfo("p1", syncStatus = PlaylistSyncStatus.ACTIVE))
+    every { playlistRepository.replaceAll(any()) } just runs
+    every { playlistRepository.findByPlaylistId("p1") } returns mockk()
     every { dashboardRefresh.notifyUserPlaylistMetadata() } just runs
     every { playlistCheckRepository.deleteByPlaylistId("p1") } just runs
 
@@ -745,9 +745,9 @@ class PlaylistServiceTests {
     val user = buildUser()
     every { userRepository.findById(userId) } returns user
     every { currentUserResolver.userId() } returns userId
-    every { playlistRepository.findByUserId(userId) } returns listOf(buildPlaylistInfo("p1", syncStatus = PlaylistSyncStatus.PASSIVE))
-    every { playlistRepository.replaceAll(any(), any()) } just runs
-    every { playlistRepository.findByUserIdAndPlaylistId(userId, "p1") } returns mockk()
+    every { playlistRepository.findAll() } returns listOf(buildPlaylistInfo("p1", syncStatus = PlaylistSyncStatus.PASSIVE))
+    every { playlistRepository.replaceAll(any()) } just runs
+    every { playlistRepository.findByPlaylistId("p1") } returns mockk()
     every { outboxPort.enqueue(any()) } just runs
     every { dashboardRefresh.notifyUserPlaylistMetadata() } just runs
 
@@ -762,8 +762,8 @@ class PlaylistServiceTests {
     val user = buildUser()
     every { userRepository.findById(userId) } returns user
     every { currentUserResolver.userId() } returns userId
-    every { playlistRepository.findByUserId(userId) } returns listOf(buildPlaylistInfo("p1", syncStatus = PlaylistSyncStatus.PASSIVE, name = "All"))
-    every { playlistRepository.replaceAll(any(), any()) } just runs
+    every { playlistRepository.findAll() } returns listOf(buildPlaylistInfo("p1", syncStatus = PlaylistSyncStatus.PASSIVE, name = "All"))
+    every { playlistRepository.replaceAll(any()) } just runs
     every { outboxPort.enqueue(any()) } just runs
     every { dashboardRefresh.notifyUserPlaylistMetadata() } just runs
 
@@ -771,7 +771,7 @@ class PlaylistServiceTests {
 
     assertThat(result.isRight()).isTrue()
     val savedSlot = slot<List<PlaylistInfo>>()
-    verify { playlistRepository.replaceAll(userId, capture(savedSlot)) }
+    verify { playlistRepository.replaceAll(capture(savedSlot)) }
     assertThat(savedSlot.captured.find { it.spotifyPlaylistId == "p1" }!!.type).isEqualTo(PlaylistType.ALL)
   }
 
@@ -780,8 +780,8 @@ class PlaylistServiceTests {
     val user = buildUser()
     every { userRepository.findById(userId) } returns user
     every { currentUserResolver.userId() } returns userId
-    every { playlistRepository.findByUserId(userId) } returns listOf(buildPlaylistInfo("p1", syncStatus = PlaylistSyncStatus.PASSIVE, name = "ALL"))
-    every { playlistRepository.replaceAll(any(), any()) } just runs
+    every { playlistRepository.findAll() } returns listOf(buildPlaylistInfo("p1", syncStatus = PlaylistSyncStatus.PASSIVE, name = "ALL"))
+    every { playlistRepository.replaceAll(any()) } just runs
     every { outboxPort.enqueue(any()) } just runs
     every { dashboardRefresh.notifyUserPlaylistMetadata() } just runs
 
@@ -789,7 +789,7 @@ class PlaylistServiceTests {
 
     assertThat(result.isRight()).isTrue()
     val savedSlot = slot<List<PlaylistInfo>>()
-    verify { playlistRepository.replaceAll(userId, capture(savedSlot)) }
+    verify { playlistRepository.replaceAll(capture(savedSlot)) }
     assertThat(savedSlot.captured.find { it.spotifyPlaylistId == "p1" }!!.type).isEqualTo(PlaylistType.ALL)
   }
 
@@ -811,7 +811,7 @@ class PlaylistServiceTests {
     val user = buildUser()
     every { userRepository.findById(userId) } returns user
     every { currentUserResolver.userId() } returns userId
-    every { playlistRepository.findByUserId(userId) } returns emptyList()
+    every { playlistRepository.findAll() } returns emptyList()
 
     val result = adapter.enqueueSyncPlaylistData("p1")
 
@@ -825,7 +825,7 @@ class PlaylistServiceTests {
     val user = buildUser()
     every { userRepository.findById(userId) } returns user
     every { currentUserResolver.userId() } returns userId
-    every { playlistRepository.findByUserId(userId) } returns listOf(buildPlaylistInfo("p1", syncStatus = PlaylistSyncStatus.PASSIVE))
+    every { playlistRepository.findAll() } returns listOf(buildPlaylistInfo("p1", syncStatus = PlaylistSyncStatus.PASSIVE))
 
     val result = adapter.enqueueSyncPlaylistData("p1")
 
@@ -839,7 +839,7 @@ class PlaylistServiceTests {
     val user = buildUser()
     every { userRepository.findById(userId) } returns user
     every { currentUserResolver.userId() } returns userId
-    every { playlistRepository.findByUserId(userId) } returns listOf(buildPlaylistInfo("p1"))
+    every { playlistRepository.findAll() } returns listOf(buildPlaylistInfo("p1"))
     every { outboxPort.enqueue(any()) } just runs
 
     val result = adapter.enqueueSyncPlaylistData("p1")

--- a/domain-impl/src/test/kotlin/de/chrgroth/spotify/control/domain/playlist/check/DuplicateTrackIdsCheckRunnerTests.kt
+++ b/domain-impl/src/test/kotlin/de/chrgroth/spotify/control/domain/playlist/check/DuplicateTrackIdsCheckRunnerTests.kt
@@ -14,7 +14,6 @@ import de.chrgroth.spotify.control.domain.model.playlist.PlaylistTrack
 import de.chrgroth.spotify.control.domain.model.playlist.PlaylistType
 import de.chrgroth.spotify.control.domain.model.catalog.TrackId
 import de.chrgroth.spotify.control.domain.model.user.AccessToken
-import de.chrgroth.spotify.control.domain.model.user.UserId
 import de.chrgroth.spotify.control.domain.port.out.catalog.AppTrackRepositoryPort
 import de.chrgroth.spotify.control.domain.port.out.playlist.SpotifyPlaylistPort
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry
@@ -33,7 +32,6 @@ class DuplicateTrackIdsCheckRunnerTests {
   private val meterRegistry = SimpleMeterRegistry()
   private val runner = DuplicateTrackIdsCheckRunner(appTrackRepository, spotifyPlaylist, meterRegistry)
 
-  private val userId = UserId("user-1")
   private val accessToken = AccessToken("token")
   private val playlistId = "playlist-1"
 
@@ -77,7 +75,7 @@ class DuplicateTrackIdsCheckRunnerTests {
   fun `run returns no violations for unique tracks`() {
     val playlist = buildPlaylist(listOf(buildTrack("t1"), buildTrack("t2")))
 
-    val result = runner.run(userId, playlistId, playlist, null, emptyList())
+    val result = runner.run(playlistId, playlist, null, emptyList())
 
     assertThat(result.succeeded).isTrue()
     assertThat(result.violations).isEmpty()
@@ -89,7 +87,7 @@ class DuplicateTrackIdsCheckRunnerTests {
     val playlist = buildPlaylist(listOf(buildTrack("t1"), buildTrack("t1"), buildTrack("t2")))
     every { appTrackRepository.findByTrackIds(setOf(TrackId("t1"))) } returns listOf(buildAppTrack("t1", "Song A", "Artist A"))
 
-    val result = runner.run(userId, playlistId, playlist, null, emptyList())
+    val result = runner.run(playlistId, playlist, null, emptyList())
 
     assertThat(result.succeeded).isFalse()
     assertThat(result.violations).containsExactly("Artist A – Song A")
@@ -110,7 +108,7 @@ class DuplicateTrackIdsCheckRunnerTests {
       buildAppTrack("t2", "Song B", "Artist B"),
     )
 
-    val result = runner.run(userId, playlistId, playlist, null, emptyList())
+    val result = runner.run(playlistId, playlist, null, emptyList())
 
     assertThat(result.succeeded).isFalse()
     assertThat(result.violations).containsExactlyInAnyOrder("Artist A – Song A", "Artist B – Song B")
@@ -121,7 +119,7 @@ class DuplicateTrackIdsCheckRunnerTests {
     val playlist = buildPlaylist(listOf(buildTrack("t1"), buildTrack("t1")))
     every { appTrackRepository.findByTrackIds(setOf(TrackId("t1"))) } returns listOf(buildAppTrack("t1", "Song", null))
 
-    val result = runner.run(userId, playlistId, playlist, null, emptyList())
+    val result = runner.run(playlistId, playlist, null, emptyList())
 
     assertThat(result.violations).containsExactly("Unknown Artist – Song")
   }
@@ -135,7 +133,7 @@ class DuplicateTrackIdsCheckRunnerTests {
   fun `fix returns success and makes no Spotify call when no duplicates`() {
     val playlist = buildPlaylist(listOf(buildTrack("t1"), buildTrack("t2")))
 
-    val result = runner.fix(userId, accessToken, playlistId, playlist, null, emptyList())
+    val result = runner.fix(accessToken, playlistId, playlist, null, emptyList())
 
     assertThat(result.isRight()).isTrue()
     verify(exactly = 0) { spotifyPlaylist.removePlaylistTracks(any(), any(), any()) }
@@ -148,7 +146,7 @@ class DuplicateTrackIdsCheckRunnerTests {
     every { spotifyPlaylist.removePlaylistTracks(accessToken, playlistId, listOf("t1")) } returns Unit.right()
     every { spotifyPlaylist.addPlaylistTracks(accessToken, playlistId, listOf("t1")) } returns Unit.right()
 
-    val result = runner.fix(userId, accessToken, playlistId, playlist, null, emptyList())
+    val result = runner.fix(accessToken, playlistId, playlist, null, emptyList())
 
     assertThat(result.isRight()).isTrue()
     verify(exactly = 1) { spotifyPlaylist.removePlaylistTracks(accessToken, playlistId, listOf("t1")) }
@@ -161,7 +159,7 @@ class DuplicateTrackIdsCheckRunnerTests {
     every { spotifyPlaylist.removePlaylistTracks(accessToken, playlistId, listOf("t1")) } returns Unit.right()
     every { spotifyPlaylist.addPlaylistTracks(accessToken, playlistId, listOf("t1")) } returns Unit.right()
 
-    val result = runner.fix(userId, accessToken, playlistId, playlist, null, emptyList())
+    val result = runner.fix(accessToken, playlistId, playlist, null, emptyList())
 
     assertThat(result.isRight()).isTrue()
     verify(exactly = 1) { spotifyPlaylist.removePlaylistTracks(accessToken, playlistId, listOf("t1")) }
@@ -178,7 +176,7 @@ class DuplicateTrackIdsCheckRunnerTests {
       spotifyPlaylist.addPlaylistTracks(accessToken, playlistId, listOf("t1", "t2"))
     } returns Unit.right()
 
-    val result = runner.fix(userId, accessToken, playlistId, playlist, null, emptyList())
+    val result = runner.fix(accessToken, playlistId, playlist, null, emptyList())
 
     assertThat(result.isRight()).isTrue()
     verify(exactly = 1) { spotifyPlaylist.removePlaylistTracks(accessToken, playlistId, listOf("t1", "t2")) }
@@ -190,7 +188,7 @@ class DuplicateTrackIdsCheckRunnerTests {
     val playlist = buildPlaylist(listOf(buildTrack("t1"), buildTrack("t1")))
     every { spotifyPlaylist.removePlaylistTracks(any(), any(), any()) } returns PlaylistFixError.FIX_FAILED.left()
 
-    val result = runner.fix(userId, accessToken, playlistId, playlist, null, emptyList())
+    val result = runner.fix(accessToken, playlistId, playlist, null, emptyList())
 
     assertThat(result.isLeft()).isTrue()
     assertThat((result as Either.Left).value).isEqualTo(PlaylistFixError.FIX_FAILED)
@@ -203,7 +201,7 @@ class DuplicateTrackIdsCheckRunnerTests {
     every { spotifyPlaylist.removePlaylistTracks(any(), any(), any()) } returns Unit.right()
     every { spotifyPlaylist.addPlaylistTracks(any(), any(), any()) } returns PlaylistFixError.FIX_FAILED.left()
 
-    val result = runner.fix(userId, accessToken, playlistId, playlist, null, emptyList())
+    val result = runner.fix(accessToken, playlistId, playlist, null, emptyList())
 
     assertThat(result.isLeft()).isTrue()
     assertThat((result as Either.Left).value).isEqualTo(PlaylistFixError.FIX_FAILED)

--- a/domain-impl/src/test/kotlin/de/chrgroth/spotify/control/domain/playlist/check/SingleArtistTrackCheckRunnerTests.kt
+++ b/domain-impl/src/test/kotlin/de/chrgroth/spotify/control/domain/playlist/check/SingleArtistTrackCheckRunnerTests.kt
@@ -9,7 +9,6 @@ import de.chrgroth.spotify.control.domain.model.playlist.PlaylistInfo
 import de.chrgroth.spotify.control.domain.model.playlist.PlaylistSyncStatus
 import de.chrgroth.spotify.control.domain.model.playlist.PlaylistTrack
 import de.chrgroth.spotify.control.domain.model.playlist.PlaylistType
-import de.chrgroth.spotify.control.domain.model.user.UserId
 import de.chrgroth.spotify.control.domain.port.out.catalog.AppTrackRepositoryPort
 import io.mockk.every
 import io.mockk.mockk
@@ -23,7 +22,6 @@ class SingleArtistTrackCheckRunnerTests {
   private val appTrackRepository: AppTrackRepositoryPort = mockk()
   private val runner = SingleArtistTrackCheckRunner(appTrackRepository)
 
-  private val userId = UserId("user-1")
   private val playlistId = "playlist-1"
 
   private fun buildPlaylistTrack(trackId: String, vararg artistIds: String, albumId: String? = null) = PlaylistTrack(
@@ -65,7 +63,7 @@ class SingleArtistTrackCheckRunnerTests {
 
   @Test
   fun `run returns no violations for empty playlist`() {
-    val result = runner.run(userId, playlistId, buildPlaylist(), null, emptyList())
+    val result = runner.run(playlistId, buildPlaylist(), null, emptyList())
 
     assertThat(result.succeeded).isTrue()
     assertThat(result.violations).isEmpty()
@@ -80,7 +78,7 @@ class SingleArtistTrackCheckRunnerTests {
       buildAppTrack("t2", "Song B", "artist-2", "Artist Two"),
     )
 
-    val result = runner.run(userId, playlistId, buildPlaylist(t1, t2), null, emptyList())
+    val result = runner.run(playlistId, buildPlaylist(t1, t2), null, emptyList())
 
     assertThat(result.succeeded).isTrue()
     assertThat(result.violations).isEmpty()
@@ -96,7 +94,7 @@ class SingleArtistTrackCheckRunnerTests {
       buildAppTrack("t2", "Song B", "artist-1", "Artist One"),
     )
 
-    val result = runner.run(userId, playlistId, buildPlaylist(t1, t2), null, emptyList())
+    val result = runner.run(playlistId, buildPlaylist(t1, t2), null, emptyList())
 
     assertThat(result.succeeded).isFalse()
     assertThat(result.violations).containsExactlyInAnyOrder(
@@ -116,7 +114,7 @@ class SingleArtistTrackCheckRunnerTests {
       buildAppTrack("t3", "Song C", "artist-2", "Artist Two"),
     )
 
-    val result = runner.run(userId, playlistId, buildPlaylist(t1, t2, t3), null, emptyList())
+    val result = runner.run(playlistId, buildPlaylist(t1, t2, t3), null, emptyList())
 
     assertThat(result.succeeded).isFalse()
     assertThat(result.violations).containsExactlyInAnyOrder("Artist One – Song A", "Artist One – Song B")
@@ -133,7 +131,7 @@ class SingleArtistTrackCheckRunnerTests {
       buildAppTrack("t3", "Middle Song", "artist-1", "Artist One"),
     )
 
-    val result = runner.run(userId, playlistId, buildPlaylist(t1, t2, t3), null, emptyList())
+    val result = runner.run(playlistId, buildPlaylist(t1, t2, t3), null, emptyList())
 
     assertThat(result.succeeded).isFalse()
     assertThat(result.violations).containsExactly(
@@ -152,7 +150,7 @@ class SingleArtistTrackCheckRunnerTests {
       buildAppTrack("t2", "Song B", "artist-1", artistName = null),
     )
 
-    val result = runner.run(userId, playlistId, buildPlaylist(t1, t2), null, emptyList())
+    val result = runner.run(playlistId, buildPlaylist(t1, t2), null, emptyList())
 
     assertThat(result.succeeded).isFalse()
     assertThat(result.violations).containsExactlyInAnyOrder("artist-1 – Song A", "artist-1 – Song B")
@@ -164,7 +162,7 @@ class SingleArtistTrackCheckRunnerTests {
     val t2 = buildPlaylistTrack("t2", "artist-1")
     every { appTrackRepository.findByTrackIds(setOf(TrackId("t1"), TrackId("t2"))) } returns emptyList()
 
-    val result = runner.run(userId, playlistId, buildPlaylist(t1, t2), null, emptyList())
+    val result = runner.run(playlistId, buildPlaylist(t1, t2), null, emptyList())
 
     assertThat(result.succeeded).isFalse()
     assertThat(result.violations).containsExactlyInAnyOrder("artist-1 – t1", "artist-1 – t2")
@@ -176,7 +174,7 @@ class SingleArtistTrackCheckRunnerTests {
     val t2 = buildPlaylistTrack("t2")
     every { appTrackRepository.findByTrackIds(setOf(TrackId("t1"), TrackId("t2"))) } returns emptyList()
 
-    val result = runner.run(userId, playlistId, buildPlaylist(t1, t2), null, emptyList())
+    val result = runner.run(playlistId, buildPlaylist(t1, t2), null, emptyList())
 
     assertThat(result.succeeded).isTrue()
     assertThat(result.violations).isEmpty()

--- a/domain-impl/src/test/kotlin/de/chrgroth/spotify/control/domain/playlist/check/TrackFromLatestReleaseCheckRunnerTests.kt
+++ b/domain-impl/src/test/kotlin/de/chrgroth/spotify/control/domain/playlist/check/TrackFromLatestReleaseCheckRunnerTests.kt
@@ -12,7 +12,6 @@ import de.chrgroth.spotify.control.domain.model.catalog.TrackId
 import de.chrgroth.spotify.control.domain.model.playlist.Playlist
 import de.chrgroth.spotify.control.domain.model.playlist.PlaylistTrack
 import de.chrgroth.spotify.control.domain.model.user.AccessToken
-import de.chrgroth.spotify.control.domain.model.user.UserId
 import de.chrgroth.spotify.control.domain.port.out.catalog.AppAlbumRepositoryPort
 import de.chrgroth.spotify.control.domain.port.out.catalog.AppTrackRepositoryPort
 import de.chrgroth.spotify.control.domain.port.out.playlist.SpotifyPlaylistPort
@@ -33,7 +32,6 @@ class TrackFromLatestReleaseCheckRunnerTests {
   private val meterRegistry = SimpleMeterRegistry()
   private val runner = TrackFromLatestReleaseCheckRunner(appTrackRepository, appAlbumRepository, spotifyPlaylist, meterRegistry)
 
-  private val userId = UserId("user-1")
   private val accessToken = AccessToken("token")
   private val playlistId = "playlist-1"
   private val artistId = ArtistId("artist-1")
@@ -68,7 +66,7 @@ class TrackFromLatestReleaseCheckRunnerTests {
 
   @Test
   fun `run returns no violations for empty playlist`() {
-    val result = runner.run(userId, playlistId, buildPlaylist(), null, emptyList())
+    val result = runner.run(playlistId, buildPlaylist(), null, emptyList())
 
     assertThat(result.succeeded).isTrue()
     assertThat(result.violations).isEmpty()
@@ -84,7 +82,7 @@ class TrackFromLatestReleaseCheckRunnerTests {
     every { appAlbumRepository.findByArtistId(artistId) } returns listOf(album)
     every { appTrackRepository.findByAlbumId(AlbumId("album-1")) } returns listOf(appTrack)
 
-    val result = runner.run(userId, playlistId, buildPlaylist(track), null, emptyList())
+    val result = runner.run(playlistId, buildPlaylist(track), null, emptyList())
 
     assertThat(result.succeeded).isTrue()
     assertThat(result.violations).isEmpty()
@@ -103,7 +101,7 @@ class TrackFromLatestReleaseCheckRunnerTests {
     every { appTrackRepository.findByAlbumId(AlbumId("album-old")) } returns listOf(appTrackOld)
     every { appTrackRepository.findByAlbumId(AlbumId("album-new")) } returns listOf(appTrackNew)
 
-    val result = runner.run(userId, playlistId, buildPlaylist(track), null, emptyList())
+    val result = runner.run(playlistId, buildPlaylist(track), null, emptyList())
 
     assertThat(result.succeeded).isTrue()
     assertThat(result.violations).isEmpty()
@@ -122,7 +120,7 @@ class TrackFromLatestReleaseCheckRunnerTests {
     every { appTrackRepository.findByAlbumId(AlbumId("album-old")) } returns listOf(appTrackOld)
     every { appTrackRepository.findByAlbumId(AlbumId("album-new")) } returns listOf(appTrackNew)
 
-    val result = runner.run(userId, playlistId, buildPlaylist(track), null, emptyList())
+    val result = runner.run(playlistId, buildPlaylist(track), null, emptyList())
 
     assertThat(result.succeeded).isFalse()
     assertThat(result.violations).containsExactly("Artist A – Song A (Old Album → New Album)")
@@ -142,7 +140,7 @@ class TrackFromLatestReleaseCheckRunnerTests {
     every { appTrackRepository.findByAlbumId(AlbumId("single-album")) } returns listOf(appTrackOnSingle)
     every { appTrackRepository.findByAlbumId(AlbumId("full-album")) } returns listOf(appTrackOnAlbum)
 
-    val result = runner.run(userId, playlistId, buildPlaylist(track), null, emptyList())
+    val result = runner.run(playlistId, buildPlaylist(track), null, emptyList())
 
     assertThat(result.succeeded).isFalse()
     assertThat(result.violations).containsExactly("Artist A – Song A (Single Release → Full Album)")
@@ -161,7 +159,7 @@ class TrackFromLatestReleaseCheckRunnerTests {
     every { appTrackRepository.findByAlbumId(AlbumId("album-a")) } returns listOf(appTrackA)
     every { appTrackRepository.findByAlbumId(AlbumId("album-b")) } returns listOf(appTrackB)
 
-    val result = runner.run(userId, playlistId, buildPlaylist(track), null, emptyList())
+    val result = runner.run(playlistId, buildPlaylist(track), null, emptyList())
 
     assertThat(result.succeeded).isFalse()
     assertThat(result.violations).containsExactly("Artist A – Song A (Album A → Album B)")
@@ -180,7 +178,7 @@ class TrackFromLatestReleaseCheckRunnerTests {
     every { appTrackRepository.findByAlbumId(AlbumId("album-a")) } returns listOf(appTrackA)
     every { appTrackRepository.findByAlbumId(AlbumId("album-b")) } returns listOf(appTrackB)
 
-    val result = runner.run(userId, playlistId, buildPlaylist(track), null, emptyList())
+    val result = runner.run(playlistId, buildPlaylist(track), null, emptyList())
 
     assertThat(result.succeeded).isFalse()
     assertThat(result.violations).containsExactly("Artist A – Song A (Album A → Album B)")
@@ -199,7 +197,7 @@ class TrackFromLatestReleaseCheckRunnerTests {
     every { appTrackRepository.findByAlbumId(AlbumId("album-old")) } returns listOf(appTrackOld)
     every { appTrackRepository.findByAlbumId(AlbumId("album-new")) } returns listOf(appTrackNew)
 
-    val result = runner.run(userId, playlistId, buildPlaylist(track), null, emptyList())
+    val result = runner.run(playlistId, buildPlaylist(track), null, emptyList())
 
     assertThat(result.succeeded).isFalse()
     assertThat(result.violations).containsExactly("Unknown Artist – Song A (Unknown Album → Unknown Album)")
@@ -220,7 +218,7 @@ class TrackFromLatestReleaseCheckRunnerTests {
     every { appAlbumRepository.findByArtistId(artistId) } returns listOf(album)
     every { appTrackRepository.findByAlbumId(AlbumId("album-1")) } returns listOf(appTrack)
 
-    val result = runner.fix(userId, accessToken, playlistId, buildPlaylist(track), null, emptyList())
+    val result = runner.fix(accessToken, playlistId, buildPlaylist(track), null, emptyList())
 
     assertThat(result.isRight()).isTrue()
     verify(exactly = 0) { spotifyPlaylist.replacePlaylistTrack(any(), any(), any(), any(), any()) }
@@ -240,7 +238,7 @@ class TrackFromLatestReleaseCheckRunnerTests {
     every { appTrackRepository.findByAlbumId(AlbumId("album-new")) } returns listOf(appTrackNew)
     every { spotifyPlaylist.replacePlaylistTrack(accessToken, playlistId, "t1", "t2", 0) } returns Unit.right()
 
-    val result = runner.fix(userId, accessToken, playlistId, buildPlaylist(track), null, emptyList())
+    val result = runner.fix(accessToken, playlistId, buildPlaylist(track), null, emptyList())
 
     assertThat(result.isRight()).isTrue()
     verify(exactly = 1) { spotifyPlaylist.replacePlaylistTrack(accessToken, playlistId, "t1", "t2", 0) }
@@ -269,7 +267,7 @@ class TrackFromLatestReleaseCheckRunnerTests {
     every { spotifyPlaylist.replacePlaylistTrack(accessToken, playlistId, "t5", "t6", 2) } returns Unit.right()
     every { spotifyPlaylist.replacePlaylistTrack(accessToken, playlistId, "t1", "t2", 0) } returns Unit.right()
 
-    val result = runner.fix(userId, accessToken, playlistId, buildPlaylist(track0, track1, track2), null, emptyList())
+    val result = runner.fix(accessToken, playlistId, buildPlaylist(track0, track1, track2), null, emptyList())
 
     assertThat(result.isRight()).isTrue()
     verifyOrder {
@@ -295,7 +293,7 @@ class TrackFromLatestReleaseCheckRunnerTests {
     every { appTrackRepository.findByAlbumId(AlbumId("album-new")) } returns listOf(appTrackNew1, appTrackNew2)
     every { spotifyPlaylist.replacePlaylistTrack(accessToken, playlistId, "t3", "t4", 1) } returns PlaylistFixError.FIX_FAILED.left()
 
-    val result = runner.fix(userId, accessToken, playlistId, buildPlaylist(track0, track1), null, emptyList())
+    val result = runner.fix(accessToken, playlistId, buildPlaylist(track0, track1), null, emptyList())
 
     assertThat(result.isLeft()).isTrue()
     assertThat((result as Either.Left).value).isEqualTo(PlaylistFixError.FIX_FAILED)

--- a/domain-impl/src/test/kotlin/de/chrgroth/spotify/control/domain/playlist/check/YearSongsInAllCheckRunnerTests.kt
+++ b/domain-impl/src/test/kotlin/de/chrgroth/spotify/control/domain/playlist/check/YearSongsInAllCheckRunnerTests.kt
@@ -14,7 +14,6 @@ import de.chrgroth.spotify.control.domain.model.playlist.PlaylistTrack
 import de.chrgroth.spotify.control.domain.model.playlist.PlaylistType
 import de.chrgroth.spotify.control.domain.model.catalog.TrackId
 import de.chrgroth.spotify.control.domain.model.user.AccessToken
-import de.chrgroth.spotify.control.domain.model.user.UserId
 import de.chrgroth.spotify.control.domain.port.out.catalog.AppTrackRepositoryPort
 import de.chrgroth.spotify.control.domain.port.out.playlist.PlaylistRepositoryPort
 import de.chrgroth.spotify.control.domain.port.out.playlist.SpotifyPlaylistPort
@@ -33,7 +32,6 @@ class YearSongsInAllCheckRunnerTests {
   private val spotifyPlaylist: SpotifyPlaylistPort = mockk()
   private val runner = YearSongsInAllCheckRunner(playlistRepository, appTrackRepository, spotifyPlaylist)
 
-  private val userId = UserId("user-1")
   private val accessToken = AccessToken("token")
   private val playlistId = "playlist-1"
   private val allPlaylistId = "playlist-all"
@@ -80,7 +78,7 @@ class YearSongsInAllCheckRunnerTests {
     val currentPlaylistInfo = buildPlaylistInfo(type = PlaylistType.YEAR)
     val playlistInfos = listOf(currentPlaylistInfo)
 
-    val result = runner.run(userId, playlistId, playlist, currentPlaylistInfo, playlistInfos)
+    val result = runner.run(playlistId, playlist, currentPlaylistInfo, playlistInfos)
 
     assertThat(result.succeeded).isTrue()
     assertThat(result.violations).isEmpty()
@@ -95,9 +93,9 @@ class YearSongsInAllCheckRunnerTests {
       currentPlaylistInfo,
       buildPlaylistInfo(spotifyPlaylistId = allPlaylistId, type = PlaylistType.ALL),
     )
-    every { playlistRepository.findByUserIdAndPlaylistId(userId, allPlaylistId) } returns null
+    every { playlistRepository.findByPlaylistId(allPlaylistId) } returns null
 
-    val result = runner.run(userId, playlistId, playlist, currentPlaylistInfo, playlistInfos)
+    val result = runner.run(playlistId, playlist, currentPlaylistInfo, playlistInfos)
 
     assertThat(result.succeeded).isTrue()
     assertThat(result.violations).isEmpty()
@@ -112,9 +110,9 @@ class YearSongsInAllCheckRunnerTests {
       currentPlaylistInfo,
       buildPlaylistInfo(spotifyPlaylistId = allPlaylistId, type = PlaylistType.ALL),
     )
-    every { playlistRepository.findByUserIdAndPlaylistId(userId, allPlaylistId) } returns allPlaylist
+    every { playlistRepository.findByPlaylistId(allPlaylistId) } returns allPlaylist
 
-    val result = runner.run(userId, playlistId, playlist, currentPlaylistInfo, playlistInfos)
+    val result = runner.run(playlistId, playlist, currentPlaylistInfo, playlistInfos)
 
     assertThat(result.succeeded).isTrue()
     assertThat(result.violations).isEmpty()
@@ -131,13 +129,13 @@ class YearSongsInAllCheckRunnerTests {
       currentPlaylistInfo,
       buildPlaylistInfo(spotifyPlaylistId = allPlaylistId, type = PlaylistType.ALL),
     )
-    every { playlistRepository.findByUserIdAndPlaylistId(userId, allPlaylistId) } returns allPlaylist
+    every { playlistRepository.findByPlaylistId(allPlaylistId) } returns allPlaylist
     every { appTrackRepository.findByTrackIds(setOf(TrackId("t2"), TrackId("t3"))) } returns listOf(
       buildAppTrack("t2", "Song B", "Artist B"),
       buildAppTrack("t3", "Song C", "Artist C"),
     )
 
-    val result = runner.run(userId, playlistId, playlist, currentPlaylistInfo, playlistInfos)
+    val result = runner.run(playlistId, playlist, currentPlaylistInfo, playlistInfos)
 
     assertThat(result.succeeded).isFalse()
     assertThat(result.violations).containsExactlyInAnyOrder("Artist B – Song B", "Artist C – Song C")
@@ -154,12 +152,12 @@ class YearSongsInAllCheckRunnerTests {
       currentPlaylistInfo,
       buildPlaylistInfo(spotifyPlaylistId = allPlaylistId, type = PlaylistType.ALL),
     )
-    every { playlistRepository.findByUserIdAndPlaylistId(userId, allPlaylistId) } returns allPlaylist
+    every { playlistRepository.findByPlaylistId(allPlaylistId) } returns allPlaylist
     every { appTrackRepository.findByTrackIds(setOf(TrackId("t2"))) } returns listOf(
       buildAppTrack("t2", "Song B", "Artist B"),
     )
 
-    val result = runner.run(userId, playlistId, playlist, currentPlaylistInfo, playlistInfos)
+    val result = runner.run(playlistId, playlist, currentPlaylistInfo, playlistInfos)
 
     assertThat(result.succeeded).isFalse()
     assertThat(result.violations).containsExactly("Artist B – Song B")
@@ -174,12 +172,12 @@ class YearSongsInAllCheckRunnerTests {
       currentPlaylistInfo,
       buildPlaylistInfo(spotifyPlaylistId = allPlaylistId, type = PlaylistType.ALL),
     )
-    every { playlistRepository.findByUserIdAndPlaylistId(userId, allPlaylistId) } returns allPlaylist
+    every { playlistRepository.findByPlaylistId(allPlaylistId) } returns allPlaylist
     every { appTrackRepository.findByTrackIds(setOf(TrackId("t2"))) } returns listOf(
       buildAppTrack("t2", "Song B", null),
     )
 
-    val result = runner.run(userId, playlistId, playlist, currentPlaylistInfo, playlistInfos)
+    val result = runner.run(playlistId, playlist, currentPlaylistInfo, playlistInfos)
 
     assertThat(result.violations).containsExactly("Unknown Artist – Song B")
   }
@@ -195,7 +193,7 @@ class YearSongsInAllCheckRunnerTests {
     val currentPlaylistInfo = buildPlaylistInfo(type = PlaylistType.YEAR)
     val playlistInfos = listOf(currentPlaylistInfo)
 
-    val result = runner.fix(userId, accessToken, playlistId, playlist, currentPlaylistInfo, playlistInfos)
+    val result = runner.fix(accessToken, playlistId, playlist, currentPlaylistInfo, playlistInfos)
 
     assertThat(result.isLeft()).isTrue()
     assertThat((result as Either.Left).value).isEqualTo(PlaylistFixError.FIX_NOT_FOUND)
@@ -210,9 +208,9 @@ class YearSongsInAllCheckRunnerTests {
       currentPlaylistInfo,
       buildPlaylistInfo(spotifyPlaylistId = allPlaylistId, type = PlaylistType.ALL),
     )
-    every { playlistRepository.findByUserIdAndPlaylistId(userId, allPlaylistId) } returns null
+    every { playlistRepository.findByPlaylistId(allPlaylistId) } returns null
 
-    val result = runner.fix(userId, accessToken, playlistId, playlist, currentPlaylistInfo, playlistInfos)
+    val result = runner.fix(accessToken, playlistId, playlist, currentPlaylistInfo, playlistInfos)
 
     assertThat(result.isLeft()).isTrue()
     assertThat((result as Either.Left).value).isEqualTo(PlaylistFixError.PLAYLIST_NOT_FOUND)
@@ -228,9 +226,9 @@ class YearSongsInAllCheckRunnerTests {
       currentPlaylistInfo,
       buildPlaylistInfo(spotifyPlaylistId = allPlaylistId, type = PlaylistType.ALL),
     )
-    every { playlistRepository.findByUserIdAndPlaylistId(userId, allPlaylistId) } returns allPlaylist
+    every { playlistRepository.findByPlaylistId(allPlaylistId) } returns allPlaylist
 
-    val result = runner.fix(userId, accessToken, playlistId, playlist, currentPlaylistInfo, playlistInfos)
+    val result = runner.fix(accessToken, playlistId, playlist, currentPlaylistInfo, playlistInfos)
 
     assertThat(result.isRight()).isTrue()
     verify(exactly = 0) { spotifyPlaylist.addPlaylistTracks(any(), any(), any()) }
@@ -245,10 +243,10 @@ class YearSongsInAllCheckRunnerTests {
       currentPlaylistInfo,
       buildPlaylistInfo(spotifyPlaylistId = allPlaylistId, type = PlaylistType.ALL),
     )
-    every { playlistRepository.findByUserIdAndPlaylistId(userId, allPlaylistId) } returns allPlaylist
+    every { playlistRepository.findByPlaylistId(allPlaylistId) } returns allPlaylist
     every { spotifyPlaylist.addPlaylistTracks(accessToken, allPlaylistId, any()) } returns Unit.right()
 
-    val result = runner.fix(userId, accessToken, playlistId, playlist, currentPlaylistInfo, playlistInfos)
+    val result = runner.fix(accessToken, playlistId, playlist, currentPlaylistInfo, playlistInfos)
 
     assertThat(result.isRight()).isTrue()
     verify(exactly = 1) {
@@ -265,10 +263,10 @@ class YearSongsInAllCheckRunnerTests {
       currentPlaylistInfo,
       buildPlaylistInfo(spotifyPlaylistId = allPlaylistId, type = PlaylistType.ALL),
     )
-    every { playlistRepository.findByUserIdAndPlaylistId(userId, allPlaylistId) } returns allPlaylist
+    every { playlistRepository.findByPlaylistId(allPlaylistId) } returns allPlaylist
     every { spotifyPlaylist.addPlaylistTracks(accessToken, allPlaylistId, listOf("t2")) } returns Unit.right()
 
-    val result = runner.fix(userId, accessToken, playlistId, playlist, currentPlaylistInfo, playlistInfos)
+    val result = runner.fix(accessToken, playlistId, playlist, currentPlaylistInfo, playlistInfos)
 
     assertThat(result.isRight()).isTrue()
     verify(exactly = 1) { spotifyPlaylist.addPlaylistTracks(accessToken, allPlaylistId, listOf("t2")) }
@@ -283,10 +281,10 @@ class YearSongsInAllCheckRunnerTests {
       currentPlaylistInfo,
       buildPlaylistInfo(spotifyPlaylistId = allPlaylistId, type = PlaylistType.ALL),
     )
-    every { playlistRepository.findByUserIdAndPlaylistId(userId, allPlaylistId) } returns allPlaylist
+    every { playlistRepository.findByPlaylistId(allPlaylistId) } returns allPlaylist
     every { spotifyPlaylist.addPlaylistTracks(any(), any(), any()) } returns PlaylistFixError.FIX_FAILED.left()
 
-    val result = runner.fix(userId, accessToken, playlistId, playlist, currentPlaylistInfo, playlistInfos)
+    val result = runner.fix(accessToken, playlistId, playlist, currentPlaylistInfo, playlistInfos)
 
     assertThat(result.isLeft()).isTrue()
     assertThat((result as Either.Left).value).isEqualTo(PlaylistFixError.FIX_FAILED)


### PR DESCRIPTION
## Summary
- Drops the `spotifyUserId` field/composite-key-prefix from `app_playback`, `app_playback_aggregation`, `spotify_currently_playing`, `spotify_recently_played`, `spotify_recently_partial_played`, `spotify_playlist`, and `spotify_playlist_metadata`, since the app only ever supports one user. Shrinks the corresponding MongoDB indexes and adds a one-time `SimplifySingleUserSchemaStarter` to migrate existing documents.
- Also removes the now-dead `UserId`/`spotifyUserId` parameters and fields from the affected repository ports, adapters, and in-memory domain models, since they were never read once Phase 3 moved user resolution to `CurrentUserResolver`.
- Updates ~30 call-site files and ~19 test files accordingly; fixes a real test-isolation bug the schema change exposed in `RecentlyPlayedRepositoryTests`.
- Updates arc42 and the migration plan docs, adds the required release note snippet.

Implements Phase 4 of [docs/plans/single-user-simplification.md](docs/plans/single-user-simplification.md), completing all schema/index work for the single-user migration. Only Phase 5 (config/test/deploy cleanup) remains.

Closes #737.

Generated with [Claude Code](https://claude.ai/code)