### PR TITLE
Implement performance review findings 1 and 2

### DIFF
--- a/adapter-out-mongodb/src/main/kotlin/de/chrgroth/spotify/control/adapter/out/mongodb/MongoIndexInitializer.kt
+++ b/adapter-out-mongodb/src/main/kotlin/de/chrgroth/spotify/control/adapter/out/mongodb/MongoIndexInitializer.kt
@@ -70,6 +70,10 @@ class MongoIndexInitializer(
       Document(AppArtistRepositoryAdapter.LAST_SYNC_FIELD, -1),
       IndexOptions().name("app_artist_lastSync_-1"),
     )
+    appArtistDocumentRepository.mongoCollection().createIndex(
+      Document(AppArtistRepositoryAdapter.ARTIST_NAME_FIELD, 1),
+      IndexOptions().name("app_artist_artistName_1"),
+    )
     appAlbumDocumentRepository.mongoCollection().createIndex(
       Document(AppAlbumRepositoryAdapter.ARTIST_ID_FIELD, 1),
       IndexOptions().name("app_album_artistId_1"),
@@ -77,6 +81,10 @@ class MongoIndexInitializer(
     appAlbumDocumentRepository.mongoCollection().createIndex(
       Document(AppAlbumRepositoryAdapter.LAST_SYNC_FIELD, -1),
       IndexOptions().name("app_album_lastSync_-1"),
+    )
+    appAlbumDocumentRepository.mongoCollection().createIndex(
+      Document(AppAlbumRepositoryAdapter.TITLE_FIELD, 1),
+      IndexOptions().name("app_album_title_1"),
     )
     appTrackDocumentRepository.mongoCollection().createIndex(
       Document(AppTrackRepositoryAdapter.ARTIST_ID_FIELD, 1),

--- a/docs/releasenotes/snippets/20260710-0657-bugfix.md
+++ b/docs/releasenotes/snippets/20260710-0657-bugfix.md
@@ -1,0 +1,2 @@
+* Sped up catalog artist/album search with a database index.
+* Catalog statistics on the dashboard and catalog page now come from a shared cache instead of running fresh database queries on every page load.

--- a/domain-impl/src/main/kotlin/de/chrgroth/spotify/control/domain/catalog/CatalogBrowserService.kt
+++ b/domain-impl/src/main/kotlin/de/chrgroth/spotify/control/domain/catalog/CatalogBrowserService.kt
@@ -1,5 +1,6 @@
 package de.chrgroth.spotify.control.domain.catalog
 
+import de.chrgroth.spotify.control.domain.infra.CatalogStatsCache
 import de.chrgroth.spotify.control.domain.model.catalog.AlbumBrowseItem
 import de.chrgroth.spotify.control.domain.model.catalog.AlbumId
 import de.chrgroth.spotify.control.domain.model.catalog.ArtistBrowseItem
@@ -31,18 +32,10 @@ class CatalogBrowserService(
   private val syncTraceRepository: SyncTraceRepositoryPort,
   private val playlistRepository: PlaylistRepositoryPort,
   private val currentUserResolver: CurrentUserResolver,
+  private val catalogStatsCache: CatalogStatsCache,
 ) : CatalogBrowserPort {
 
-  override fun getCatalogStats(): CatalogStats {
-    val artistCount = appArtistRepository.countAll()
-    val albumCount = appAlbumRepository.countAll()
-    val trackCount = appTrackRepository.countAll()
-    return CatalogStats(
-      artistCount = artistCount,
-      albumCount = albumCount,
-      trackCount = trackCount,
-    )
-  }
+  override fun getCatalogStats(): CatalogStats = catalogStatsCache.current()
 
   override fun getArtists(filter: String?): List<ArtistBrowseItem> {
     val filterTrimmed = filter?.trim()

--- a/domain-impl/src/main/kotlin/de/chrgroth/spotify/control/domain/infra/CatalogStatsCache.kt
+++ b/domain-impl/src/main/kotlin/de/chrgroth/spotify/control/domain/infra/CatalogStatsCache.kt
@@ -1,0 +1,41 @@
+package de.chrgroth.spotify.control.domain.infra
+
+import de.chrgroth.spotify.control.domain.model.catalog.CatalogStats
+import de.chrgroth.spotify.control.domain.port.out.catalog.AppAlbumRepositoryPort
+import de.chrgroth.spotify.control.domain.port.out.catalog.AppArtistRepositoryPort
+import de.chrgroth.spotify.control.domain.port.out.catalog.AppTrackRepositoryPort
+import io.quarkus.scheduler.Scheduled
+import jakarta.enterprise.context.ApplicationScoped
+import mu.KLogging
+
+// shared by DomainMetrics and CatalogBrowserService so that neither the Prometheus gauges nor
+// every /dashboard and /catalog page load query the catalog collections directly; a single
+// refresh serves every reader, following the same pattern as OutboxPartitionStatsCache.
+@ApplicationScoped
+@Suppress("Unused")
+class CatalogStatsCache(
+  private val appArtistRepository: AppArtistRepositoryPort,
+  private val appAlbumRepository: AppAlbumRepositoryPort,
+  private val appTrackRepository: AppTrackRepositoryPort,
+) {
+
+  @Volatile
+  private var cachedStats = CatalogStats(artistCount = 0L, albumCount = 0L, trackCount = 0L)
+
+  fun current(): CatalogStats = cachedStats
+
+  @Scheduled(every = "15s")
+  fun refresh() {
+    try {
+      cachedStats = CatalogStats(
+        artistCount = appArtistRepository.countAll(),
+        albumCount = appAlbumRepository.countAll(),
+        trackCount = appTrackRepository.countAll(),
+      )
+    } catch (e: Exception) {
+      logger.warn(e) { "Failed to refresh catalog stats cache, keeping previous values" }
+    }
+  }
+
+  companion object : KLogging()
+}

--- a/domain-impl/src/main/kotlin/de/chrgroth/spotify/control/domain/infra/DomainMetrics.kt
+++ b/domain-impl/src/main/kotlin/de/chrgroth/spotify/control/domain/infra/DomainMetrics.kt
@@ -1,69 +1,41 @@
 package de.chrgroth.spotify.control.domain.infra
 
 import de.chrgroth.spotify.control.domain.model.playlist.PlaylistSyncStatus
-import de.chrgroth.spotify.control.domain.port.out.catalog.AppAlbumRepositoryPort
-import de.chrgroth.spotify.control.domain.port.out.catalog.AppArtistRepositoryPort
-import de.chrgroth.spotify.control.domain.port.out.catalog.AppTrackRepositoryPort
 import de.chrgroth.spotify.control.domain.port.out.playlist.PlaylistRepositoryPort
 import io.micrometer.core.instrument.Gauge
 import io.micrometer.core.instrument.MeterRegistry
 import io.quarkus.runtime.StartupEvent
-import io.quarkus.scheduler.Scheduled
 import jakarta.enterprise.context.ApplicationScoped
 import jakarta.enterprise.event.Observes
 import mu.KLogging
 
 // registers eagerly on StartupEvent so these gauges are always visible, even before any sync activity occurs.
-// catalog counts are refreshed on a background schedule rather than during gauge evaluation, following the same
-// pattern as MongoCollectionMetrics, so a slow countAll() call can never delay the Prometheus scrape response itself.
+// catalog counts are read from the shared CatalogStatsCache rather than queried here, so a slow countAll() call
+// can never delay the Prometheus scrape response itself, and the same cache also serves CatalogBrowserService.
 @ApplicationScoped
 @Suppress("Unused", "UnusedParameter")
 class DomainMetrics(
   private val playlistRepository: PlaylistRepositoryPort,
-  private val appArtistRepository: AppArtistRepositoryPort,
-  private val appTrackRepository: AppTrackRepositoryPort,
-  private val appAlbumRepository: AppAlbumRepositoryPort,
+  private val catalogStatsCache: CatalogStatsCache,
   private val meterRegistry: MeterRegistry,
 ) {
 
-  @Volatile
-  private var artistCount: Long = 0L
-
-  @Volatile
-  private var trackCount: Long = 0L
-
-  @Volatile
-  private var albumCount: Long = 0L
-
   fun onStartup(@Observes event: StartupEvent) {
-    refreshCatalogCounts()
-
     Gauge.builder("app.playlist.out_of_sync", this) { it.outOfSyncPlaylistCount().toDouble() }
       .description("Number of active playlists whose local mirror hasn't caught up with the latest Spotify snapshot yet")
       .register(meterRegistry)
 
-    Gauge.builder("app.catalog.artists", this) { it.artistCount.toDouble() }
+    Gauge.builder("app.catalog.artists", this) { it.catalogStatsCache.current().artistCount.toDouble() }
       .description("Number of artists in the local catalog")
       .register(meterRegistry)
 
-    Gauge.builder("app.catalog.tracks", this) { it.trackCount.toDouble() }
+    Gauge.builder("app.catalog.tracks", this) { it.catalogStatsCache.current().trackCount.toDouble() }
       .description("Number of tracks in the local catalog")
       .register(meterRegistry)
 
-    Gauge.builder("app.catalog.albums", this) { it.albumCount.toDouble() }
+    Gauge.builder("app.catalog.albums", this) { it.catalogStatsCache.current().albumCount.toDouble() }
       .description("Number of albums in the local catalog")
       .register(meterRegistry)
-  }
-
-  @Scheduled(every = "15s")
-  fun refreshCatalogCounts() {
-    try {
-      artistCount = appArtistRepository.countAll()
-      trackCount = appTrackRepository.countAll()
-      albumCount = appAlbumRepository.countAll()
-    } catch (e: Exception) {
-      logger.warn(e) { "Failed to refresh catalog counts for metrics, keeping previous values" }
-    }
   }
 
   private fun outOfSyncPlaylistCount(): Int =

--- a/domain-impl/src/test/kotlin/de/chrgroth/spotify/control/domain/catalog/CatalogBrowserServiceTests.kt
+++ b/domain-impl/src/test/kotlin/de/chrgroth/spotify/control/domain/catalog/CatalogBrowserServiceTests.kt
@@ -1,10 +1,12 @@
 package de.chrgroth.spotify.control.domain.catalog
 
+import de.chrgroth.spotify.control.domain.infra.CatalogStatsCache
 import de.chrgroth.spotify.control.domain.model.catalog.AlbumId
 import de.chrgroth.spotify.control.domain.model.catalog.AppAlbum
 import de.chrgroth.spotify.control.domain.model.catalog.AppArtist
 import de.chrgroth.spotify.control.domain.model.catalog.AppTrack
 import de.chrgroth.spotify.control.domain.model.catalog.ArtistId
+import de.chrgroth.spotify.control.domain.model.catalog.CatalogStats
 import de.chrgroth.spotify.control.domain.model.catalog.CatalogSyncEntityType
 import de.chrgroth.spotify.control.domain.model.catalog.SyncCause
 import de.chrgroth.spotify.control.domain.model.catalog.SyncTrace
@@ -33,6 +35,7 @@ class CatalogBrowserServiceTests {
   private val syncTraceRepository: SyncTraceRepositoryPort = mockk()
   private val playlistRepository: PlaylistRepositoryPort = mockk()
   private val currentUserResolver: CurrentUserResolver = mockk()
+  private val catalogStatsCache: CatalogStatsCache = mockk()
 
   private val service = CatalogBrowserService(
     appArtistRepository,
@@ -41,10 +44,21 @@ class CatalogBrowserServiceTests {
     syncTraceRepository,
     playlistRepository,
     currentUserResolver,
+    catalogStatsCache,
   )
 
   private val userId = UserId("user-1")
   private val triggeredAt = Instant.fromEpochSeconds(100)
+
+  @Test
+  fun `getCatalogStats reads through the shared catalog stats cache`() {
+    val stats = CatalogStats(artistCount = 3L, albumCount = 5L, trackCount = 42L)
+    every { catalogStatsCache.current() } returns stats
+
+    val result = service.getCatalogStats()
+
+    assertThat(result).isEqualTo(stats)
+  }
 
   @Test
   fun `getAlbums returns empty list when filter is blank`() {

--- a/domain-impl/src/test/kotlin/de/chrgroth/spotify/control/domain/infra/CatalogStatsCacheTests.kt
+++ b/domain-impl/src/test/kotlin/de/chrgroth/spotify/control/domain/infra/CatalogStatsCacheTests.kt
@@ -1,0 +1,60 @@
+package de.chrgroth.spotify.control.domain.infra
+
+import de.chrgroth.spotify.control.domain.model.catalog.CatalogStats
+import de.chrgroth.spotify.control.domain.port.out.catalog.AppAlbumRepositoryPort
+import de.chrgroth.spotify.control.domain.port.out.catalog.AppArtistRepositoryPort
+import de.chrgroth.spotify.control.domain.port.out.catalog.AppTrackRepositoryPort
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class CatalogStatsCacheTests {
+
+  private val appArtistRepository: AppArtistRepositoryPort = mockk()
+  private val appAlbumRepository: AppAlbumRepositoryPort = mockk()
+  private val appTrackRepository: AppTrackRepositoryPort = mockk()
+  private val cache = CatalogStatsCache(appArtistRepository, appAlbumRepository, appTrackRepository)
+
+  @Test
+  fun `current is zeroed out before the first refresh`() {
+    assertThat(cache.current()).isEqualTo(CatalogStats(artistCount = 0L, albumCount = 0L, trackCount = 0L))
+  }
+
+  @Test
+  fun `refresh populates current with the latest catalog counts`() {
+    every { appArtistRepository.countAll() } returns 3L
+    every { appAlbumRepository.countAll() } returns 5L
+    every { appTrackRepository.countAll() } returns 42L
+
+    cache.refresh()
+
+    assertThat(cache.current()).isEqualTo(CatalogStats(artistCount = 3L, albumCount = 5L, trackCount = 42L))
+  }
+
+  @Test
+  fun `a failed refresh keeps the previously cached values instead of propagating`() {
+    every { appArtistRepository.countAll() } returns 3L
+    every { appAlbumRepository.countAll() } returns 5L
+    every { appTrackRepository.countAll() } returns 42L
+    cache.refresh()
+
+    every { appArtistRepository.countAll() } throws IllegalStateException("mongo unreachable")
+    cache.refresh()
+
+    assertThat(cache.current()).isEqualTo(CatalogStats(artistCount = 3L, albumCount = 5L, trackCount = 42L))
+  }
+
+  @Test
+  fun `current can be read repeatedly without re-querying the catalog repositories`() {
+    every { appArtistRepository.countAll() } returns 0L
+    every { appAlbumRepository.countAll() } returns 0L
+    every { appTrackRepository.countAll() } returns 0L
+    cache.refresh()
+
+    repeat(5) { cache.current() }
+
+    verify(exactly = 1) { appArtistRepository.countAll() }
+  }
+}


### PR DESCRIPTION
Implements findings 1 and 2 from `docs/plans/2026-07-10-performance-review.md`:

- Finding 1: index `app_artist.artistName`/`app_album.title` for catalog search.
- Finding 2: share a new `CatalogStatsCache` between `DomainMetrics` and `CatalogBrowserService.getCatalogStats()`, following the existing `MongoCollectionMetrics`/`OutboxPartitionStatsCache` pattern.

Addresses #735.

Generated with [Claude Code](https://claude.ai/code)