### PR TITLE
Fix slow app_album.findByArtistIds query on /catalog-sync

### DIFF
--- a/adapter-out-mongodb/src/main/kotlin/de/chrgroth/spotify/control/adapter/out/mongodb/AppAlbumRepositoryAdapter.kt
+++ b/adapter-out-mongodb/src/main/kotlin/de/chrgroth/spotify/control/adapter/out/mongodb/AppAlbumRepositoryAdapter.kt
@@ -1,5 +1,7 @@
 package de.chrgroth.spotify.control.adapter.out.mongodb
 
+import com.mongodb.client.model.Accumulators
+import com.mongodb.client.model.Aggregates
 import com.mongodb.client.model.BulkWriteOptions
 import com.mongodb.client.model.Filters
 import com.mongodb.client.model.Sorts
@@ -13,6 +15,7 @@ import de.chrgroth.spotify.control.domain.port.out.catalog.AppAlbumRepositoryPor
 import jakarta.enterprise.context.ApplicationScoped
 import java.util.regex.Pattern
 import kotlin.time.toKotlinInstant
+import org.bson.Document
 
 
 @ApplicationScoped
@@ -91,6 +94,23 @@ class AppAlbumRepositoryAdapter(
         .find(Filters.`in`(ARTIST_ID_FIELD, artistIds.map { it.value }))
         .toList()
         .map { it.toDomain() }
+    }
+  }
+
+  override fun countByArtistIds(artistIds: Set<ArtistId>): Map<String, Long> {
+    if (artistIds.isEmpty()) return emptyMap()
+    val pipeline = listOf(
+      Aggregates.match(Filters.`in`(ARTIST_ID_FIELD, artistIds.map { it.value })),
+      Aggregates.group("\$$ARTIST_ID_FIELD", Accumulators.sum("count", 1)),
+    )
+    return mongoQueryMetrics.timed("app_album.countByArtistIds") {
+      appAlbumDocumentRepository.mongoCollection()
+        .aggregate(pipeline, Document::class.java)
+        .associate { doc ->
+          val artistId = doc.getString("_id")
+          val count = (doc["count"] as? Int)?.toLong() ?: doc.getLong("count") ?: 0L
+          artistId to count
+        }
     }
   }
 

--- a/application-quarkus/src/test/kotlin/de/chrgroth/spotify/control/adapter/out/mongodb/AppAlbumRepositoryTests.kt
+++ b/application-quarkus/src/test/kotlin/de/chrgroth/spotify/control/adapter/out/mongodb/AppAlbumRepositoryTests.kt
@@ -134,6 +134,27 @@ class AppAlbumRepositoryTests {
   }
 
   @Test
+  fun `countByArtistIds returns album counts per artist for all given artists in a single batch`() {
+    val artistId1 = ArtistId("artist-count1-${UUID.randomUUID()}")
+    val artistId2 = ArtistId("artist-count2-${UUID.randomUUID()}")
+    val album1 = album("count-bulk1").copy(artistId = artistId1)
+    val album2 = album("count-bulk2").copy(artistId = artistId1)
+    val album3 = album("count-bulk3").copy(artistId = artistId2)
+    val other = album("count-bulk-other").copy(artistId = ArtistId("other-artist-${UUID.randomUUID()}"))
+    appAlbumRepository.upsertAll(listOf(album1, album2, album3, other))
+
+    val result = appAlbumRepository.countByArtistIds(setOf(artistId1, artistId2))
+
+    assertThat(result).containsExactlyInAnyOrderEntriesOf(mapOf(artistId1.value to 2L, artistId2.value to 1L))
+  }
+
+  @Test
+  fun `countByArtistIds returns empty map for empty input`() {
+    val result = appAlbumRepository.countByArtistIds(emptySet())
+    assertThat(result).isEmpty()
+  }
+
+  @Test
   fun `findRecentlySynced returns albums ordered by lastSync descending`() {
     val older = album("recent-older")
     appAlbumRepository.upsertAll(listOf(older))

--- a/docs/releasenotes/snippets/0746-bugfix.md
+++ b/docs/releasenotes/snippets/0746-bugfix.md
@@ -1,0 +1,1 @@
+* Fixed a slow database query on the Catalog Sync page by computing per-artist album counts directly in the database instead of loading full album records.

--- a/domain-api/src/main/kotlin/de/chrgroth/spotify/control/domain/port/out/catalog/AppAlbumRepositoryPort.kt
+++ b/domain-api/src/main/kotlin/de/chrgroth/spotify/control/domain/port/out/catalog/AppAlbumRepositoryPort.kt
@@ -12,6 +12,7 @@ interface AppAlbumRepositoryPort {
   fun findByAlbumIds(albumIds: Set<AlbumId>): List<AppAlbum>
   fun findByArtistId(artistId: ArtistId): List<AppAlbum>
   fun findByArtistIds(artistIds: Set<ArtistId>): List<AppAlbum>
+  fun countByArtistIds(artistIds: Set<ArtistId>): Map<String, Long>
   fun findRecentlySynced(offset: Int, limit: Int): List<AppAlbum>
   fun deleteAll()
 }

--- a/domain-impl/src/main/kotlin/de/chrgroth/spotify/control/domain/catalog/CatalogBrowserService.kt
+++ b/domain-impl/src/main/kotlin/de/chrgroth/spotify/control/domain/catalog/CatalogBrowserService.kt
@@ -147,9 +147,7 @@ class CatalogBrowserService(
     val boundedArtists = artistCandidates.take(limit)
     val boundedAlbums = albumCandidates.take(limit)
 
-    val albumCountByArtistId = appAlbumRepository.findByArtistIds(boundedArtists.map { it.id }.toSet())
-      .groupingBy { it.artistId?.value }
-      .eachCount()
+    val albumCountByArtistId = appAlbumRepository.countByArtistIds(boundedArtists.map { it.id }.toSet())
 
     val artistEntries = boundedArtists.map { artist ->
       CatalogSyncTimelineEntry(
@@ -157,7 +155,7 @@ class CatalogBrowserService(
         syncedAt = artist.lastSync,
         artistId = artist.id.value,
         artistName = artist.artistName,
-        albumCount = albumCountByArtistId[artist.id.value] ?: 0,
+        albumCount = (albumCountByArtistId[artist.id.value] ?: 0L).toInt(),
       )
     }
     val albumEntries = boundedAlbums.map { album ->

--- a/domain-impl/src/test/kotlin/de/chrgroth/spotify/control/domain/catalog/CatalogBrowserServiceTests.kt
+++ b/domain-impl/src/test/kotlin/de/chrgroth/spotify/control/domain/catalog/CatalogBrowserServiceTests.kt
@@ -196,10 +196,7 @@ class CatalogBrowserServiceTests {
     )
     every { appArtistRepository.findRecentlySynced(0, 3) } returns listOf(artistA, artistB, AppArtist(id = ArtistId("artist-z"), artistName = "Z", lastSync = Instant.fromEpochSeconds(50)))
     every { appAlbumRepository.findRecentlySynced(0, 3) } returns listOf(albumX)
-    every { appAlbumRepository.findByArtistIds(setOf(artistA.id, artistB.id)) } returns listOf(
-      AppAlbum(id = AlbumId("album-a1"), artistId = artistA.id, lastSync = triggeredAt),
-      AppAlbum(id = AlbumId("album-a2"), artistId = artistA.id, lastSync = triggeredAt),
-    )
+    every { appAlbumRepository.countByArtistIds(setOf(artistA.id, artistB.id)) } returns mapOf(artistA.id.value to 2L)
 
     val result = service.getSyncTimeline(artistOffset = 0, albumOffset = 0, limit = 2)
 
@@ -222,7 +219,7 @@ class CatalogBrowserServiceTests {
       AppArtist(id = ArtistId("artist-a"), artistName = "Artist A", lastSync = Instant.fromEpochSeconds(100)),
     )
     every { appAlbumRepository.findRecentlySynced(0, 3) } returns emptyList()
-    every { appAlbumRepository.findByArtistIds(setOf(ArtistId("artist-a"))) } returns emptyList()
+    every { appAlbumRepository.countByArtistIds(setOf(ArtistId("artist-a"))) } returns emptyMap()
 
     val result = service.getSyncTimeline(artistOffset = 0, albumOffset = 0, limit = 2)
 


### PR DESCRIPTION
Fixes #712.

## Summary
- `CatalogBrowserService.getSyncTimeline()` (the /catalog-sync page) called `appAlbumRepository.findByArtistIds()` with up to 200 artist ids (page size) against a 256-artist catalog, pulling back almost the entire `app_album` collection just to compute per-artist album counts for display.
- Added `AppAlbumRepositoryPort.countByArtistIds()`, implemented as a MongoDB `$match`/`$group` aggregation in `AppAlbumRepositoryAdapter`, so counting happens server-side without transferring any album documents.
- The other four slow queries reported in the issue (`findByPeriods`, `countSucceeded`, `findDailySummaryByPeriodRange`, `spotify_currently_playing.findAll`) were investigated and found to already be correctly indexed/projected from earlier fixes in this thread; their 100-300ms durations are consistent with MongoDB connection-pool contention during concurrent dashboard/stats loads, not a code-level inefficiency, so no change was made for those.

## Test plan
- `./gradlew build` passes (tests + static analysis).
- Added `AppAlbumRepositoryTests` and updated `CatalogBrowserServiceTests` for the new aggregation-based count method.

Generated with [Claude Code](https://claude.ai/code)