### PR TITLE
Unify slow MongoDB query log pattern

### DIFF
--- a/adapter-out-mongodb/src/main/kotlin/de/chrgroth/spotify/control/adapter/out/mongodb/MongoQueryMetrics.kt
+++ b/adapter-out-mongodb/src/main/kotlin/de/chrgroth/spotify/control/adapter/out/mongodb/MongoQueryMetrics.kt
@@ -64,7 +64,7 @@ class MongoQueryMetrics(
     pruneOldEntries(execDeque)
 
     if (durationMs >= slowQueryThresholdMs) {
-      logger.warn { "Slow MongoDB query detected: operation=$operation duration=${durationMs}ms threshold=${slowQueryThresholdMs}ms" }
+      logger.warn { "Slow MongoDB query detected: operation=$operation duration=${durationMs}/${slowQueryThresholdMs}ms" }
       slowQueryCounters.getOrPut(operation) {
         meterRegistry.counter("mongodb.slow.queries", "operation", operation)
       }.increment()

--- a/docs/releasenotes/snippets/issue-756-20260710-0804-bugfix.md
+++ b/docs/releasenotes/snippets/issue-756-20260710-0804-bugfix.md
@@ -1,0 +1,1 @@
+* Unified the slow MongoDB query warning to a single consistent log format.


### PR DESCRIPTION
Unifies the two different slow-query log formats into a single `duration=${x}/${y}ms` pattern, matching the format already used by the outbox library's slow-query warnings.

Fixes #756.

Generated with [Claude Code](https://claude.ai/code)