### PR TITLE
Add grouped, collapsible Release Notes page (Step 2)

### DIFF
--- a/adapter-in-web/src/main/kotlin/de/chrgroth/spotify/control/adapter/in/web/DocsFileResource.kt
+++ b/adapter-in-web/src/main/kotlin/de/chrgroth/spotify/control/adapter/in/web/DocsFileResource.kt
@@ -22,7 +22,7 @@ class DocsFileResource(
   private val docsTemplate: Template,
 ) {
 
-  private val allowedSubdirs = setOf("arc42", "adr", "coding-guidelines", "releasenotes")
+  private val allowedSubdirs = setOf("arc42", "adr", "coding-guidelines")
 
   @GET
   @Authenticated

--- a/adapter-in-web/src/main/kotlin/de/chrgroth/spotify/control/adapter/in/web/ReleaseNotesResource.kt
+++ b/adapter-in-web/src/main/kotlin/de/chrgroth/spotify/control/adapter/in/web/ReleaseNotesResource.kt
@@ -1,0 +1,61 @@
+package de.chrgroth.spotify.control.adapter.`in`.web
+
+import io.quarkus.qute.Location
+import io.quarkus.qute.Template
+import io.quarkus.qute.TemplateInstance
+import io.quarkus.security.Authenticated
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.ws.rs.GET
+import jakarta.ws.rs.NotFoundException
+import jakarta.ws.rs.Path
+import jakarta.ws.rs.Produces
+import jakarta.ws.rs.core.MediaType
+
+data class ReleaseNotesGroupView(
+  val id: String,
+  val title: String,
+  val versionsLabel: String,
+  val markdownContent: String,
+  val expanded: Boolean,
+)
+
+@Path("/docs/releasenotes/RELEASENOTES.md")
+@ApplicationScoped
+@Suppress("Unused")
+class ReleaseNotesResource(
+  @param:Location("release-notes.html")
+  private val releaseNotesTemplate: Template,
+) {
+
+  @GET
+  @Authenticated
+  @Produces(MediaType.TEXT_HTML)
+  fun releaseNotes(): TemplateInstance {
+    val content = DocsUtils.readMarkdown("docs/releasenotes/RELEASENOTES.md")
+      ?: throw NotFoundException("Release notes not found")
+    val groups = ReleaseNotesParser.groupByMinorVersion(ReleaseNotesParser.parse(content))
+    return releaseNotesTemplate.instance()
+      .data("groups", groups.mapIndexed { index, group -> toView(group, expanded = index == 0) })
+  }
+
+  private fun toView(group: ReleaseNotesMinorGroup, expanded: Boolean): ReleaseNotesGroupView {
+    val dateRange = if (group.fromDate == group.toDate) group.toDate else "${group.fromDate} – ${group.toDate}"
+    val versionCount = group.versions.size
+    return ReleaseNotesGroupView(
+      id = "release-notes-group-${group.minorVersion.replace(".", "-")}",
+      title = "${group.minorVersion}.x ($dateRange)",
+      versionsLabel = "$versionCount version${if (versionCount == 1) "" else "s"}: ${group.versions.joinToString(", ")}",
+      markdownContent = toMarkdown(group),
+      expanded = expanded,
+    )
+  }
+
+  private fun toMarkdown(group: ReleaseNotesMinorGroup): String {
+    val sections = mutableListOf<String>()
+    if (group.highlights.isNotEmpty()) sections.add(group.highlights.joinToString("\n") { "* $it" })
+    if (group.breakingChanges.isNotEmpty()) sections.add("### Breaking Changes\n" + group.breakingChanges.joinToString("\n") { "* $it" })
+    if (group.features.isNotEmpty()) sections.add("### New Features\n" + group.features.joinToString("\n") { "* $it" })
+    if (group.bugfixes.isNotEmpty()) sections.add("### Bugfixes / Chore\n" + group.bugfixes.joinToString("\n") { "* $it" })
+    return sections.joinToString("\n\n")
+  }
+}

--- a/adapter-in-web/src/main/resources/templates/layout.html
+++ b/adapter-in-web/src/main/resources/templates/layout.html
@@ -128,6 +128,25 @@
         .docs-content {
             max-width: 860px;
         }
+        .app-accordion-item {
+            overflow: hidden;
+        }
+        .app-accordion-button {
+            background-color: var(--color-bg-card);
+            color: var(--color-text-primary);
+        }
+        .app-accordion-button:not(.collapsed) {
+            background-color: var(--color-bg-card);
+            color: var(--color-text-primary);
+            box-shadow: inset 0 -1px 0 var(--color-border);
+        }
+        .app-accordion-button::after {
+            filter: invert(1) grayscale(1) brightness(1.5);
+        }
+        .app-accordion-button:focus {
+            box-shadow: none;
+            border-color: var(--color-border);
+        }
         .form-control::placeholder {
             color: var(--color-text-muted);
             opacity: 1;

--- a/adapter-in-web/src/main/resources/templates/release-notes.html
+++ b/adapter-in-web/src/main/resources/templates/release-notes.html
@@ -1,0 +1,38 @@
+{#include layout.html}
+    {#title}SpCtl – Release Notes{/title}
+    {#content}
+    <div class="container py-4">
+        <h1 class="mb-4">Release Notes</h1>
+        <div class="accordion" id="release-notes-accordion">
+            {#for group in groups}
+            <div class="accordion-item app-card app-accordion-item mb-2">
+                <h2 class="accordion-header" id="{group.id}-heading">
+                    <button class="accordion-button app-accordion-button {#if !group.expanded}collapsed{/if}" type="button"
+                            data-bs-toggle="collapse" data-bs-target="#{group.id}-collapse"
+                            aria-expanded="{group.expanded}" aria-controls="{group.id}-collapse">
+                        <span>
+                            <span class="d-block">{group.title}</span>
+                            <span class="d-block app-section-label">{group.versionsLabel}</span>
+                        </span>
+                    </button>
+                </h2>
+                <div id="{group.id}-collapse" class="accordion-collapse collapse {#if group.expanded}show{/if}" aria-labelledby="{group.id}-heading">
+                    <div class="accordion-body docs-content">
+                        <div class="release-notes-rendered" data-target="{group.id}"></div>
+                        <textarea class="d-none release-notes-raw" data-group="{group.id}">{group.markdownContent}</textarea>
+                    </div>
+                </div>
+            </div>
+            {/for}
+        </div>
+    </div>
+    <script>
+        document.querySelectorAll('.release-notes-raw').forEach(function (textarea) {
+            var target = document.querySelector('.release-notes-rendered[data-target="' + textarea.dataset.group + '"]');
+            if (target) {
+                target.innerHTML = marked.parse(textarea.value);
+            }
+        });
+    </script>
+    {/content}
+{/include}

--- a/application-quarkus/src/test/kotlin/de/chrgroth/spotify/control/adapter/in/web/DocsPageTests.kt
+++ b/application-quarkus/src/test/kotlin/de/chrgroth/spotify/control/adapter/in/web/DocsPageTests.kt
@@ -74,32 +74,6 @@ class DocsPageTests {
       .statusCode(404)
   }
 
-  @Test
-  fun `docs releasenotes page is available and renders markdown content`() {
-    given()
-      .`when`()
-      .get("/docs/releasenotes/RELEASENOTES.md")
-      .then()
-      .statusCode(200)
-      .contentType(containsString("text/html"))
-      .body(containsString("docs-rendered"))
-      .body(containsString("Bugfixes"))
-  }
-
-  @Test
-  fun `docs releasenotes page contains raw markdown in textarea and rendering script`() {
-    val body = given()
-      .`when`()
-      .get("/docs/releasenotes/RELEASENOTES.md")
-      .then()
-      .statusCode(200)
-      .extract()
-      .body()
-      .asString()
-
-    assertMarkdownRenderingPipeline(body, "# 0.9")
-  }
-
   private fun assertMarkdownRenderingPipeline(body: String, expectedMarkdownContent: String) {
     assertThat(body).contains("""id="docs-raw"""")
     assertThat(body).contains(expectedMarkdownContent)

--- a/application-quarkus/src/test/kotlin/de/chrgroth/spotify/control/adapter/in/web/ReleaseNotesPageTests.kt
+++ b/application-quarkus/src/test/kotlin/de/chrgroth/spotify/control/adapter/in/web/ReleaseNotesPageTests.kt
@@ -1,0 +1,85 @@
+package de.chrgroth.spotify.control.adapter.`in`.web
+
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.test.security.TestSecurity
+import io.restassured.RestAssured.given
+import org.assertj.core.api.Assertions.assertThat
+import org.hamcrest.CoreMatchers.containsString
+import org.junit.jupiter.api.Test
+
+@QuarkusTest
+@TestSecurity(user = "test-user-a")
+class ReleaseNotesPageTests {
+
+  @Test
+  fun `release notes page is available and renders a grouped accordion`() {
+    given()
+      .`when`()
+      .get("/docs/releasenotes/RELEASENOTES.md")
+      .then()
+      .statusCode(200)
+      .contentType(containsString("text/html"))
+      .body(containsString("Release Notes"))
+      .body(containsString("accordion-item"))
+      .body(containsString("release-notes-raw"))
+  }
+
+  @Test
+  fun `newest minor version group is expanded, older groups are collapsed`() {
+    val groups = groupsFromRealFile()
+    assertThat(groups.size).isGreaterThan(1)
+
+    val body = renderedBody()
+
+    val newestGroupId = groupId(groups[0])
+    assertThat(body).contains("""id="$newestGroupId-collapse" class="accordion-collapse collapse show"""")
+    assertThat(body).contains("""aria-expanded="true" aria-controls="$newestGroupId-collapse"""")
+
+    val olderGroupId = groupId(groups[1])
+    assertThat(body).contains("""id="$olderGroupId-collapse" class="accordion-collapse collapse """")
+    assertThat(body).contains("""aria-expanded="false" aria-controls="$olderGroupId-collapse"""")
+  }
+
+  @Test
+  fun `page contains marked rendering pipeline for every group`() {
+    val groups = groupsFromRealFile()
+    val body = renderedBody()
+
+    assertThat(body).contains("marked.parse(")
+    assertThat(body.indexOf("marked.umd.js")).isLessThan(body.indexOf("marked.parse("))
+    groups.forEach { group ->
+      assertThat(body).contains("""data-group="${groupId(group)}"""")
+    }
+  }
+
+  @Test
+  fun `no bullet content is lost when grouping entries by minor version`() {
+    val entries = ReleaseNotesParser.parse(readRealReleaseNotes())
+    val groups = ReleaseNotesParser.groupByMinorVersion(entries)
+
+    val entryBulletCount = entries.sumOf { it.highlights.size + it.breakingChanges.size + it.features.size + it.bugfixes.size }
+    val groupBulletCount = groups.sumOf { it.highlights.size + it.breakingChanges.size + it.features.size + it.bugfixes.size }
+    assertThat(groupBulletCount).isEqualTo(entryBulletCount)
+  }
+
+  private fun groupsFromRealFile(): List<ReleaseNotesMinorGroup> =
+    ReleaseNotesParser.groupByMinorVersion(ReleaseNotesParser.parse(readRealReleaseNotes()))
+
+  private fun readRealReleaseNotes(): String {
+    val stream = Thread.currentThread().contextClassLoader.getResourceAsStream("docs/releasenotes/RELEASENOTES.md")
+    assertThat(stream).isNotNull()
+    return stream!!.bufferedReader(Charsets.UTF_8).readText()
+  }
+
+  private fun renderedBody(): String =
+    given()
+      .`when`()
+      .get("/docs/releasenotes/RELEASENOTES.md")
+      .then()
+      .statusCode(200)
+      .extract()
+      .body()
+      .asString()
+
+  private fun groupId(group: ReleaseNotesMinorGroup): String = "release-notes-group-${group.minorVersion.replace(".", "-")}"
+}

--- a/docs/releasenotes/snippets/0926-feature.md
+++ b/docs/releasenotes/snippets/0926-feature.md
@@ -1,0 +1,1 @@
+* The Release Notes page now groups patch releases together by minor version, with collapsible panels showing the newest version group expanded by default.


### PR DESCRIPTION
## Summary
- Adds a dedicated `ReleaseNotesResource` + `release-notes.html` template that parses and groups `RELEASENOTES.md` by minor version using the `ReleaseNotesParser` from Step 1.
- Renders each minor-version group as a Bootstrap accordion panel (newest expanded by default, older ones collapsed) instead of the raw, ungrouped markdown dump.
- `DocsFileResource` no longer handles `releasenotes`; arc42/adr/coding-guidelines are unaffected.
- Adds `ReleaseNotesPageTests` covering page availability, expand/collapse state, the marked.js rendering pipeline, and that no bullet content is lost when grouping.

Refs #754

## Test plan
- [x] `./gradlew build` passes (tests + static analysis)
- [x] New `ReleaseNotesPageTests` pass (4/4)
- [x] Existing `ReleaseNotesParserTests` (9/9) and `DocsPageTests` still pass

Generated with [Claude Code](https://claude.ai/code)