### PR TITLE
Fix release notes accordion display

### DIFF
--- a/adapter-in-web/src/main/kotlin/de/chrgroth/spotify/control/adapter/in/web/ReleaseNotesResource.kt
+++ b/adapter-in-web/src/main/kotlin/de/chrgroth/spotify/control/adapter/in/web/ReleaseNotesResource.kt
@@ -35,7 +35,7 @@ class ReleaseNotesResource(
       ?: throw NotFoundException("Release notes not found")
     val groups = ReleaseNotesParser.groupByMinorVersion(ReleaseNotesParser.parse(content))
     return releaseNotesTemplate.instance()
-      .data("groups", groups.mapIndexed { index, group -> toView(group, expanded = index == 0) })
+      .data("groups", groups.mapIndexed { index, group -> toView(group, expanded = index < 3) })
   }
 
   private fun toView(group: ReleaseNotesMinorGroup, expanded: Boolean): ReleaseNotesGroupView {

--- a/adapter-in-web/src/main/resources/templates/layout.html
+++ b/adapter-in-web/src/main/resources/templates/layout.html
@@ -127,6 +127,7 @@
         }
         .docs-content {
             max-width: 860px;
+            color: var(--color-text-primary);
         }
         .app-accordion-item {
             overflow: hidden;
@@ -134,6 +135,10 @@
         .app-accordion-button {
             background-color: var(--color-bg-card);
             color: var(--color-text-primary);
+        }
+        .app-accordion-title {
+            font-size: 1.75rem;
+            font-weight: 500;
         }
         .app-accordion-button:not(.collapsed) {
             background-color: var(--color-bg-card);

--- a/adapter-in-web/src/main/resources/templates/release-notes.html
+++ b/adapter-in-web/src/main/resources/templates/release-notes.html
@@ -11,7 +11,7 @@
                             data-bs-toggle="collapse" data-bs-target="#{group.id}-collapse"
                             aria-expanded="{group.expanded}" aria-controls="{group.id}-collapse">
                         <span>
-                            <span class="d-block">{group.title}</span>
+                            <span class="d-block app-accordion-title">{group.title}</span>
                             <span class="d-block app-section-label">{group.versionsLabel}</span>
                         </span>
                     </button>

--- a/application-quarkus/src/test/kotlin/de/chrgroth/spotify/control/adapter/in/web/ReleaseNotesPageTests.kt
+++ b/application-quarkus/src/test/kotlin/de/chrgroth/spotify/control/adapter/in/web/ReleaseNotesPageTests.kt
@@ -25,17 +25,19 @@ class ReleaseNotesPageTests {
   }
 
   @Test
-  fun `newest minor version group is expanded, older groups are collapsed`() {
+  fun `newest 3 minor version groups are expanded, older groups are collapsed`() {
     val groups = groupsFromRealFile()
-    assertThat(groups.size).isGreaterThan(1)
+    assertThat(groups.size).isGreaterThan(3)
 
     val body = renderedBody()
 
-    val newestGroupId = groupId(groups[0])
-    assertThat(body).contains("""id="$newestGroupId-collapse" class="accordion-collapse collapse show"""")
-    assertThat(body).contains("""aria-expanded="true" aria-controls="$newestGroupId-collapse"""")
+    groups.take(3).forEach { group ->
+      val groupId = groupId(group)
+      assertThat(body).contains("""id="$groupId-collapse" class="accordion-collapse collapse show"""")
+      assertThat(body).contains("""aria-expanded="true" aria-controls="$groupId-collapse"""")
+    }
 
-    val olderGroupId = groupId(groups[1])
+    val olderGroupId = groupId(groups[3])
     assertThat(body).contains("""id="$olderGroupId-collapse" class="accordion-collapse collapse """")
     assertThat(body).contains("""aria-expanded="false" aria-controls="$olderGroupId-collapse"""")
   }

--- a/docs/releasenotes/snippets/1007-bugfix.md
+++ b/docs/releasenotes/snippets/1007-bugfix.md
@@ -1,0 +1,1 @@
+* Fixed the release notes page: the newest 3 version groups are now expanded by default, bullet point text is readable again, and the accordion headers are now at least as large as the section headings inside them.


### PR DESCRIPTION
## Summary
- Expands the newest 3 minor-version groups by default instead of just the first one.
- Fixes unreadable bullet text (black on dark background) by giving the `docs-content` wrapper an explicit light text color, instead of inheriting Bootstrap's default dark `.accordion` text color.
- Bumps the accordion header font size to match the "New Features" etc. section headings inside it.

Follow-up to the Step 2 release notes accordion work.

Refs #754

## Test plan
- [x] `./gradlew build` passes (tests + static analysis)
- [x] Updated `ReleaseNotesPageTests` verifies the newest 3 groups are expanded and older ones collapsed

Generated with [Claude Code](https://claude.ai/code)