### PR TITLE
Fix release notes accordion header display

### DIFF
--- a/adapter-in-web/src/main/kotlin/de/chrgroth/spotify/control/adapter/in/web/ReleaseNotesResource.kt
+++ b/adapter-in-web/src/main/kotlin/de/chrgroth/spotify/control/adapter/in/web/ReleaseNotesResource.kt
@@ -14,6 +14,7 @@ import jakarta.ws.rs.core.MediaType
 data class ReleaseNotesGroupView(
   val id: String,
   val title: String,
+  val dateRange: String,
   val versionsLabel: String,
   val markdownContent: String,
   val expanded: Boolean,
@@ -43,7 +44,8 @@ class ReleaseNotesResource(
     val versionCount = group.versions.size
     return ReleaseNotesGroupView(
       id = "release-notes-group-${group.minorVersion.replace(".", "-")}",
-      title = "${group.minorVersion}.x ($dateRange)",
+      title = group.minorVersion,
+      dateRange = dateRange,
       versionsLabel = "$versionCount version${if (versionCount == 1) "" else "s"}: ${group.versions.joinToString(", ")}",
       markdownContent = toMarkdown(group),
       expanded = expanded,

--- a/adapter-in-web/src/main/resources/templates/layout.html
+++ b/adapter-in-web/src/main/resources/templates/layout.html
@@ -140,6 +140,12 @@
             font-size: 1.75rem;
             font-weight: 500;
         }
+        .app-accordion-date {
+            font-size: .9rem;
+            font-weight: 400;
+            color: var(--color-text-muted);
+            white-space: nowrap;
+        }
         .app-accordion-button:not(.collapsed) {
             background-color: var(--color-bg-card);
             color: var(--color-text-primary);

--- a/adapter-in-web/src/main/resources/templates/release-notes.html
+++ b/adapter-in-web/src/main/resources/templates/release-notes.html
@@ -10,14 +10,15 @@
                     <button class="accordion-button app-accordion-button {#if !group.expanded}collapsed{/if}" type="button"
                             data-bs-toggle="collapse" data-bs-target="#{group.id}-collapse"
                             aria-expanded="{group.expanded}" aria-controls="{group.id}-collapse">
-                        <span>
-                            <span class="d-block app-accordion-title">{group.title}</span>
-                            <span class="d-block app-section-label">{group.versionsLabel}</span>
+                        <span class="d-flex justify-content-between align-items-center flex-grow-1 me-2">
+                            <span class="app-accordion-title">{group.title}</span>
+                            <span class="app-accordion-date">{group.dateRange}</span>
                         </span>
                     </button>
                 </h2>
                 <div id="{group.id}-collapse" class="accordion-collapse collapse {#if group.expanded}show{/if}" aria-labelledby="{group.id}-heading">
                     <div class="accordion-body docs-content">
+                        <p class="app-section-label mb-3">{group.versionsLabel}</p>
                         <div class="release-notes-rendered" data-target="{group.id}"></div>
                         <textarea class="d-none release-notes-raw" data-group="{group.id}">{group.markdownContent}</textarea>
                     </div>

--- a/docs/releasenotes/snippets/1037-bugfix.md
+++ b/docs/releasenotes/snippets/1037-bugfix.md
@@ -1,0 +1,1 @@
+* Improved the release notes accordion header: removed the redundant ".x" suffix, moved the date to the right without parentheses, and moved the version list into the panel body.


### PR DESCRIPTION
## Summary
- Removes the redundant ".x" suffix from the minor-version accordion title (e.g. `0.107` instead of `0.107.x`).
- Shows the date range right-aligned in the header, without parentheses, instead of inline next to the title.
- Moves the "x versions: ..." text out of the header into the accordion body.

Follow-up to the Step 2 release notes accordion work.

Refs #754

## Test plan
- [x] `./gradlew build` passes (tests + static analysis)
- [x] Existing `ReleaseNotesPageTests` still pass

Generated with [Claude Code](https://claude.ai/code)