### PR TITLE
Prefix release notes version numbers with "v"

### DIFF
--- a/adapter-in-web/src/main/kotlin/de/chrgroth/spotify/control/adapter/in/web/ReleaseNotesResource.kt
+++ b/adapter-in-web/src/main/kotlin/de/chrgroth/spotify/control/adapter/in/web/ReleaseNotesResource.kt
@@ -44,9 +44,9 @@ class ReleaseNotesResource(
     val versionCount = group.versions.size
     return ReleaseNotesGroupView(
       id = "release-notes-group-${group.minorVersion.replace(".", "-")}",
-      title = group.minorVersion,
+      title = "v${group.minorVersion}",
       dateRange = dateRange,
-      versionsLabel = "$versionCount version${if (versionCount == 1) "" else "s"}: ${group.versions.joinToString(", ")}",
+      versionsLabel = "$versionCount version${if (versionCount == 1) "" else "s"}: ${group.versions.joinToString(", ") { "v$it" }}",
       markdownContent = toMarkdown(group),
       expanded = expanded,
     )

--- a/docs/releasenotes/snippets/1135-bugfix.md
+++ b/docs/releasenotes/snippets/1135-bugfix.md
@@ -1,0 +1,1 @@
+* Prefixed release notes version numbers with "v" (e.g. "v0.107") in the Release Notes page.


### PR DESCRIPTION
## Summary
- Prefixes version numbers shown on the Release Notes page with "v" (e.g. "v0.107" in the accordion header, "v0.107.16" etc. in the versions list).

Follow-up to the Step 2 release notes accordion work.

Refs #754

## Test plan
- [x] `./gradlew build` passes (tests + static analysis)

Generated with [Claude Code](https://claude.ai/code)