### PR TITLE
Fix: outbox viewer cache polling all partitions every 15s in the background

### DIFF
--- a/docs/releasenotes/snippets/0455-bugfix.md
+++ b/docs/releasenotes/snippets/0455-bugfix.md
@@ -1,0 +1,1 @@
+* Fixed the outbox viewer background refresh continuously querying the database every 15 seconds, even when nobody was viewing the outbox viewer page, causing repeated slow-query warnings.

--- a/domain-impl/src/main/kotlin/de/chrgroth/spotify/control/domain/infra/OutboxViewerTasksCache.kt
+++ b/domain-impl/src/main/kotlin/de/chrgroth/spotify/control/domain/infra/OutboxViewerTasksCache.kt
@@ -3,20 +3,17 @@ package de.chrgroth.spotify.control.domain.infra
 import de.chrgroth.spotify.control.domain.model.infra.OutboxViewerPartition
 import de.chrgroth.spotify.control.domain.outbox.DomainOutboxPartition
 import de.chrgroth.spotify.control.domain.port.out.infra.OutboxPort
-import io.quarkus.runtime.StartupEvent
-import io.quarkus.scheduler.Scheduled
 import jakarta.enterprise.context.ApplicationScoped
-import jakarta.enterprise.event.Observes
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.runBlocking
 import mu.KLogging
 
-// shared by every /outbox-viewer request so that the refresh-outbox-partitions SSE event, which fires on every
-// outbox task lifecycle event, can never trigger more than one findByPartition scan per partition per refresh
-// interval, no matter how many task events or open tabs are involved.
+// refreshed lazily on read with a 15s TTL so that concurrent /outbox-viewer requests (page load plus the
+// refresh-outbox-partitions SSE-triggered snippet fetch) never trigger more than one findByPartition scan per
+// partition per interval, and the outbox is not queried at all while nobody is viewing the page.
 @ApplicationScoped
-@Suppress("Unused", "UnusedParameter")
+@Suppress("Unused")
 class OutboxViewerTasksCache(
   private val outbox: OutboxPort,
 ) {
@@ -24,11 +21,18 @@ class OutboxViewerTasksCache(
   @Volatile
   private var cachedPartitions: List<OutboxViewerPartition> = emptyList()
 
-  fun current(): List<OutboxViewerPartition> = cachedPartitions
+  @Volatile
+  private var lastRefreshAtMs: Long = 0
 
-  fun onStartup(@Observes event: StartupEvent) = refresh()
+  @Synchronized
+  fun current(): List<OutboxViewerPartition> {
+    if (System.currentTimeMillis() - lastRefreshAtMs >= REFRESH_INTERVAL_MS) {
+      refresh()
+    }
+    return cachedPartitions
+  }
 
-  @Scheduled(every = "15s")
+  @Synchronized
   fun refresh() {
     try {
       cachedPartitions = runBlocking {
@@ -38,8 +42,12 @@ class OutboxViewerTasksCache(
       }
     } catch (e: Exception) {
       logger.warn(e) { "Failed to refresh outbox viewer tasks, keeping previous values" }
+    } finally {
+      lastRefreshAtMs = System.currentTimeMillis()
     }
   }
 
-  companion object : KLogging()
+  companion object : KLogging() {
+    private const val REFRESH_INTERVAL_MS = 15_000L
+  }
 }

--- a/domain-impl/src/test/kotlin/de/chrgroth/spotify/control/domain/infra/OutboxViewerTasksCacheTests.kt
+++ b/domain-impl/src/test/kotlin/de/chrgroth/spotify/control/domain/infra/OutboxViewerTasksCacheTests.kt
@@ -66,4 +66,24 @@ class OutboxViewerTasksCacheTests {
 
     DomainOutboxPartition.all.forEach { partition -> verify(exactly = 1) { outbox.getTasksByPartition(partition.key) } }
   }
+
+  @Test
+  fun `current triggers a refresh on first access without an explicit refresh call`() {
+    stubAllPartitionsEmpty()
+    val task = OutboxTask(
+      eventType = "TYPE_A",
+      deduplicationKey = "dedup-key",
+      priority = "MEDIUM",
+      status = "PENDING",
+      attempts = 0,
+      nextRetryAt = null,
+      createdAt = Instant.fromEpochSeconds(0),
+      lastError = null,
+    )
+    every { outbox.getTasksByPartition(DomainOutboxPartition.Domain.key) } returns listOf(task)
+
+    val domainPartition = cache.current().first { it.key == DomainOutboxPartition.Domain.key }
+
+    assertThat(domainPartition.tasks).containsExactly(task)
+  }
 }


### PR DESCRIPTION
## Summary

- `OutboxViewerTasksCache` ran as an unconditional `@Scheduled(every = "15s")` job forever, regardless of whether anyone viewed the outbox viewer page.
- Every tick fetched the full task list for all 5 outbox partitions via `outbox.getTasksByPartition(...)`, which is exactly the query logged as `outbox.task.findByPartition` in the reported slow-query warnings (fired continuously every 15s, unrelated to any page view).
- Switched the cache to a lazy 15s TTL: `current()` now refreshes itself only when read and stale, so the outbox is queried at most every 15s while the page is actually being viewed, and not at all otherwise.

Fixes #771

Generated with [Claude Code](https://claude.ai/code)