### PR TITLE
Fix slow health fragment HTTP responses

### DIFF
--- a/adapter-in-http-frontend/src/main/kotlin/de/chrgroth/spotify/control/adapter/in/http/frontend/HealthResource.kt
+++ b/adapter-in-http-frontend/src/main/kotlin/de/chrgroth/spotify/control/adapter/in/http/frontend/HealthResource.kt
@@ -1,5 +1,6 @@
 package de.chrgroth.spotify.control.adapter.`in`.http.frontend
 
+import de.chrgroth.spotify.control.domain.model.infra.HealthStats
 import de.chrgroth.spotify.control.domain.port.`in`.infra.HealthPort
 import de.chrgroth.spotify.control.domain.port.out.infra.ResponseTimingPort
 import io.quarkus.qute.Location
@@ -32,7 +33,7 @@ class HealthResource(
   @Authenticated
   @Produces(MediaType.TEXT_HTML)
   fun snippetPredicates(): TemplateInstance = httpResponseMetrics.timed("fragment.health.predicates") {
-    healthTemplate.getFragment("snippet_predicates").data("stats", health.getStats())
+    healthTemplate.getFragment("snippet_predicates").data("stats", HealthStats(predicateStats = health.getPredicateStats()))
   }
 
   @GET
@@ -40,7 +41,7 @@ class HealthResource(
   @Authenticated
   @Produces(MediaType.TEXT_HTML)
   fun snippetCronjobs(): TemplateInstance = httpResponseMetrics.timed("fragment.health.cronjobs") {
-    healthTemplate.getFragment("snippet_cronjobs").data("stats", health.getStats())
+    healthTemplate.getFragment("snippet_cronjobs").data("stats", HealthStats(cronjobStats = health.getCronjobStats()))
   }
 
   @GET
@@ -48,7 +49,7 @@ class HealthResource(
   @Authenticated
   @Produces(MediaType.TEXT_HTML)
   fun snippetOutgoingHttpCalls(): TemplateInstance = httpResponseMetrics.timed("fragment.health.outgoing-http-calls") {
-    healthTemplate.getFragment("snippet_outgoing_http_calls").data("stats", health.getStats())
+    healthTemplate.getFragment("snippet_outgoing_http_calls").data("stats", HealthStats(outgoingRequestStats = health.getOutgoingRequestStats()))
   }
 
   @GET
@@ -56,7 +57,7 @@ class HealthResource(
   @Authenticated
   @Produces(MediaType.TEXT_HTML)
   fun snippetOutboxPartitions(): TemplateInstance = httpResponseMetrics.timed("fragment.health.outbox-partitions") {
-    healthTemplate.getFragment("snippet_outbox_partitions").data("stats", health.getStats())
+    healthTemplate.getFragment("snippet_outbox_partitions").data("stats", HealthStats(outboxPartitions = health.getOutboxPartitions()))
   }
 
   @GET
@@ -64,7 +65,7 @@ class HealthResource(
   @Authenticated
   @Produces(MediaType.TEXT_HTML)
   fun snippetMongoDbCollections(): TemplateInstance = httpResponseMetrics.timed("fragment.health.mongodb-collections") {
-    healthTemplate.getFragment("snippet_mongodb_collections").data("stats", health.getStats())
+    healthTemplate.getFragment("snippet_mongodb_collections").data("stats", HealthStats(mongoCollectionStats = health.getMongoCollectionStats()))
   }
 
   @GET
@@ -72,7 +73,7 @@ class HealthResource(
   @Authenticated
   @Produces(MediaType.TEXT_HTML)
   fun snippetMongoDbQueries(): TemplateInstance = httpResponseMetrics.timed("fragment.health.mongodb-queries") {
-    healthTemplate.getFragment("snippet_mongodb_queries").data("stats", health.getStats())
+    healthTemplate.getFragment("snippet_mongodb_queries").data("stats", HealthStats(mongoQueryStats = health.getMongoQueryStats()))
   }
 
   @GET
@@ -80,7 +81,7 @@ class HealthResource(
   @Authenticated
   @Produces(MediaType.TEXT_HTML)
   fun snippetNavbarOutboxStatus(): TemplateInstance = httpResponseMetrics.timed("fragment.health.navbar-outbox-status") {
-    healthTemplate.getFragment("snippet_navbar_outbox_status").data("stats", health.getStats())
+    healthTemplate.getFragment("snippet_navbar_outbox_status").data("stats", HealthStats(outboxPartitions = health.getOutboxPartitions()))
   }
 
   @GET
@@ -88,6 +89,6 @@ class HealthResource(
   @Authenticated
   @Produces(MediaType.TEXT_HTML)
   fun snippetNavbarPlaybackStatus(): TemplateInstance = httpResponseMetrics.timed("fragment.health.navbar-playback-status") {
-    healthTemplate.getFragment("snippet_navbar_playback_status").data("stats", health.getStats())
+    healthTemplate.getFragment("snippet_navbar_playback_status").data("stats", HealthStats(predicateStats = health.getPredicateStats()))
   }
 }

--- a/docs/releasenotes/snippets/1813-bugfix.md
+++ b/docs/releasenotes/snippets/1813-bugfix.md
@@ -1,0 +1,1 @@
+* Fixed slow responses for health page fragments and navbar status icons.

--- a/domain-api/src/main/kotlin/de/chrgroth/spotify/control/domain/model/infra/HealthStats.kt
+++ b/domain-api/src/main/kotlin/de/chrgroth/spotify/control/domain/model/infra/HealthStats.kt
@@ -1,13 +1,13 @@
 package de.chrgroth.spotify.control.domain.model.infra
 
 data class HealthStats(
-  val outgoingRequestStats: List<OutgoingRequestStats>,
-  val outboxPartitions: List<OutboxPartitionStats>,
-  val mongoCollectionStats: List<MongoCollectionStats>,
-  val mongoQueryStats: List<MongoQueryStats>,
-  val cronjobStats: List<CronjobStats>,
-  val predicateStats: List<PredicateStats>,
-  val configurationStats: ConfigurationStats,
+  val outgoingRequestStats: List<OutgoingRequestStats> = emptyList(),
+  val outboxPartitions: List<OutboxPartitionStats> = emptyList(),
+  val mongoCollectionStats: List<MongoCollectionStats> = emptyList(),
+  val mongoQueryStats: List<MongoQueryStats> = emptyList(),
+  val cronjobStats: List<CronjobStats> = emptyList(),
+  val predicateStats: List<PredicateStats> = emptyList(),
+  val configurationStats: ConfigurationStats = ConfigurationStats(emptyList(), emptyList()),
 ) {
   val mongoCollectionDocumentTotal: Long get() = mongoCollectionStats.sumOf { it.documentCount }
   val mongoCollectionSizeTotalKb: Long get() = mongoCollectionStats.sumOf { it.sizeKb }

--- a/domain-api/src/main/kotlin/de/chrgroth/spotify/control/domain/port/in/infra/HealthPort.kt
+++ b/domain-api/src/main/kotlin/de/chrgroth/spotify/control/domain/port/in/infra/HealthPort.kt
@@ -1,7 +1,21 @@
 package de.chrgroth.spotify.control.domain.port.`in`.infra
 
+import de.chrgroth.spotify.control.domain.model.infra.ConfigurationStats
+import de.chrgroth.spotify.control.domain.model.infra.CronjobStats
 import de.chrgroth.spotify.control.domain.model.infra.HealthStats
+import de.chrgroth.spotify.control.domain.model.infra.MongoCollectionStats
+import de.chrgroth.spotify.control.domain.model.infra.MongoQueryStats
+import de.chrgroth.spotify.control.domain.model.infra.OutboxPartitionStats
+import de.chrgroth.spotify.control.domain.model.infra.OutgoingRequestStats
+import de.chrgroth.spotify.control.domain.model.infra.PredicateStats
 
 interface HealthPort {
   fun getStats(): HealthStats
+  fun getOutboxPartitions(): List<OutboxPartitionStats>
+  fun getOutgoingRequestStats(): List<OutgoingRequestStats>
+  fun getMongoCollectionStats(): List<MongoCollectionStats>
+  fun getMongoQueryStats(): List<MongoQueryStats>
+  fun getCronjobStats(): List<CronjobStats>
+  fun getPredicateStats(): List<PredicateStats>
+  fun getConfigurationStats(): ConfigurationStats
 }

--- a/domain-impl/src/main/kotlin/de/chrgroth/spotify/control/domain/infra/HealthService.kt
+++ b/domain-impl/src/main/kotlin/de/chrgroth/spotify/control/domain/infra/HealthService.kt
@@ -1,6 +1,12 @@
 package de.chrgroth.spotify.control.domain.infra
 
+import de.chrgroth.spotify.control.domain.model.infra.ConfigurationStats
+import de.chrgroth.spotify.control.domain.model.infra.CronjobStats
 import de.chrgroth.spotify.control.domain.model.infra.HealthStats
+import de.chrgroth.spotify.control.domain.model.infra.MongoCollectionStats
+import de.chrgroth.spotify.control.domain.model.infra.MongoQueryStats
+import de.chrgroth.spotify.control.domain.model.infra.OutboxPartitionStats
+import de.chrgroth.spotify.control.domain.model.infra.OutgoingRequestStats
 import de.chrgroth.spotify.control.domain.model.infra.PredicateStats
 import de.chrgroth.spotify.control.domain.port.`in`.infra.HealthPort
 import de.chrgroth.spotify.control.domain.port.out.infra.ConfigurationInfoPort
@@ -47,6 +53,22 @@ class HealthService(
       configurationStats = configurationStatsAsync.await(),
     )
   }
+
+  override fun getOutboxPartitions(): List<OutboxPartitionStats> = outboxStatsCache.current()
+
+  override fun getOutgoingRequestStats(): List<OutgoingRequestStats> = outgoingRequestStats.getRequestStats()
+
+  override fun getMongoCollectionStats(): List<MongoCollectionStats> = mongoStats.getCollectionStats()
+
+  override fun getMongoQueryStats(): List<MongoQueryStats> = mongoStats.getQueryStats()
+
+  override fun getCronjobStats(): List<CronjobStats> = cronjobInfo.getCronjobStats()
+
+  override fun getPredicateStats(): List<PredicateStats> = listOf(
+    PredicateStats(name = "playbackActive", active = playbackActivity.isPlaybackActive(), lastCheck = playbackActivity.lastActivityTimestamp()),
+  )
+
+  override fun getConfigurationStats(): ConfigurationStats = configurationInfo.getConfigurationStats()
 }
 
 /**


### PR DESCRIPTION
## Summary
- Every `/health/snippets/*` fragment endpoint called the full `HealthPort.getStats()`, which fanned out to all health data sources (Mongo collStats, cronjob lookup, outgoing HTTP stats, config dump, playback activity) and waited for all of them before returning.
- This made lightweight, frequently-polled fragments (navbar status icons) as slow as the slowest underlying data source, matching the ~14s durations reported in the issue.
- Added targeted `HealthPort` methods per data source so each fragment only fetches what it renders.

Closes #783.

Generated with [Claude Code](https://claude.ai/code)