### PR TITLE
Unify page content width: shared responsive container everywhere

### DIFF
--- a/adapter-in-http-frontend/src/main/resources/templates/catalog-artists-settings.html
+++ b/adapter-in-http-frontend/src/main/resources/templates/catalog-artists-settings.html
@@ -2,7 +2,7 @@
     {#title}SpCtl – Artist Settings{/title}
     {#scripts}<script src="/settings-utils.js"></script>{/scripts}
     {#content}
-    <div class="container py-4">
+    <div class="app-page-container py-4 px-3 px-md-4">
         <div class="d-flex align-items-center mb-2 gap-3">
             <h1 class="fs-4 fw-semibold mb-0">Artist Settings</h1>
             <a href="/catalog" class="btn btn-outline-secondary btn-sm">Back to Catalog</a>

--- a/adapter-in-http-frontend/src/main/resources/templates/catalog-sync.html
+++ b/adapter-in-http-frontend/src/main/resources/templates/catalog-sync.html
@@ -1,7 +1,7 @@
 {#include layout.html}
     {#title}SpCtl – Catalog Sync{/title}
     {#content}
-    <div class="container-fluid py-4 px-3 px-md-4">
+    <div class="app-page-container py-4 px-3 px-md-4">
 
         <h1 class="mb-4 fs-4 fw-semibold">Catalog Sync</h1>
         <p class="text-secondary small mb-4">Timeline of artists and albums most recently synced from Spotify, newest first.</p>

--- a/adapter-in-http-frontend/src/main/resources/templates/catalog.html
+++ b/adapter-in-http-frontend/src/main/resources/templates/catalog.html
@@ -2,7 +2,7 @@
     {#title}SpCtl – Catalog{/title}
     {#scripts}<script src="/settings-utils.js"></script>{/scripts}
     {#content}
-    <div class="container-fluid py-4 px-3 px-md-4">
+    <div class="app-page-container py-4 px-3 px-md-4">
 
         <h1 class="mb-4 fs-4 fw-semibold">Catalog</h1>
 
@@ -350,7 +350,7 @@
 
         // Event delegation on the main content area: artist rows, re-sync buttons, and
         // dynamically-loaded album rows are all descendants of the catalog container.
-        document.querySelector('.container-fluid').addEventListener('click', function(e) {
+        document.querySelector('.app-page-container').addEventListener('click', function(e) {
             const traceBtn = e.target.closest('.sync-trace-btn');
             if (traceBtn) {
                 e.stopPropagation();

--- a/adapter-in-http-frontend/src/main/resources/templates/config.html
+++ b/adapter-in-http-frontend/src/main/resources/templates/config.html
@@ -2,7 +2,7 @@
     {#title}SpCtl – Config{/title}
     {#scripts}<script src="/settings-utils.js"></script>{/scripts}
     {#content}
-    <div class="container-fluid py-4 px-3 px-md-4">
+    <div class="app-page-container py-4 px-3 px-md-4">
 
         <h1 class="mb-4 fs-4 fw-semibold">Configuration</h1>
 

--- a/adapter-in-http-frontend/src/main/resources/templates/dashboard.html
+++ b/adapter-in-http-frontend/src/main/resources/templates/dashboard.html
@@ -1,7 +1,7 @@
 {#include layout.html}
     {#title}SpCtl – Dashboard{/title}
     {#content}
-    <div class="container-fluid py-4 px-3 px-md-4">
+    <div class="app-page-container py-4 px-3 px-md-4">
 
         <h1 class="mb-4 fs-4 fw-semibold" data-testid="welcome-message">Hej {displayName}!</h1>
 

--- a/adapter-in-http-frontend/src/main/resources/templates/docs.html
+++ b/adapter-in-http-frontend/src/main/resources/templates/docs.html
@@ -1,7 +1,7 @@
 {#include layout.html}
     {#title}SpCtl – {title}{/title}
     {#content}
-    <div class="container py-4">
+    <div class="app-page-container py-4 px-3 px-md-4">
         <div id="docs-rendered" class="docs-content"></div>
         <textarea id="docs-raw" class="d-none">{markdownContent}</textarea>
     </div>

--- a/adapter-in-http-frontend/src/main/resources/templates/error.html
+++ b/adapter-in-http-frontend/src/main/resources/templates/error.html
@@ -5,7 +5,7 @@
     {#pageNav}{/pageNav}
     {#navbarSse}{/navbarSse}
     {#content}
-    <div class="container py-4">
+    <div class="app-page-container py-4 px-3 px-md-4">
         <h1 class="fs-4 fw-semibold mb-4 text-danger">Error {statusCode}</h1>
 
         <div class="app-card card border mb-4">

--- a/adapter-in-http-frontend/src/main/resources/templates/health.html
+++ b/adapter-in-http-frontend/src/main/resources/templates/health.html
@@ -1,7 +1,7 @@
 {#include layout.html}
     {#title}SpCtl – Health{/title}
     {#content}
-    <div class="container-fluid py-4 px-3 px-md-4">
+    <div class="app-page-container py-4 px-3 px-md-4">
 
         <h1 class="mb-4 fs-4 fw-semibold">System Health</h1>
 

--- a/adapter-in-http-frontend/src/main/resources/templates/layout.html
+++ b/adapter-in-http-frontend/src/main/resources/templates/layout.html
@@ -57,6 +57,19 @@
             background-color: var(--color-bg-card);
             border-color: var(--color-border) !important;
         }
+        /* Shared page-content wrapper: full width on small/medium screens, capped and centered
+           on large screens so lines/tables don't stretch edge-to-edge on wide monitors. Used
+           by every page instead of Bootstrap's `.container`/`.container-fluid` directly. */
+        .app-page-container {
+            width: 100%;
+        }
+        @media (min-width: 992px) {
+            .app-page-container {
+                max-width: 66.6667%;
+                margin-left: auto;
+                margin-right: auto;
+            }
+        }
         /* Cross-page navigation tiles shown below the top navbar */
         .app-page-nav {
             background-color: #000000;
@@ -147,7 +160,6 @@
             color: var(--spotify-green);
         }
         .docs-content {
-            max-width: 860px;
             color: var(--color-text-primary);
         }
         .app-accordion-item {

--- a/adapter-in-http-frontend/src/main/resources/templates/logs-viewer.html
+++ b/adapter-in-http-frontend/src/main/resources/templates/logs-viewer.html
@@ -1,7 +1,7 @@
 {#include layout.html}
     {#title}SpCtl – Logs{/title}
     {#content}
-    <div class="container-fluid py-4 px-3 px-md-4">
+    <div class="app-page-container py-4 px-3 px-md-4">
         <h1 class="mb-4 fs-4 fw-semibold">Logs (last 2 hours)</h1>
         <div class="btn-group btn-group-sm mb-3" role="group" aria-label="Logs view mode">
             <a href="/logs-viewer" class="btn {#if viewMode == 'chronological'}btn-spotify{#else}btn-outline-secondary{/if}" data-testid="logs-view-chronological">Chronological</a>

--- a/adapter-in-http-frontend/src/main/resources/templates/mongodb-viewer.html
+++ b/adapter-in-http-frontend/src/main/resources/templates/mongodb-viewer.html
@@ -1,7 +1,7 @@
 {#include layout.html}
     {#title}SpCtl – MongoDB Viewer{/title}
     {#content}
-    <div class="container-fluid py-4 px-3 px-md-4">
+    <div class="app-page-container py-4 px-3 px-md-4">
 
         <h1 class="mb-4 fs-4 fw-semibold">MongoDB Viewer</h1>
 

--- a/adapter-in-http-frontend/src/main/resources/templates/outbox-viewer.html
+++ b/adapter-in-http-frontend/src/main/resources/templates/outbox-viewer.html
@@ -2,7 +2,7 @@
     {#title}SpCtl – Outbox{/title}
     {#scripts}<script src="/settings-utils.js"></script>{/scripts}
     {#content}
-    <div class="container-fluid py-4 px-3 px-md-4">
+    <div class="app-page-container py-4 px-3 px-md-4">
 
         <h1 class="mb-4 fs-4 fw-semibold">Outbox</h1>
 

--- a/adapter-in-http-frontend/src/main/resources/templates/playback-event-viewer.html
+++ b/adapter-in-http-frontend/src/main/resources/templates/playback-event-viewer.html
@@ -2,7 +2,7 @@
     {#title}SpCtl – Playback Event Viewer{/title}
     {#scripts}<script src="/settings-utils.js"></script>{/scripts}
     {#content}
-    <div class="container-fluid py-4 px-3 px-md-4">
+    <div class="app-page-container py-4 px-3 px-md-4">
 
         <div class="d-flex align-items-center justify-content-between mb-4 flex-wrap gap-2">
             <h1 class="fs-4 fw-semibold mb-0">Playback Events</h1>

--- a/adapter-in-http-frontend/src/main/resources/templates/playback.html
+++ b/adapter-in-http-frontend/src/main/resources/templates/playback.html
@@ -2,7 +2,7 @@
     {#title}SpCtl – Playback{/title}
     {#scripts}<script src="/settings-utils.js"></script>{/scripts}
     {#content}
-    <div class="container py-4">
+    <div class="app-page-container py-4 px-3 px-md-4">
         <h1 class="fs-4 fw-semibold mb-4">Playback</h1>
 
         <div class="row g-3 mb-4">

--- a/adapter-in-http-frontend/src/main/resources/templates/playlist-checks.html
+++ b/adapter-in-http-frontend/src/main/resources/templates/playlist-checks.html
@@ -1,7 +1,7 @@
 {#include layout.html}
     {#title}SpCtl – Playlist Checks{/title}
     {#content}
-    <div class="container-fluid py-4 px-3 px-md-4">
+    <div class="app-page-container py-4 px-3 px-md-4">
 
         <h1 class="mb-4 fs-4 fw-semibold">Playlist Checks</h1>
         <div id="status-banner" class="alert d-none mb-3" role="alert"></div>

--- a/adapter-in-http-frontend/src/main/resources/templates/release-notes.html
+++ b/adapter-in-http-frontend/src/main/resources/templates/release-notes.html
@@ -1,7 +1,7 @@
 {#include layout.html}
     {#title}SpCtl – Release Notes{/title}
     {#content}
-    <div class="container py-4">
+    <div class="app-page-container py-4 px-3 px-md-4">
         <h1 class="mb-4">Release Notes</h1>
         <div class="accordion" id="release-notes-accordion">
             {#for group in groups}

--- a/adapter-in-http-frontend/src/main/resources/templates/settings/playback.html
+++ b/adapter-in-http-frontend/src/main/resources/templates/settings/playback.html
@@ -2,7 +2,7 @@
     {#title}SpCtl – Playback Settings{/title}
     {#scripts}<script src="/settings-utils.js"></script>{/scripts}
     {#content}
-    <div class="container py-4">
+    <div class="app-page-container py-4 px-3 px-md-4">
         <h1 class="fs-4 fw-semibold mb-4">Playback Settings</h1>
 
         <div id="status-banner" class="alert d-none mb-3" role="alert"></div>

--- a/adapter-in-http-frontend/src/main/resources/templates/settings/playlist.html
+++ b/adapter-in-http-frontend/src/main/resources/templates/settings/playlist.html
@@ -2,7 +2,7 @@
     {#title}SpCtl – Playlists{/title}
     {#scripts}<script src="/settings-utils.js"></script>{/scripts}
     {#content}
-    <div class="container py-4">
+    <div class="app-page-container py-4 px-3 px-md-4">
         <div class="d-flex align-items-center mb-4 gap-3">
             <h1 class="fs-4 fw-semibold mb-0">Playlists</h1>
             <button id="sync-now-btn" class="btn btn-spotify btn-sm">Sync Now</button>

--- a/adapter-in-http-frontend/src/main/resources/templates/spotify-debug.html
+++ b/adapter-in-http-frontend/src/main/resources/templates/spotify-debug.html
@@ -1,7 +1,7 @@
 {#include layout.html}
     {#title}SpCtl – Spotify Debug{/title}
     {#content}
-    <div class="container-fluid py-4 px-3 px-md-4">
+    <div class="app-page-container py-4 px-3 px-md-4">
 
         <h1 class="mb-2 fs-4 fw-semibold">Spotify Debug</h1>
         <p class="text-secondary small mb-4">

--- a/adapter-in-http-frontend/src/main/resources/templates/stats.html
+++ b/adapter-in-http-frontend/src/main/resources/templates/stats.html
@@ -1,7 +1,7 @@
 {#include layout.html}
     {#title}SpCtl – Stats{/title}
     {#content}
-    <div class="container-fluid py-4 px-3 px-md-4">
+    <div class="app-page-container py-4 px-3 px-md-4">
 
         <h1 class="mb-3 fs-4 fw-semibold">Stats</h1>
 

--- a/docs/releasenotes/snippets/unify-page-content-width-bugfix.md
+++ b/docs/releasenotes/snippets/unify-page-content-width-bugfix.md
@@ -1,0 +1,1 @@
+* Fixed inconsistent page widths: all pages now share the same responsive content container, so lines and tables no longer stretch edge-to-edge on wide monitors while still using the full width on small and medium screens.


### PR DESCRIPTION
## Summary

Every page here used Bootstrap's `.container`/`.container-fluid` directly instead of a shared, capped wrapper — on `-fluid` pages that meant unbounded full-viewport-width content on wide monitors. Docs was the only page with any width cap at all, via a bespoke `.docs-content { max-width: 860px; }`.

This applies the same fix already made in the james-platform template ([PR #469](https://github.com/christiangroth/james-platform/pull/469), commit `70d2e310`), adapted to this repo's template set.

### Changes
- Introduces `.app-page-container` in `layout.html`: full width below the `lg` breakpoint (992px, so small/medium screens are unaffected), capped at two thirds of the viewport and centered from 992px up.
- Replaces `.container`/`.container-fluid` with `.app-page-container` on all 19 page templates (`config`, `catalog*`, `dashboard`, `docs`, `error`, `health`, `logs-viewer`, `mongodb-viewer`, `outbox-viewer`, `playback*`, `playlist-checks`, `release-notes`, `settings/*`, `spotify-debug`, `stats`), including the `catalog.html` JS `querySelector` that targeted the old class name.
- Drops `.docs-content`'s own `max-width: 860px` so Docs now behaves like every other page instead of being a special case, relying on the shared container instead.
- Adds the required release note snippet (`docs/releasenotes/snippets/unify-page-content-width-bugfix.md`).

No ticket exists for this in this repo, so the branch is freestyled to match the change.

## Verification note
No local Java/Gradle toolchain available in this session, so `./gradlew build` could not be run and the actual Quarkus dev server could not be started to visually confirm the change in the running app. Instead, verified the width/breakpoint math in an isolated browser harness (the exact `.app-page-container` CSS, no app markup) at 981px, 992px, and 1920px viewports:
- 981px (just below the 992px breakpoint): container = 100% of viewport
- 992px and 1920px: container = exactly 66.67% of viewport, centered

## Test plan
- [ ] Run `./gradlew build` locally to confirm build/tests/static analysis are green
- [ ] Start `quarkusDev` and click through a few pages (Dashboard, Catalog, Docs, Health, Settings) at a normal laptop width and on an actual wide monitor to confirm the width/centering feels right
- [ ] Confirm the Catalog page's click-delegation still works (event listener was moved from `.container-fluid` to `.app-page-container`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)