### PR TITLE
Restrict Claude CI workflow to repository owner

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -13,10 +13,12 @@ on:
 jobs:
   claude:
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      github.actor == 'christiangroth' && (
+        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+        (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      )
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/docs/releasenotes/snippets/restrict-claude-ci-to-owner-bugfix.md
+++ b/docs/releasenotes/snippets/restrict-claude-ci-to-owner-bugfix.md
@@ -1,0 +1,1 @@
+* Restricted the Claude Code CI workflow so it only runs for actions performed by the repository owner.

--- a/docs/releasenotes/snippets/unify-page-content-width-bugfix.md
+++ b/docs/releasenotes/snippets/unify-page-content-width-bugfix.md
@@ -1,1 +1,0 @@
-* Fixed inconsistent page widths: all pages now share the same responsive content container, so lines and tables no longer stretch edge-to-edge on wide monitors while still using the full width on small and medium screens.


### PR DESCRIPTION
## Summary
- Adds a `github.actor == 'christiangroth'` guard to `.github/workflows/claude.yml` so the write-permissioned Claude Code workflow (`contents`/`pull-requests`/`issues` write, `GHCR_PAT`, `CLAUDE_CODE_OAUTH_TOKEN`) can only be triggered by actions performed by the repo owner.
- Relevant ahead of switching this repository from private to public, since public repos allow any GitHub user to comment on issues/PRs, which could otherwise trigger this workflow.

Applies the same fix already made in the james-platform template ([PR #468](https://github.com/christiangroth/james-platform/pull/468), commit `808efa0d`).

Note: this was originally going to ride along on the `unify-page-content-width` branch/PR, but that PR was merged before this commit was pushed, so it's split out into its own branch/PR here.

## Test plan
- [ ] Confirm workflow YAML is valid (Actions tab shows no parse errors)
- [ ] Verify a comment/issue from a non-owner account no longer triggers the `claude` job
- [ ] Verify the workflow still triggers for actions performed by the owner

🤖 Generated with [Claude Code](https://claude.com/claude-code)