### PR TITLE
Remove leftover DEBUG env var from Claude Code workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -53,4 +53,3 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GHCR_PAT: ${{ secrets.GHCR_PAT }}
-          DEBUG: true


### PR DESCRIPTION
## Summary
- Removes the `DEBUG: true` env var from the "Run Claude Code" step in `.github/workflows/claude.yml`. It's not present in `james-platform` or `family-wall`'s otherwise-identical workflow and looks like a debugging leftover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)