### PR TITLE
Log Spotify error bodies and add outbox partition requeue action

### DIFF
--- a/adapter-in-http-frontend/src/main/kotlin/de/chrgroth/spotify/control/adapter/in/http/frontend/OutboxViewerResource.kt
+++ b/adapter-in-http-frontend/src/main/kotlin/de/chrgroth/spotify/control/adapter/in/http/frontend/OutboxViewerResource.kt
@@ -10,6 +10,7 @@ import jakarta.enterprise.context.ApplicationScoped
 import jakarta.ws.rs.GET
 import jakarta.ws.rs.POST
 import jakarta.ws.rs.Path
+import jakarta.ws.rs.PathParam
 import jakarta.ws.rs.Produces
 import jakarta.ws.rs.core.MediaType
 import jakarta.ws.rs.core.Response
@@ -46,5 +47,14 @@ class OutboxViewerResource(
   fun wipe(): Response = httpResponseMetrics.timed("rest.outbox.wipe") {
     outboxViewer.wipeAll()
     Response.ok(mapOf("status" to "ok")).build()
+  }
+
+  @POST
+  @Path("/{partition}/requeue")
+  @Authenticated
+  @Produces(MediaType.APPLICATION_JSON)
+  fun requeue(@PathParam("partition") partition: String): Response = httpResponseMetrics.timed("rest.outbox.requeue") {
+    val clearedCount = outboxViewer.requeueStuckTasks(partition)
+    Response.ok(mapOf("status" to "ok", "cleared" to clearedCount)).build()
   }
 }

--- a/adapter-in-http-frontend/src/main/resources/templates/outbox-viewer.html
+++ b/adapter-in-http-frontend/src/main/resources/templates/outbox-viewer.html
@@ -43,7 +43,14 @@
         <div id="snippet-outbox-tasks">
             {#fragment id="snippet_tasks"}
             {#for partition in partitions}
-            <h2 class="mb-3 fs-6 fw-semibold text-uppercase" style="color:#888;letter-spacing:.05em;">{partition.key}</h2>
+            <h2 class="mb-3 fs-6 fw-semibold text-uppercase d-flex align-items-center gap-2" style="color:#888;letter-spacing:.05em;">
+                {partition.key}
+                <button type="button" class="btn btn-sm btn-outline-secondary py-0 px-1 lh-1 requeue-partition-btn" data-partition="{partition.key}"
+                        title="Requeue stuck tasks in this partition (workaround until the underlying quarkus-outbox bug is fixed)"
+                        aria-label="Requeue stuck tasks in {partition.key}" data-testid="requeue-partition-btn-{partition.key}">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" fill="currentColor" viewBox="0 0 16 16"><use href="#icon-nav-page-playback"/></svg>
+                </button>
+            </h2>
             {#if partition.tasks.empty}
             <p class="text-secondary small mb-4">No pending tasks in this partition.</p>
             {#else}
@@ -136,6 +143,32 @@
                 });
             });
         })();
+
+        document.getElementById('snippet-outbox-tasks').addEventListener('click', function(event) {
+            const btn = event.target.closest('.requeue-partition-btn');
+            if (!btn) return;
+            const partition = btn.dataset.partition;
+            btn.disabled = true;
+            fetch('/outbox-viewer/' + encodeURIComponent(partition) + '/requeue', { method: 'POST' })
+                .then(function(response) {
+                    return response.json().then(function(data) { return { ok: response.ok, data: data }; });
+                })
+                .then(function(result) {
+                    if (result.ok) {
+                        const cleared = result.data.cleared;
+                        showBanner(cleared > 0 ? 'Requeued ' + cleared + ' stuck task(s) in ' + partition + '.' : 'No stuck tasks found in ' + partition + '.', 'success');
+                        patchUpdate('snippet-outbox-tasks', '/outbox-viewer/snippets/tasks');
+                    } else {
+                        showBanner('Requeue failed: ' + (result.data.error || 'Unknown error'), 'danger');
+                    }
+                })
+                .catch(function(err) {
+                    showBanner('Request failed: ' + err.message, 'danger');
+                })
+                .finally(function() {
+                    btn.disabled = false;
+                });
+        });
     </script>
     {/content}
 {/include}

--- a/adapter-out-mongodb/src/main/kotlin/de/chrgroth/spotify/control/adapter/out/mongodb/OutboxAdminPortAdapter.kt
+++ b/adapter-out-mongodb/src/main/kotlin/de/chrgroth/spotify/control/adapter/out/mongodb/OutboxAdminPortAdapter.kt
@@ -1,11 +1,13 @@
 package de.chrgroth.spotify.control.adapter.out.mongodb
 
 import com.mongodb.client.MongoClient
+import com.mongodb.client.model.Filters
 import de.chrgroth.spotify.control.domain.port.out.infra.OutboxAdminPort
 import jakarta.enterprise.context.ApplicationScoped
 import mu.KLogging
 import org.bson.Document
 import org.eclipse.microprofile.config.inject.ConfigProperty
+import java.time.Instant
 
 @ApplicationScoped
 @Suppress("Unused")
@@ -23,6 +25,20 @@ class OutboxAdminPortAdapter(
 
     val partitionsResult = db.getCollection(OUTBOX_PARTITIONS_COLLECTION).deleteMany(Document())
     logger.info { "Deleted ${partitionsResult.deletedCount} outbox partition document(s)" }
+  }
+
+  override fun requeueStuckTasks(partitionKey: String): Int {
+    val result = mongoClient.getDatabase(databaseName).getCollection(OUTBOX_COLLECTION).deleteMany(
+      Filters.and(
+        Filters.eq("partition", partitionKey),
+        Filters.eq("status", "PENDING"),
+        Filters.ne("nextRetryAt", null),
+        Filters.lte("nextRetryAt", Instant.now()),
+      ),
+    )
+    val clearedCount = result.deletedCount.toInt()
+    logger.info { "Requeued $clearedCount stuck task(s) in outbox partition '$partitionKey'" }
+    return clearedCount
   }
 
   companion object : KLogging() {

--- a/adapter-out-spotify/src/main/kotlin/de/chrgroth/spotify/control/adapter/out/spotify/SpotifyPlaybackAdapter.kt
+++ b/adapter-out-spotify/src/main/kotlin/de/chrgroth/spotify/control/adapter/out/spotify/SpotifyPlaybackAdapter.kt
@@ -45,7 +45,7 @@ class SpotifyPlaybackAdapter(
     } catch (e: SpotifyRateLimitException) {
       SpotifyRateLimitError(e.retryAfterSeconds.seconds).left()
     } catch (e: SpotifyApiException) {
-      logger.error { "Spotify currently playing fetch failed: ${e.statusCode}" }
+      logger.error { "Spotify currently playing fetch failed: status=${e.statusCode}, body=${e.body.take(500)}" }
       PlaybackError.CURRENTLY_PLAYING_FETCH_FAILED.left()
     } catch (e: Exception) {
       logger.error(e) { "Unexpected error during currently playing fetch" }
@@ -103,7 +103,7 @@ class SpotifyPlaybackAdapter(
     } catch (e: SpotifyRateLimitException) {
       SpotifyRateLimitError(e.retryAfterSeconds.seconds).left()
     } catch (e: SpotifyApiException) {
-      logger.error { "Spotify recently played fetch failed: ${e.statusCode}" }
+      logger.error { "Spotify recently played fetch failed: status=${e.statusCode}, body=${e.body.take(500)}" }
       PlaybackError.RECENTLY_PLAYED_FETCH_FAILED.left()
     } catch (e: Exception) {
       logger.error(e) { "Unexpected error during recently played fetch" }

--- a/application-quarkus/src/test/kotlin/de/chrgroth/spotify/control/adapter/in/http/frontend/OutboxViewerPageTests.kt
+++ b/application-quarkus/src/test/kotlin/de/chrgroth/spotify/control/adapter/in/http/frontend/OutboxViewerPageTests.kt
@@ -100,4 +100,27 @@ class OutboxViewerPageTests {
       .statusCode(200)
       .body("status", equalTo("ok"))
   }
+
+  @Test
+  fun `outbox-viewer page contains requeue button per partition`() {
+    given()
+      .`when`()
+      .get("/outbox-viewer")
+      .then()
+      .statusCode(200)
+      .body(containsString("requeue-partition-btn"))
+      .body(containsString("data-partition=\"to-spotify-playback\""))
+      .body(containsString("/requeue"))
+  }
+
+  @Test
+  fun `outbox-viewer requeue endpoint returns ok status and cleared count`() {
+    given()
+      .`when`()
+      .post("/outbox-viewer/to-spotify-playback/requeue")
+      .then()
+      .statusCode(200)
+      .body("status", equalTo("ok"))
+      .body("cleared", equalTo(0))
+  }
 }

--- a/application-quarkus/src/test/kotlin/de/chrgroth/spotify/control/adapter/out/mongodb/OutboxAdminPortAdapterTests.kt
+++ b/application-quarkus/src/test/kotlin/de/chrgroth/spotify/control/adapter/out/mongodb/OutboxAdminPortAdapterTests.kt
@@ -1,5 +1,6 @@
 package de.chrgroth.spotify.control.adapter.out.mongodb
 
+import com.mongodb.client.MongoClient
 import de.chrgroth.spotify.control.domain.outbox.DomainOutboxEvent
 import de.chrgroth.spotify.control.domain.outbox.DomainOutboxPartition
 import de.chrgroth.spotify.control.domain.port.out.infra.OutboxAdminPort
@@ -7,7 +8,11 @@ import de.chrgroth.spotify.control.domain.port.out.infra.OutboxPort
 import io.quarkus.test.junit.QuarkusTest
 import jakarta.inject.Inject
 import org.assertj.core.api.Assertions.assertThat
+import org.bson.Document
+import org.eclipse.microprofile.config.inject.ConfigProperty
 import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.util.UUID
 
 @QuarkusTest
 class OutboxAdminPortAdapterTests {
@@ -18,6 +23,12 @@ class OutboxAdminPortAdapterTests {
   @Inject
   lateinit var outboxAdmin: OutboxAdminPort
 
+  @Inject
+  lateinit var mongoClient: MongoClient
+
+  @ConfigProperty(name = "quarkus.mongodb.database")
+  lateinit var databaseName: String
+
   @Test
   fun `wipeAll removes all enqueued outbox tasks and partition documents`() {
     outbox.enqueue(DomainOutboxEvent.FetchPlaybackData())
@@ -27,5 +38,44 @@ class OutboxAdminPortAdapterTests {
     val stats = outbox.getPartitionStats()
     assertThat(stats).allSatisfy { assertThat(it.documentCount).isZero() }
     assertThat(outbox.getTasksByPartition(DomainOutboxPartition.ToSpotifyPlayback.key)).isEmpty()
+  }
+
+  @Test
+  fun `requeueStuckTasks clears only overdue pending retries and leaves other tasks untouched`() {
+    val partition = DomainOutboxPartition.ToSpotifyPlayback.key
+    val now = Instant.now()
+    insertTask(partition = partition, status = "PENDING", nextRetryAt = now.minusSeconds(60))
+    val freshTask = insertTask(partition = partition, status = "PENDING", nextRetryAt = null)
+    val futureRetryTask = insertTask(partition = partition, status = "PENDING", nextRetryAt = now.plusSeconds(60))
+    val processingTask = insertTask(partition = partition, status = "PROCESSING", nextRetryAt = now.minusSeconds(60))
+
+    val clearedCount = outboxAdmin.requeueStuckTasks(partition)
+
+    assertThat(clearedCount).isEqualTo(1)
+    val remainingIds = outbox.getTasksByPartition(partition).map { it.deduplicationKey }
+    assertThat(remainingIds).containsExactlyInAnyOrder(freshTask, futureRetryTask, processingTask)
+  }
+
+  private fun insertTask(partition: String, status: String, nextRetryAt: Instant?): String {
+    val deduplicationKey = UUID.randomUUID().toString()
+    val now = Instant.now()
+    mongoClient.getDatabase(databaseName).getCollection("outbox").insertOne(
+      Document().apply {
+        put("_id", UUID.randomUUID().toString())
+        put("partition", partition)
+        put("eventType", DomainOutboxEvent.FetchPlaybackData.KEY)
+        put("deduplicationKey", deduplicationKey)
+        put("payload", "")
+        put("status", status)
+        put("attempts", 1)
+        put("createdAt", now)
+        put("updatedAt", now)
+        put("nextRetryAt", nextRetryAt)
+        put("priority", "HIGH")
+        put("priorityOrder", 1)
+        put("lastError", "Connection reset")
+      },
+    )
+    return deduplicationKey
   }
 }

--- a/docs/releasenotes/snippets/0915-feature.md
+++ b/docs/releasenotes/snippets/0915-feature.md
@@ -1,0 +1,1 @@
+* Added a "Requeue" button per partition on the outbox viewer to clear stuck, overdue tasks without restarting the app.

--- a/domain-api/src/main/kotlin/de/chrgroth/spotify/control/domain/port/in/infra/OutboxViewerPort.kt
+++ b/domain-api/src/main/kotlin/de/chrgroth/spotify/control/domain/port/in/infra/OutboxViewerPort.kt
@@ -5,4 +5,10 @@ import de.chrgroth.spotify.control.domain.model.infra.OutboxViewerPartition
 interface OutboxViewerPort {
   fun getPartitions(): List<OutboxViewerPartition>
   fun wipeAll()
+
+  /**
+   * Clears stuck, overdue-retry tasks in [partitionKey] so they get freshly re-enqueued (and the
+   * partition re-signalled) on the next regular attempt. Returns the number of tasks cleared.
+   */
+  fun requeueStuckTasks(partitionKey: String): Int
 }

--- a/domain-api/src/main/kotlin/de/chrgroth/spotify/control/domain/port/out/infra/OutboxAdminPort.kt
+++ b/domain-api/src/main/kotlin/de/chrgroth/spotify/control/domain/port/out/infra/OutboxAdminPort.kt
@@ -7,4 +7,14 @@ package de.chrgroth.spotify.control.domain.port.out.infra
  */
 interface OutboxAdminPort {
   fun wipeAll()
+
+  /**
+   * Clears overdue pending tasks (already retried at least once, with a due `nextRetryAt` in the past)
+   * for [partitionKey]. Works around a quarkus-outbox defect where a failed task's retry never
+   * re-signals its partition worker, so an overdue retry sits claimable but is never picked up again.
+   * Deleting the stuck task lets the next regular enqueue attempt for the same deduplication key insert
+   * successfully and signal the partition, unblocking it without an application restart.
+   * Returns the number of tasks cleared.
+   */
+  fun requeueStuckTasks(partitionKey: String): Int
 }

--- a/domain-impl/src/main/kotlin/de/chrgroth/spotify/control/domain/infra/OutboxViewerService.kt
+++ b/domain-impl/src/main/kotlin/de/chrgroth/spotify/control/domain/infra/OutboxViewerService.kt
@@ -21,5 +21,12 @@ class OutboxViewerService(
     tasksCache.refresh()
   }
 
+  override fun requeueStuckTasks(partitionKey: String): Int {
+    logger.info { "Requeuing stuck tasks in outbox partition '$partitionKey'" }
+    val clearedCount = outboxAdmin.requeueStuckTasks(partitionKey)
+    tasksCache.refresh()
+    return clearedCount
+  }
+
   companion object : KLogging()
 }

--- a/domain-impl/src/test/kotlin/de/chrgroth/spotify/control/domain/infra/OutboxViewerServiceTests.kt
+++ b/domain-impl/src/test/kotlin/de/chrgroth/spotify/control/domain/infra/OutboxViewerServiceTests.kt
@@ -38,4 +38,18 @@ class OutboxViewerServiceTests {
       tasksCache.refresh()
     }
   }
+
+  @Test
+  fun `requeueStuckTasks delegates to OutboxAdminPort, refreshes the tasks cache and returns the cleared count`() {
+    every { outboxAdmin.requeueStuckTasks("to-spotify-playback") } returns 2
+    every { tasksCache.refresh() } just runs
+
+    val clearedCount = service.requeueStuckTasks("to-spotify-playback")
+
+    assertThat(clearedCount).isEqualTo(2)
+    verifyOrder {
+      outboxAdmin.requeueStuckTasks("to-spotify-playback")
+      tasksCache.refresh()
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- Log the Spotify API error response body (not just the status code) on currently-playing/recently-played fetch failures, so a future 403/other denial reveals its actual cause.
- Add a per-partition "Requeue" action on the outbox viewer that clears overdue, already-failed pending tasks so the next regular enqueue attempt can insert and self-signal the partition — a workaround for a quarkus-outbox defect (failed retries never re-signal their partition) until it's fixed upstream.

Fixes #805.

## Test plan
- [x] `./gradlew build` green
- [x] New unit/integration tests for the requeue action (domain service, real-Mongo adapter, HTTP endpoint/page)
- [ ] Manually verify in a running app: trigger a stuck partition, click Requeue, confirm it unblocks

Generated with [Claude Code](https://claude.ai/code)