### PR TITLE
Fix Set Sync/Set Shallow buttons on artist settings page

### DIFF
--- a/adapter-in-http-frontend/src/main/resources/templates/catalog-artists-settings.html
+++ b/adapter-in-http-frontend/src/main/resources/templates/catalog-artists-settings.html
@@ -73,7 +73,7 @@
     </div>
 
     <script>
-        document.querySelector('.container').addEventListener('click', function(e) {
+        document.querySelector('.app-page-container').addEventListener('click', function(e) {
             const setSyncBtn = e.target.closest('.confirm-sync-artist-btn');
             if (setSyncBtn) {
                 const artistId = setSyncBtn.dataset.artistId;

--- a/docs/releasenotes/snippets/issue-808-20260722-1403-bugfix.md
+++ b/docs/releasenotes/snippets/issue-808-20260722-1403-bugfix.md
@@ -1,0 +1,1 @@
+* Fixed the "Set Sync" and "Set Shallow" buttons on the Artist Settings page, which stopped reacting to clicks.


### PR DESCRIPTION
## Summary
Fixes the "Set Sync" and "Set Shallow" buttons on the Artist Settings page, which stopped reacting to clicks.

The click-delegation handler in `catalog-artists-settings.html` queried `document.querySelector('.container')`, but the page uses the app-wide `.app-page-container` class instead of Bootstrap's `.container`. The selector returned `null`, so `.addEventListener` threw a TypeError and the click handler was never attached — explaining why no network request was made when clicking the buttons.

Fixes #808.

Generated with [Claude Code](https://claude.ai/code)