### PR TITLE
Fix playlist Artists/Tracks stats breaking for documents missing the tracks field

### DIFF
--- a/adapter-out-mongodb/src/main/kotlin/de/chrgroth/spotify/control/adapter/out/mongodb/PlaylistRepositoryAdapter.kt
+++ b/adapter-out-mongodb/src/main/kotlin/de/chrgroth/spotify/control/adapter/out/mongodb/PlaylistRepositoryAdapter.kt
@@ -52,11 +52,13 @@ class PlaylistRepositoryAdapter(
     }
 
   override fun findTrackCounts(): Map<String, Int> {
+    // $size errors out entirely (aborting the whole aggregation, for every playlist) if $tracks is missing
+    // on any single document, so it is wrapped in $ifNull to default to an empty array first.
     val pipeline = listOf(
       Aggregates.project(
         Projections.fields(
           Projections.include("spotifyPlaylistId"),
-          Projections.computed("trackCount", Document("\$size", "\$tracks")),
+          Projections.computed("trackCount", Document("\$size", Document("\$ifNull", listOf("\$tracks", emptyList<String>())))),
         ),
       ),
     )
@@ -71,6 +73,8 @@ class PlaylistRepositoryAdapter(
     // Uses $reduce/$setUnion instead of $unwind so playlists with zero tracks or tracks without artistIds
     // are still included (with an empty set), matching findTrackCounts() semantics. $unwind would otherwise
     // silently drop any document whose target path is missing, null or an empty array.
+    // Both $tracks itself and each track's artistIds are wrapped in $ifNull: if $tracks were missing,
+    // $reduce would otherwise return null instead of an empty array, causing the getList() below to NPE.
     val pipeline = listOf(
       Aggregates.project(
         Projections.fields(
@@ -79,7 +83,7 @@ class PlaylistRepositoryAdapter(
             "artistIds",
             Document(
               "\$reduce",
-              Document("input", "\$tracks")
+              Document("input", Document("\$ifNull", listOf("\$tracks", emptyList<String>())))
                 .append("initialValue", emptyList<String>())
                 .append(
                   "in",

--- a/application-quarkus/src/test/kotlin/de/chrgroth/spotify/control/adapter/out/mongodb/PlaylistDataRepositoryTests.kt
+++ b/application-quarkus/src/test/kotlin/de/chrgroth/spotify/control/adapter/out/mongodb/PlaylistDataRepositoryTests.kt
@@ -1,5 +1,6 @@
 package de.chrgroth.spotify.control.adapter.out.mongodb
 
+import com.mongodb.client.model.Filters
 import de.chrgroth.spotify.control.domain.model.catalog.AlbumId
 import de.chrgroth.spotify.control.domain.model.catalog.ArtistId
 import de.chrgroth.spotify.control.domain.model.playlist.Playlist
@@ -9,6 +10,7 @@ import de.chrgroth.spotify.control.domain.port.out.playlist.PlaylistRepositoryPo
 import io.quarkus.test.junit.QuarkusTest
 import jakarta.inject.Inject
 import org.assertj.core.api.Assertions.assertThat
+import org.bson.Document
 import org.junit.jupiter.api.Test
 import java.util.UUID
 
@@ -17,6 +19,9 @@ class PlaylistDataRepositoryTests {
 
   @Inject
   lateinit var playlistRepository: PlaylistRepositoryPort
+
+  @Inject
+  lateinit var playlistDocumentRepository: PlaylistDocumentRepository
 
   private fun buildPlaylist(playlistId: String) = Playlist(
     spotifyPlaylistId = playlistId,
@@ -142,6 +147,19 @@ class PlaylistDataRepositoryTests {
 
     assertThat(result[playlistId1]).containsExactlyInAnyOrder(ArtistId("a1"), ArtistId("a2"))
     assertThat(result[playlistId2]).containsExactlyInAnyOrder(ArtistId("artist-1"))
+  }
+
+  @Test
+  fun `findDistinctArtistIds and findTrackCounts do not fail for a document with a missing tracks field`() {
+    val playlistId = "playlist-${UUID.randomUUID()}"
+    val rawCollection = playlistDocumentRepository.mongoCollection().withDocumentClass(Document::class.java)
+    rawCollection.insertOne(Document("_id", playlistId).append("spotifyPlaylistId", playlistId))
+    try {
+      assertThat(playlistRepository.findDistinctArtistIds()).containsEntry(playlistId, emptySet())
+      assertThat(playlistRepository.findTrackCounts()).containsEntry(playlistId, 0)
+    } finally {
+      rawCollection.deleteOne(Filters.eq("_id", playlistId))
+    }
   }
 
   @Test

--- a/docs/releasenotes/snippets/20260723-0958-bugfix.md
+++ b/docs/releasenotes/snippets/20260723-0958-bugfix.md
@@ -1,0 +1,1 @@
+* Fixed the "Artists" column on the playlist settings page failing to show a count when playlist data was incomplete.


### PR DESCRIPTION
## Summary
- Fixes a defect where a `spotify_playlist` document missing the `tracks` field entirely broke playlist stats for **every** playlist on /settings/playlist:
  - `findDistinctArtistIds()` threw a `NullPointerException` (Mongo's `$reduce` returns `null`, not `[]`, when its input path is missing)
  - `findTrackCounts()` aborted the entire aggregation with a hard Mongo error (`$size` on a missing field)
- Both queries scan the whole collection in one call, so a single malformed/legacy document broke stats for all playlists, not just one row.
- Wraps `$tracks` in `$ifNull` in both aggregation pipelines so a missing field defaults to an empty array.
- Adds a regression test that reproduces both failures against a real MongoDB and verifies the fix.

Refs #790.

Generated with [Claude Code](https://claude.ai/code)