### PR TITLE
Harden Claude Code workflow: foreground builds, PR completion contract, incremental commits

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 1
+          fetch-depth: 0
 
       - name: Set up Java
         uses: actions/setup-java@v4
@@ -50,9 +50,10 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          track_progress: true
           claude_args: |
             --allowedTools Edit,MultiEdit,Write,TodoWrite,Glob,Grep,LS,Read,BashOutput,KillShell,Bash(git:*),Bash(./gradlew:*),Bash(gh:*)
-            --append-system-prompt "Lange Kommandos (./gradlew build, ./gradlew test o.ä.) IMMER mit run_in_background:true starten, danach mit BashOutput pollen statt synchron zu warten. Erst nach status:completed und exit_code:0 weitermachen. WICHTIG: Sobald Build/Tests grün sind, IMMER selbstständig bis zum Ende durcharbeiten: committen, pushen, und per 'gh pr create --base main --title ... --body ...' direkt einen PR öffnen. Prüfe vorher mit 'gh pr list --head <branch>', ob für den Branch schon ein offener PR existiert - falls ja, stattdessen 'gh pr edit'/normalen Push verwenden statt einen zweiten PR anzulegen. Beende die Session nie mit einem offenen 'PR wird noch erstellt'-Punkt - das Öffnen des PRs ist Teil der Aufgabe, nicht optional."
+            --append-system-prompt "Bevor du einen PR anlegst, prüfe mit 'gh pr list --head <branch>', ob für den Branch schon ein offener PR existiert - falls ja, 'gh pr edit' statt eines zweiten PRs verwenden. Folge CLAUDE.md für die Build-Strategie (Abschnitt 'Running Gradle in Time-Limited Agent Sessions') und die Abschlusskriterien (Abschnitte 'Abschluss einer Aufgabe' und 'Inkrementelle Commits')."
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GHCR_PAT: ${{ secrets.GHCR_PAT }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -51,6 +51,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           track_progress: true
+          branch_prefix: "claude-"
           claude_args: |
             --allowedTools Edit,MultiEdit,Write,TodoWrite,Glob,Grep,LS,Read,BashOutput,KillShell,Bash(git:*),Bash(./gradlew:*),Bash(gh:*)
             --append-system-prompt "Bevor du einen PR anlegst, prüfe mit 'gh pr list --head <branch>', ob für den Branch schon ein offener PR existiert - falls ja, 'gh pr edit' statt eines zweiten PRs verwenden. Folge CLAUDE.md für die Build-Strategie (Abschnitt 'Running Gradle in Time-Limited Agent Sessions') und die Abschlusskriterien (Abschnitte 'Abschluss einer Aufgabe' und 'Inkrementelle Commits')."

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -52,6 +52,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           track_progress: true
           branch_prefix: "claude-"
+          display_report: true
           claude_args: |
             --allowedTools Edit,MultiEdit,Write,TodoWrite,Glob,Grep,LS,Read,BashOutput,KillShell,Bash(git:*),Bash(./gradlew:*),Bash(gh:*)
             --append-system-prompt "Bevor du einen PR anlegst, prüfe mit 'gh pr list --head <branch>', ob für den Branch schon ein offener PR existiert - falls ja, 'gh pr edit' statt eines zweiten PRs verwenden. Folge CLAUDE.md für die Build-Strategie (Abschnitt 'Running Gradle in Time-Limited Agent Sessions') und die Abschlusskriterien (Abschnitte 'Abschluss einer Aufgabe' und 'Inkrementelle Commits')."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,17 @@
 - **Run `./gradlew build` before pushing** to verify the build, tests, and static analysis all pass.
 - **CI must be green** on the PR branch before requesting or completing a merge into `main`.
 - If CI fails on a PR, fix the underlying issue — do not skip CI.
+- **Exception for time-limited agent sessions:** see "Running Gradle in Time-Limited Agent Sessions" below — the full local `./gradlew build` is replaced by scoped commands plus watching CI in that context.
+
+## Running Gradle in Time-Limited Agent Sessions
+
+This applies whenever a single command execution is time-limited (e.g. the Claude Code GitHub Action, whose Bash tool has a hard execution ceiling of a few minutes per call). A full multi-module `./gradlew build` (all modules, tests, static analysis) can exceed that ceiling, and gets killed at an inconsistent point from run to run — do not rely on it in this context.
+
+- **Never background a Gradle invocation** (no `run_in_background` / async execution). A build that keeps running after its tool call is considered "timed out" produces results that cannot be trusted or awaited.
+- **Scope the build to the module(s) you touched** for a fast, reliable local signal, e.g. `./gradlew :module-name:test` or `:module-name:compileKotlin` instead of the whole-repo `build`.
+- **Push the branch and open the PR**, then rely on this repository's `Java CI/CD with Gradle` workflow (triggered automatically on push) as the authoritative full-build gate. Poll with `gh pr checks` (short, non-blocking calls) to confirm it goes green rather than reproducing the whole build locally.
+
+This supersedes the general "run `./gradlew build` before pushing" rule above only in these time-limited contexts; a normal local developer session with no such execution ceiling should still run the full build.
 
 ## Formatting
 
@@ -80,9 +91,15 @@ Do not add a database lookup solely to obtain a name for a log message.
 **Type selection:** Use `feature` for new user-facing functionality. Use `bugfix` for fixes and chore/internal changes (e.g. refactoring, configuration restructuring, dependency updates).
 
 ## Abschluss einer Aufgabe
+
 Eine Aufgabe gilt erst als fertig, wenn:
-1. Build/Tests grün sind (im Hintergrund + Polling, siehe oben)
-2. Änderungen committet und gepusht sind
-3. Ein PR via `gh pr create` (oder `gh pr edit`, falls schon vorhanden) offen ist
-Kein Task endet mit "PR wird noch erstellt" als offenem Punkt.
+1. Die für die geänderten Module relevanten Tests/Checks grün sind (siehe "Running Gradle in Time-Limited Agent Sessions" für den Ausführungsmodus), und der reguläre CI-Workflow nach dem Push grün ist oder zumindest läuft.
+2. Änderungen committet und gepusht sind.
+3. Ein PR via `gh pr create` offen ist — vorher mit `gh pr list --head <branch>` prüfen, ob für den Branch schon einer existiert; falls ja, `gh pr edit`/normalen Push verwenden statt einen zweiten PR anzulegen.
+
+Kein Task endet mit "PR wird noch erstellt" als offenem Punkt, und kein Task endet stillschweigend nach einer teilweisen Änderung. Scheitert ein Schritt (z. B. `git push` oder `gh pr create`), erneut versuchen (z. B. mit anderem Branch-Namen); schlägt es weiterhin fehl, den Grund explizit in einem Kommentar nennen. Ist nach Prüfung klar, dass keine Code-Änderung nötig ist, das ebenfalls explizit kommentieren statt ohne jede Rückmeldung zu enden.
+
+## Inkrementelle Commits
+
+Nicht bis zum Schluss warten und alles in einem Commit bündeln: nach jedem in sich abgeschlossenen Schritt committen und pushen. Sobald der erste sinnvolle Commit gepusht ist, direkt einen Draft-PR öffnen (`gh pr create --draft`) und die Beschreibung im Verlauf aktualisieren; erst am Ende aus dem Draft-Status nehmen. So bleibt auch bei einem abgebrochenen Lauf sichtbar, was bereits passiert ist, statt dass ein Run spurlos endet.
 


### PR DESCRIPTION
## Summary
- Never background `./gradlew`/`mvn` invocations in the Claude Code Action - the Bash tool's hard timeout ceiling kills background tasks the same way it kills foreground ones, so backgrounding was masking failures instead of avoiding them.
- Scope builds/tests to what was touched, run them in the foreground, and rely on the branch's own CI run (or the repo's local-scoped-build rule) as the real gate.
- `CLAUDE.md` now has an explicit Task Completion contract: branch -> commit -> push -> PR is mandatory, no silent endings, retry on failure, duplicate-PR check via `gh pr list --head`.
- Incremental commits: commit/push after each self-contained step and open a draft PR early instead of bundling everything into one commit at the end.
- `fetch-depth: 0`, `track_progress: true`, `branch_prefix: "claude-"` (avoids the `/`-encoding 404 bug in claude-code-action#589).

## Test plan
- [ ] Trigger `@claude` on an issue/PR comment and confirm a branch + PR appear even for a longer task
- [ ] Confirm no Gradle/Maven invocation is backgrounded during the run

🤖 Generated with [Claude Code](https://claude.com/claude-code)