### PR TITLE
Fix Grafana Explore link using stale job= Loki selector

### DIFF
--- a/docs/releasenotes/snippets/fix-grafana-explore-link-service-name-bugfix.md
+++ b/docs/releasenotes/snippets/fix-grafana-explore-link-service-name-bugfix.md
@@ -1,0 +1,1 @@
+* Fixed the "View In Explore" link on the Grafana Quarkus Logs dashboard so it uses the correct Loki label and no longer leads to an empty view.

--- a/monitoring/grafana/quarkus-logs.json
+++ b/monitoring/grafana/quarkus-logs.json
@@ -51,7 +51,7 @@
       "targetBlank": true,
       "title": "View In Explore",
       "type": "link",
-      "url": "/explore?orgId=1&left=[\"now-1h\",\"now\",\"Loki\",{\"expr\":\"{job=\\\"$app\\\"}\"},{\"ui\":[true,true,true,\"none\"]}]"
+      "url": "/explore?orgId=1&left=[\"now-1h\",\"now\",\"Loki\",{\"expr\":\"{service_name=\\\"$app\\\"}\"},{\"ui\":[true,true,true,\"none\"]}]"
     },
     {
       "icon": "external link",
@@ -342,7 +342,7 @@
   "timezone": "browser",
   "title": "Quarkus Logs",
   "weekStart": "",
-  "version": 5,
+  "version": 6,
   "uid": "sadlil-loki-apps-dashboard",
   "id": 2240415473623040
 }


### PR DESCRIPTION
## Summary
- The "View In Explore" link on `monitoring/grafana/quarkus-logs.json` used the deprecated Loki selector `{job="$app"}`, while every panel query and the `app` template variable already use `service_name`. This meant the link jumped to an empty Explore view even though the dashboard panels themselves showed data correctly.
- Updated the Explore link query to `{service_name="$app"}`, consistent with the rest of the dashboard.
- Bumped the dashboard `version` field from 5 to 6.

Closes #839

## Test plan
- [x] Validated `monitoring/grafana/quarkus-logs.json` is still valid JSON (`node -e "JSON.parse(...)"`).
- [x] Confirmed via grep that no `{job="$app"}` (or similar stale selector) remains in the file, and that `service_name` is now used consistently across all queries/links.
- [ ] Manual verification against the live Grafana Cloud instance after deploy: confirm the "View In Explore" link actually jumps to the matching log view (not possible locally without access to the real Grafana instance, per the issue's own point 3).
- No Gradle build affected — this is a pure JSON config file change.