### PR TITLE
CI: Push-Trigger auf main beschränken, Concurrency-Guard und bedingtes Gradle-Cache-Write

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -2,11 +2,15 @@ name: Java CI/CD with Gradle
 
 on:
   push:
+    branches: [main]
   workflow_dispatch:
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}-build
+      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
@@ -14,6 +18,8 @@ jobs:
           java-version: '25'
           distribution: 'temurin'
       - uses: gradle/actions/setup-gradle@v5
+        with:
+          cache-read-only: ${{ github.ref != 'refs/heads/main' }}
       - run: ./gradlew build
         env:
           GHCR_PAT: ${{ secrets.GHCR_PAT }}
@@ -22,6 +28,9 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.ref == 'refs/heads/main' }}
     needs: release
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}-provision-grafana-dashboard
+      cancel-in-progress: false
     steps:
       - uses: actions/checkout@v4
       - name: Provision Grafana dashboards
@@ -29,7 +38,7 @@ jobs:
           GRAFANA_CLOUD_SA_TOKEN: ${{ secrets.GRAFANA_CLOUD_SA_TOKEN }}
           COMMIT_SHA: ${{ github.sha }}
         run: ./provision-grafana-dashboards.sh
-  
+
   release:
     runs-on: ubuntu-latest
     if: ${{ github.ref == 'refs/heads/main' }}
@@ -37,6 +46,9 @@ jobs:
     permissions:
       contents: write
       packages: write
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}-release
+      cancel-in-progress: false
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
@@ -44,6 +56,8 @@ jobs:
           java-version: '25'
           distribution: 'temurin'
       - uses: gradle/actions/setup-gradle@v5
+        with:
+          cache-read-only: ${{ github.ref != 'refs/heads/main' }}
       - run: |
           git config user.name "GitHub Actions Bot"
           git config user.email "<>"

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -2,7 +2,6 @@ name: Java CI/CD with Gradle
 
 on:
   push:
-    branches: [main]
   workflow_dispatch:
 
 jobs:

--- a/docs/releasenotes/snippets/hardening-bugfix.md
+++ b/docs/releasenotes/snippets/hardening-bugfix.md
@@ -1,1 +1,1 @@
-* Hardened the CI pipeline: pushes now only trigger builds on `main`, concurrent runs on the same branch are guarded, and the Gradle cache is only written from `main`.
+* Hardened the CI pipeline: concurrent runs on the same branch are guarded, and the Gradle cache is only written from `main`.

--- a/docs/releasenotes/snippets/hardening-bugfix.md
+++ b/docs/releasenotes/snippets/hardening-bugfix.md
@@ -1,0 +1,1 @@
+* Hardened the CI pipeline: pushes now only trigger builds on `main`, concurrent runs on the same branch are guarded, and the Gradle cache is only written from `main`.


### PR DESCRIPTION
## Summary

- Adds a per-job `concurrency` block to `.github/workflows/gradle.yml`, grouped by `${{ github.workflow }}-${{ github.ref }}-<job>`:
  - `build`: `cancel-in-progress: true` (safe to cancel a superseded plain build).
  - `release` and `provision-grafana-dashboard`: `cancel-in-progress: false` (never abort an in-flight deploy).
- Adds `cache-read-only: ${{ github.ref != 'refs/heads/main' }}` to both `gradle/actions/setup-gradle@v5` steps (build and release jobs), so only `main` runs can write to the Gradle cache.
- Test parallelization (`maxParallelForks`) was intentionally left untouched, per the issue's explicit scope note.

## Deliberately NOT implemented: restricting `push` to `branches: [main]`

Issue #838's plan also asked to restrict `on.push` to `main` only. This repo's `gradle.yml` has no `pull_request` trigger — it relies entirely on `push` events (including on PR branches) to populate the PR "Checks" tab. Restricting push to `main`-only would have silently stopped CI from running on any PR branch until after merge, breaking CLAUDE.md's "Every PR must have a green CI build before merging" requirement. After flagging this to the repo owner, the decision was to keep `push` unrestricted and only land the concurrency guard + conditional cache-read-only from this issue.

## Issues closed

Closes #838
Closes #837

Note: #837 asked only for the `concurrency` block (grouped by `github.ref`). #838 was filed later as a superset covering the same concurrency requirement plus the `main`-only push trigger and conditional cache-read-only. Per the repo owner's decision, this single PR implements the concurrency guard and cache-read-only parts of #838 (not the push-trigger restriction, see above) and closes both issues instead of splitting the concurrency block into a separate PR that would conflict with this one on the same file.

## Test plan

- [x] Validated workflow YAML parses correctly.
- [x] Push trigger left unrestricted, so this PR branch's own push triggers the `build` job as usual — see CI checks below.