### PR TITLE
Add Docker HEALTHCHECK to container images

### DIFF
--- a/application-quarkus/src/main/docker/Dockerfile.jvm
+++ b/application-quarkus/src/main/docker/Dockerfile.jvm
@@ -93,5 +93,10 @@ USER 185
 ENV JAVA_OPTS_APPEND="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
 ENV JAVA_APP_JAR="/deployments/quarkus-run.jar"
 
+# curl is present by default in Red Hat's ubi9/openjdk base images, so it is used here to probe
+# the Quarkus readiness endpoint (requires the quarkus-smallrye-health extension).
+HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
+  CMD curl -f http://localhost:8080/q/health/ready || exit 1
+
 ENTRYPOINT [ "/opt/jboss/container/java/run/run-java.sh" ]
 

--- a/application-quarkus/src/main/docker/Dockerfile.legacy-jar
+++ b/application-quarkus/src/main/docker/Dockerfile.legacy-jar
@@ -90,4 +90,9 @@ USER 185
 ENV JAVA_OPTS_APPEND="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
 ENV JAVA_APP_JAR="/deployments/quarkus-run.jar"
 
+# curl is present by default in Red Hat's ubi8/openjdk base images, so it is used here to probe
+# the Quarkus readiness endpoint (requires the quarkus-smallrye-health extension).
+HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
+  CMD curl -f http://localhost:8080/q/health/ready || exit 1
+
 ENTRYPOINT [ "/opt/jboss/container/java/run/run-java.sh" ]

--- a/application-quarkus/src/main/docker/Dockerfile.native
+++ b/application-quarkus/src/main/docker/Dockerfile.native
@@ -24,4 +24,9 @@ COPY --chown=1001:root build/*-runner /work/application
 EXPOSE 8080
 USER 1001
 
+# curl is present by default in Red Hat's ubi-minimal image, so it is used here to probe the
+# Quarkus readiness endpoint (requires the quarkus-smallrye-health extension).
+HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
+  CMD curl -f http://localhost:8080/q/health/ready || exit 1
+
 ENTRYPOINT ["./application", "-Dquarkus.http.host=0.0.0.0"]

--- a/application-quarkus/src/main/docker/Dockerfile.native-micro
+++ b/application-quarkus/src/main/docker/Dockerfile.native-micro
@@ -27,4 +27,11 @@ COPY --chown=1001:root build/*-runner /work/application
 EXPOSE 8080
 USER 1001
 
+# No HEALTHCHECK here on purpose: quarkus-micro-image is a distroless-style base image with no
+# shell, package manager, curl or wget, so there is no HTTP client available to probe
+# /q/health/ready. Adding a HEALTHCHECK CMD here would always fail and could deadlock deployments
+# that gate on container health. If a healthcheck is required for this variant, switch to
+# Dockerfile.native (ubi-minimal, which ships curl) or add an orchestrator-level TCP check on
+# port 8080 instead.
+
 ENTRYPOINT ["./application", "-Dquarkus.http.host=0.0.0.0"]

--- a/docs/releasenotes/snippets/docker-healthcheck-bugfix.md
+++ b/docs/releasenotes/snippets/docker-healthcheck-bugfix.md
@@ -1,0 +1,1 @@
+* Added a Docker `HEALTHCHECK` to the JVM and native container images that polls the application's readiness endpoint, so orchestrators can detect and restart unhealthy containers automatically.


### PR DESCRIPTION
## Summary

Closes #836

Adds a Docker `HEALTHCHECK` that polls the Quarkus readiness endpoint (`/q/health/ready`, provided by the already-present `quarkus-smallrye-health` extension — verified via the existing `HealthCheckTests`) to the container image variants that have a suitable HTTP client available in their base image:

- `application-quarkus/src/main/docker/Dockerfile.jvm` (`registry.access.redhat.com/ubi9/openjdk-25`) — uses `curl`.
- `application-quarkus/src/main/docker/Dockerfile.legacy-jar` (`registry.access.redhat.com/ubi8/openjdk-21`) — uses `curl`.
- `application-quarkus/src/main/docker/Dockerfile.native` (`registry.access.redhat.com/ubi8/ubi-minimal`) — uses `curl` (ubi-minimal ships `curl` by default, though notably not `wget`).

`application-quarkus/src/main/docker/Dockerfile.native-micro` (`quay.io/quarkus/quarkus-micro-image`) intentionally has **no** `HEALTHCHECK` — that base image is distroless-style with no shell, package manager, `curl`, or `wget`, so a healthcheck command would always fail and could deadlock deployments that gate on container health (exactly the risk flagged in the issue). A comment in the Dockerfile explains this and points at `Dockerfile.native` as the alternative if a healthcheck is required for a native build.

`deploy/docker-stack.yml` has no existing `healthcheck:`/`HEALTHCHECK`-equivalent definitions for the `quarkus` service, so the Dockerfile `HEALTHCHECK` is the single source of truth — no duplication to resolve.

A `bugfix` release note snippet was added at `docs/releasenotes/snippets/docker-healthcheck-bugfix.md`.

## Verification

- Docker is not available in this sandbox/agent environment, so `docker build` + `docker inspect --format='{{json .State.Health}}'` per variant could **not** be run locally. This is a Dockerfile/comment-only change (no Kotlin/module changes), so it isn't exercised by `./gradlew build` either — the `curl`/`wget` availability claims per base image were cross-checked against Red Hat's UBI documentation instead (ubi-minimal ships `curl` but not `wget`; the OpenJDK images build on the same UBI base).
- Confirmed `/q/health/ready` is exposed and returns 200 without authentication via the existing `application-quarkus/src/test/kotlin/de/chrgroth/spotify/control/application/quarkus/HealthCheckTests.kt`.

## Test plan

- [ ] CI (`Java CI/CD with Gradle`) green on this branch.
- [ ] Manual/local `docker build` + `docker inspect` verification recommended before/at merge if Docker is available to a reviewer, since this could not be done in this sandbox.