### PR TITLE
Test-Guideline: keine Unit-Tests für reine Delegations-/Wiring-Klassen

### DIFF
--- a/application-quarkus/src/test/kotlin/de/chrgroth/spotify/control/adapter/in/http/frontend/CatalogPageTests.kt
+++ b/application-quarkus/src/test/kotlin/de/chrgroth/spotify/control/adapter/in/http/frontend/CatalogPageTests.kt
@@ -1,0 +1,34 @@
+package de.chrgroth.spotify.control.adapter.`in`.http.frontend
+
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.test.security.TestSecurity
+import io.restassured.RestAssured.given
+import org.hamcrest.CoreMatchers.containsString
+import org.hamcrest.CoreMatchers.equalTo
+import org.junit.jupiter.api.Test
+
+@QuarkusTest
+@TestSecurity(user = "test-user-a")
+class CatalogPageTests {
+
+  @Test
+  fun `catalog page is available and displays wipe catalog button`() {
+    given()
+      .`when`()
+      .get("/catalog")
+      .then()
+      .statusCode(200)
+      .body(containsString("Wipe Catalog"))
+      .body(containsString("wipe-catalog-btn"))
+  }
+
+  @Test
+  fun `catalog wipe endpoint enqueues catalog wipe and returns ok status`() {
+    given()
+      .`when`()
+      .post("/catalog/wipe")
+      .then()
+      .statusCode(200)
+      .body("status", equalTo("ok"))
+  }
+}

--- a/docs/coding-guidelines/role-test-engineer.md
+++ b/docs/coding-guidelines/role-test-engineer.md
@@ -179,6 +179,10 @@ fun `SyncPlaylistData payload round-trip`() {
 
 Use these sparingly. If the logic is complex enough to need its own unit test, question whether it should live in the domain instead.
 
+## Pure Delegation/Wiring Classes
+
+A class whose entire body is "call the one method on my single dependency" (e.g. a `@Scheduled` method that just forwards to a port) adds no value when unit-tested in isolation – mocking the dependency and verifying it was called proves nothing beyond what the compiler already guarantees. If the wiring is worth testing, cover it through a Layer 3 `@QuarkusTest` (e.g. asserting the schedule actually fires) rather than a standalone unit test.
+
 ## Test Data Conventions
 
 - Use Kotlin builder functions (not lengthy object construction in every test)

--- a/docs/releasenotes/snippets/test-guideline-no-delegation-unit-tests-bugfix.md
+++ b/docs/releasenotes/snippets/test-guideline-no-delegation-unit-tests-bugfix.md
@@ -1,0 +1,1 @@
+* Internal test suite cleanup; no user-facing behavior changed.

--- a/domain-impl/src/test/kotlin/de/chrgroth/spotify/control/domain/catalog/CatalogServiceTests.kt
+++ b/domain-impl/src/test/kotlin/de/chrgroth/spotify/control/domain/catalog/CatalogServiceTests.kt
@@ -677,15 +677,6 @@ class CatalogServiceTests {
   }
 
   @Test
-  fun `enqueueWipeCatalog enqueues WipeCatalog`() {
-    every { outboxPort.enqueue(any()) } just runs
-
-    adapter.enqueueWipeCatalog()
-
-    verify { outboxPort.enqueue(DomainOutboxEvent.WipeCatalog()) }
-  }
-
-  @Test
   fun `handle WipeCatalog deletes all catalog data, deactivates playlists and deletes checks`() {
     every { appArtistRepository.deleteAll() } just runs
     every { appAlbumRepository.deleteAll() } just runs

--- a/domain-impl/src/test/kotlin/de/chrgroth/spotify/control/domain/infra/OutboxViewerServiceTests.kt
+++ b/domain-impl/src/test/kotlin/de/chrgroth/spotify/control/domain/infra/OutboxViewerServiceTests.kt
@@ -27,19 +27,6 @@ class OutboxViewerServiceTests {
   }
 
   @Test
-  fun `wipeAll delegates to OutboxAdminPort and refreshes the tasks cache afterwards`() {
-    every { outboxAdmin.wipeAll() } just runs
-    every { tasksCache.refresh() } just runs
-
-    service.wipeAll()
-
-    verifyOrder {
-      outboxAdmin.wipeAll()
-      tasksCache.refresh()
-    }
-  }
-
-  @Test
   fun `requeueStuckTasks delegates to OutboxAdminPort, refreshes the tasks cache and returns the cleared count`() {
     every { outboxAdmin.requeueStuckTasks("to-spotify-playback") } returns 2
     every { tasksCache.refresh() } just runs

--- a/domain-impl/src/test/kotlin/de/chrgroth/spotify/control/domain/playback/PlaybackAggregationServiceTests.kt
+++ b/domain-impl/src/test/kotlin/de/chrgroth/spotify/control/domain/playback/PlaybackAggregationServiceTests.kt
@@ -194,6 +194,15 @@ class PlaybackAggregationServiceTests {
   }
 
   @Test
+  fun `enqueueRebuildAllAggregations does nothing when no users available`() {
+    every { currentUserResolver.userId() } returns null
+
+    service.enqueueRebuildAllAggregations()
+
+    verify(exactly = 0) { outboxPort.enqueue(any()) }
+  }
+
+  @Test
   fun `handle RebuildAllAggregations delegates to rebuildAllAggregations`() {
     every { currentUserResolver.userId() } returns userId
     every { appPlaybackRepository.findOldestPlayedAt() } returns null


### PR DESCRIPTION
## Summary

Adds a new rule to `docs/coding-guidelines/role-test-engineer.md`:

> **Pure delegation/wiring classes** – a class whose entire body is "call the one method on my single dependency" (e.g. a `@Scheduled` method that just forwards to a port) adds no value when unit-tested in isolation – mocking the dependency and verifying it was called proves nothing beyond what the compiler already guarantees. If the wiring is worth testing, cover it through a Layer 3 `@QuarkusTest` (e.g. asserting the schedule actually fires) rather than a standalone unit test.

## Test cleanup

Audited the whole codebase (all modules) for existing unit tests that violate this rule. Most "verify-only-looking" tests turned out to be legitimate (real branching/filtering/dedup logic worth testing at Layer 1) and were left untouched. Two genuine matches were found and removed:

- **`CatalogService.enqueueWipeCatalog()`** (`domain-impl/.../catalog/CatalogService.kt`): entire body is `log + outboxPort.enqueue(...)`, zero branching. Removed its unit test in `CatalogServiceTests.kt`. Since `POST /catalog/wipe` had **no** Layer 3 coverage at all before this change, added `CatalogPageTests.kt` with a test hitting that endpoint — no coverage lost.
- **`OutboxViewerService.wipeAll()`** (`domain-impl/.../infra/OutboxViewerService.kt`): entire body is two fixed forwarding calls in order. Removed its unit test in `OutboxViewerServiceTests.kt`. Layer 3 coverage already existed via `OutboxViewerPageTests`' `POST /outbox-viewer/wipe` test — no coverage lost.

**Not removed:** `PlaybackAggregationService.enqueueRebuildAllAggregations()` looks similar (single dependency, `enqueue` call) but has a guard clause (`currentUserResolver.userId() ?: return`) — real branching, same shape as `enqueueResyncCatalog` and other sibling methods that keep their unit tests. While auditing it, found it was missing the negative-path test (`verify(exactly = 0)` when no user is available) that all its siblings have — added that as a small consistency fix, unrelated to the removal criteria.

**No test gaps introduced:** every removed unit test either had equivalent-or-better Layer 3 coverage already, or got one added in this PR before the removal.

## Issue closed

Closes #841