### PR TITLE
Fix Playlist Check dashboard hiding results when user lookup is null

### DIFF
--- a/docs/releasenotes/snippets/fix-playlist-check-dashboard-user-guard-bugfix.md
+++ b/docs/releasenotes/snippets/fix-playlist-check-dashboard-user-guard-bugfix.md
@@ -1,0 +1,1 @@
+* Fixed the Playlist Checks page sometimes showing "no results" even though checks had already run and been saved.

--- a/domain-impl/src/main/kotlin/de/chrgroth/spotify/control/domain/playlist/PlaylistCheckService.kt
+++ b/domain-impl/src/main/kotlin/de/chrgroth/spotify/control/domain/playlist/PlaylistCheckService.kt
@@ -81,14 +81,7 @@ class PlaylistCheckService(
   }
 
   override fun getCheckDashboard(): PlaylistCheckDashboard {
-    val user = userRepository.get() ?: return PlaylistCheckDashboard(
-      displayName = "",
-      checks = emptyList(),
-      playlistNameById = emptyMap(),
-      displayNames = getDisplayNames(),
-      fixableCheckIds = getFixableCheckIds(),
-    )
-    val displayNameFuture = managedExecutor.supplyAsync { user.displayName }
+    val displayNameFuture = managedExecutor.supplyAsync { userRepository.get()?.displayName ?: "" }
     val playlistNamesFuture = managedExecutor.supplyAsync {
       playlistRepository.findAll().associateBy({ it.spotifyPlaylistId }, { it.name })
     }

--- a/domain-impl/src/test/kotlin/de/chrgroth/spotify/control/domain/playlist/PlaylistCheckServiceTests.kt
+++ b/domain-impl/src/test/kotlin/de/chrgroth/spotify/control/domain/playlist/PlaylistCheckServiceTests.kt
@@ -289,13 +289,19 @@ class PlaylistCheckServiceTests {
   }
 
   @Test
-  fun `getCheckDashboard returns empty dashboard when no user exists`() {
+  fun `getCheckDashboard falls back to empty display name but still returns checks when no user exists`() {
+    val check = buildCheck(succeeded = true)
+    val playlistInfo = buildPlaylistInfo()
     every { userRepository.get() } returns null
+    every { playlistRepository.findAll() } returns listOf(playlistInfo)
+    every { playlistCheckRepository.findAll() } returns listOf(check)
     every { checkRunners.iterator() } answers { mutableListOf<PlaylistCheckRunner>().iterator() }
 
     val dashboard = adapter.getCheckDashboard()
 
     assertThat(dashboard.displayName).isEqualTo("")
+    assertThat(dashboard.checks).containsExactly(check)
+    assertThat(dashboard.playlistNameById).containsEntry(playlistId, "Playlist $playlistId")
   }
 
   @Test


### PR DESCRIPTION
## Problem

Reported: the [/playlist-checks](https://spctl.chrgroth.de/playlist-checks) page (and the older, still-linked `/playlists/checks` variant) can show "No playlist check results available yet." even though `app_playlist_check` genuinely contains fresh, valid check documents.

## Root cause

`PlaylistCheckService.getCheckDashboard()` had:

```kotlin
val user = userRepository.get() ?: return PlaylistCheckDashboard(
  displayName = "",
  checks = emptyList(),
  ...
)
```

This ties the entire checks list to an unrelated lookup (the user profile, used only for the display name in the header). If `userRepository.get()` returns `null` for any reason at that particular moment, the whole dashboard renders empty — even though the `app_playlist_check` collection is untouched and fully populated.

## Fix

Only the display name now falls back to `""` when no user record exists; checks and playlist names are always fetched and returned independently.

## Test plan

- [x] Updated `PlaylistCheckServiceTests` to cover: no user exists → empty display name, but checks/playlist names are still returned.
- [ ] CI (`./gradlew build`) green — could not run the full build locally in this session (this environment's Gradle can't reach `maven.pkg.github.com` / Maven Central due to network/TLS restrictions), relying on CI per `CLAUDE.md`'s guidance for build-restricted sessions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)